### PR TITLE
Fix lint error in docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@
 
 - [E2E Test Discovery Prompt](../testing_prompts/01_e2e_test_discovery.md)
 - [Overview of Testing Prompts](../testing_prompts/overview.md)
+
 ## Codebase Analysis
 
 - [DRY Codebase Analysis](../codebase_analysis/DRY_Codebase_Analysis.md)


### PR DESCRIPTION
## Summary
- fix MD032 list spacing in docs/index.md

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_68794739fdd8832c807edc028dee4747