### PR TITLE
Add comprehensive-task prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@
 - [L2 Prompt Engineer](../meta_prompts/L2_prompt-engineer.md)
 - [L3 - Task Prototyper](../meta_prompts/L3_task-prototyper.md)
 - [L4 “Worker Prompt”](../meta_prompts/L4_worker_prompt.md)
+- [L5 Comprehensive-Task Prompt Template](../meta_prompts/L5_comprehensive-task-template.md)
 - [Overview of Meta Prompts](../meta_prompts/overview.md)
 
 ## Documentation

--- a/meta_prompts/L5_comprehensive-task-template.md
+++ b/meta_prompts/L5_comprehensive-task-template.md
@@ -1,0 +1,53 @@
+# L5 Comprehensive-Task Prompt Template
+
+Below is a plug-and-play “super-prompt” you can copy, then fill in the brackets to suit any task.
+It guides the AI through ✅ planning, ✅ execution, and ✅ self-checking—so results are as comprehensive and exhaustive as you need.
+
+---
+
+## 📌 Comprehensive-Task Prompt Template
+
+### Role & Mission
+
+“You are **[expert role]**. Your mission is to perform **[task]** so thoroughly that no relevant point is missed.”
+
+### Scope & Coverage Rules
+
+- ***Enumerate first*:** List every sub-topic, angle, and edge-case relevant to the task before you begin the main work.
+- **Depth gauge:** For each item, dig until one of these is true:
+   - all obvious and non-obvious details are addressed;
+   - additional detail would be redundant or speculative.
+- **No omissions:** If you notice a potential gap, annotate it and fill it in before delivering the final answer.
+
+### Output Structure
+
+- **Executive summary** (≤ 150 words).
+- **Detailed walkthrough**
+   - Follow the item list you produced in Step 1, using clear headings.
+- **Assumptions & sources** (cite or explain any data or reasoning).
+- **Self-audit checklist** (see next section).
+
+### Self-Audit Checklist
+
+“Before finalizing, verify that:
+
+- Every item from the initial enumeration is covered.
+- Each claim is backed by logic, calculation, or citation.
+- Formatting matches the requested structure.
+- No unexplained acronyms or jargon remain.”
+
+### Constraints
+
+- Use plain language unless technical terms are necessary.
+- Bullets and tables are welcome where they improve clarity.
+- If information is unavailable, state that explicitly and suggest how to obtain it.
+
+---
+
+## 🛠️ How to use it
+
+1. Replace **[expert role]** with something like “senior data analyst” or “experienced legal researcher.”
+1. Replace **[task]** with the exact deliverable (e.g., “draft a GDPR-compliant data-retention policy”).
+1. Add any extra constraints (style guide, length limit, citation style).
+
+Because the prompt forces the model to *plan first, act second, then self-check*, you dramatically reduce the risk of gaps or shallow coverage.


### PR DESCRIPTION
## Summary
- add Comprehensive-Task Prompt Template under `meta_prompts`
- link new prompt in docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_6879452f3f24832c83b0e093d6c03db1