### PR TITLE
Add codebase analysis prompts

### DIFF
--- a/codebase_analysis/DRY_Codebase_Analysis.md
+++ b/codebase_analysis/DRY_Codebase_Analysis.md
@@ -1,0 +1,39 @@
+# DRY Codebase Analysis
+
+**Objective**  
+Identify every meaningful opportunity to remove code duplication and enforce the **DRY** (Don’t Repeat Yourself) principle.
+
+---
+
+## Scope of Analysis
+
+1. Locate duplicated logic, structures, or patterns across modules, classes, functions, and tests.  
+1. Recommend consolidation via abstraction, reusable utilities, or modularization.  
+1. Flag duplicated tests and propose shared helpers or fixtures.
+
+---
+
+## Task-Stub Specification
+
+For each duplication detected, output a **task stub** using the fields below.  
+Create **one stub per distinct duplication site**.
+
+| Field | Description |
+|-------|-------------|
+| **ID** | `DRY-NNN` (sequential) |
+| **Location** | File path(s) and line range(s) where duplication appears |
+| **Issue&nbsp;Summary** | One-sentence description of what is duplicated |
+| **Suggested&nbsp;Change** | Concrete refactor (e.g., “Extract function `parseUser` to `utils/user.ts` and call from A, B, C”) |
+| **Rationale** | Why this reduces repetition or risk |
+| **Dependencies** | Other task IDs this change relies on (if any) |
+| **Effort** | `S`, `M`, or `L` (author’s estimate) |
+
+Return the stubs as a **markdown table**, sorted by effort (S → L).
+
+---
+
+## Input
+
+- Root path to the codebase  
+- Programming languages used  
+- Framework or architectural context if applicable  

--- a/codebase_analysis/Maintainability_Codebase_Analysis.md
+++ b/codebase_analysis/Maintainability_Codebase_Analysis.md
@@ -1,0 +1,41 @@
+# Maintainability Codebase Analysis
+
+**Objective**  
+Improve overall **code maintainability** by addressing readability, organization, and test quality.
+
+---
+
+## Scope of Analysis
+
+1. Naming clarity, documentation gaps, style compliance.  
+1. Long or deeply nested functions; complex expressions.  
+1. Project/module structure consistency.  
+1. Missing or brittle tests; inadequate coverage.  
+1. Tooling recommendations (linters, formatters, CI checks).
+
+---
+
+## Task-Stub Specification
+
+Create a task stub for every maintainability concern found.
+
+| Field | Description |
+|-------|-------------|
+| **ID** | `MAIN-NNN` (sequential) |
+| **Category** | `Naming`, `Docs`, `Structure`, `Complexity`, `Testing`, or `Tooling` |
+| **Location** | File/function/class (or project-level) |
+| **Issue&nbsp;Summary** | One-sentence statement of the concern |
+| **Suggested&nbsp;Change** | Explicit action (e.g., “Split `orders.py` into `service`, `repository`, `dto` modules”) |
+| **Rationale** | How this improves maintainability |
+| **Dependencies** | Other task IDs, if any |
+| **Effort** | `S`, `M`, or `L` |
+
+Return the stubs as a markdown table, ordered **by category** and then by effort.
+
+---
+
+## Input
+
+- Root path to the codebase  
+- Programming languages used  
+- Framework or architectural context if applicable  

--- a/codebase_analysis/SOLID_Codebase_Analysis.md
+++ b/codebase_analysis/SOLID_Codebase_Analysis.md
@@ -1,0 +1,41 @@
+# SOLID Codebase Analysis
+
+**Objective**  
+Evaluate the codebase against the five **SOLID** object-oriented design principles and produce concrete refactoring tasks.
+
+---
+
+## Scope of Analysis
+
+1. **Single Responsibility Principle (SRP)** – Split classes/functions with multiple concerns.  
+1. **Open/Closed Principle (OCP)** – Enable extension without modifying existing code.  
+1. **Liskov Substitution Principle (LSP)** – Ensure subclasses honor base-type contracts.  
+1. **Interface Segregation Principle (ISP)** – Decompose broad interfaces into cohesive ones.  
+1. **Dependency Inversion Principle (DIP)** – Depend on abstractions, not concretes; introduce dependency injection.
+
+---
+
+## Task-Stub Specification
+
+Generate one task stub per SOLID violation.
+
+| Field | Description |
+|-------|-------------|
+| **ID** | `SOLID-NNN` (sequential) |
+| **Principle** | `SRP`, `OCP`, `LSP`, `ISP`, or `DIP` |
+| **Location** | File/class/function and line range |
+| **Issue&nbsp;Summary** | One-sentence description of the violation |
+| **Suggested&nbsp;Change** | Specific refactor (e.g., “Extract `EmailSender` from `UserService` to satisfy SRP”) |
+| **Rationale** | How the change aligns with the principle |
+| **Dependencies** | Other task IDs, if applicable |
+| **Effort** | `S`, `M`, or `L` |
+
+Return the stubs in a markdown table, **grouped by principle** and sorted by effort within each group.
+
+---
+
+## Input
+
+- Root path to the codebase  
+- Programming languages used  
+- Framework or architectural context if applicable  

--- a/codebase_analysis/overview.md
+++ b/codebase_analysis/overview.md
@@ -1,0 +1,3 @@
+# Overview of Codebase Analysis Prompts
+
+This folder contains prompts designed to analyze a codebase for quality and architectural improvements. Use them to identify duplication, SOLID violations, and maintainability issues.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,13 @@
 - [L4 “Worker Prompt”](../meta_prompts/L4_worker_prompt.md)
 - [Overview of Meta Prompts](../meta_prompts/overview.md)
 
+## Codebase Analysis
+
+- [DRY Codebase Analysis](../codebase_analysis/DRY_Codebase_Analysis.md)
+- [SOLID Codebase Analysis](../codebase_analysis/SOLID_Codebase_Analysis.md)
+- [Maintainability Codebase Analysis](../codebase_analysis/Maintainability_Codebase_Analysis.md)
+- [Overview of Codebase Analysis Prompts](../codebase_analysis/overview.md)
+
 ## Documentation
 
 - [Repository Documentation Overview](overview.md)


### PR DESCRIPTION
## Summary
- add DRY, SOLID, and maintainability analysis prompts
- add overview and update docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687943ed4aa4832caf2ad2f7bc535d58