### PR TITLE
Add markdown lint workflow

### DIFF
--- a/.github/workflows/markdown-validation.yml
+++ b/.github/workflows/markdown-validation.yml
@@ -1,0 +1,22 @@
+name: Markdown Validation
+
+on:
+  push:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/markdown-validation.yml'
+      - 'scripts/validate_markdown.sh'
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/markdown-validation.yml'
+      - 'scripts/validate_markdown.sh'
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate Markdown format
+        run: |
+          ./scripts/validate_markdown.sh

--- a/scripts/validate_markdown.sh
+++ b/scripts/validate_markdown.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate formatting of all Markdown files using mdl (Markdown lint)
+# Requires the 'markdownlint' package (provides the 'mdl' command)
+
+find . -name "*.md" | xargs mdl -r ~MD013


### PR DESCRIPTION
## Summary
- add `validate_markdown.sh` script that runs `mdl`
- add GitHub Actions workflow to run markdown validation on pushes and PRs

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687935145ae4832ca533f2e081c80f48