### PR TITLE
Fix markdown lint issues

### DIFF
--- a/meta_prompts/L5_agents-md-checklist.md
+++ b/meta_prompts/L5_agents-md-checklist.md
@@ -6,8 +6,6 @@
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
 | **Clarify purpose**                | Codex (and similar agents) read AGENTS.md before acting; the file is the “bridge” between repo context and agent behaviour ([Agents.md Guide for OpenAI Codex][1]) | Start the file with a one-sentence statement of what the repo is and how the agent should help.               |
 | **Place files hierarchically**     | Codex merges *\~/.codex/AGENTS.md → repo-root → cwd*; deeper files override parent rules ([GitHub][2], [Vibe Coding][3])                                           | Keep broad standards in the root file; nest narrower rules (e.g. `/tests/AGENTS.md`).                         |
-=======
-| **Place files hierarchically**     | Codex merges ~/.codex/AGENTS.md → repo-root → cwd; deeper files override parent rules ([GitHub][2], [Vibe Coding][3])                                           | Keep broad standards in the root file; nest narrower rules (e.g. `/tests/AGENTS.md`).                         |
 | **Define scope & precedence**      | Each file governs its directory tree; more-nested rules trump parents, but an explicit prompt from the user trumps everything ([Gist][4])                          | Add a bullet reminding agents not to apply rules outside the directory unless stated.                         |
 | **Describe project structure**     | Agents navigate quicker and produce fewer hallucinations when they know where things live ([Agents.md Guide for OpenAI Codex][1])                                  | Provide a concise tree or list of key folders / modules.                                                      |
 | **Spell out coding conventions**   | Style-aware output reduces review churn ([Vibe Coding][3])                                                                                                         | Reference existing linters/formatters, language versions, naming patterns, preferred libraries.               |
@@ -20,7 +18,6 @@
 ---
 
 ## Ready-to-use **meta-prompt** for generating an AGENTS.md from any GitHub repo
-
 
 ```
 # SYSTEM (not visible to user)


### PR DESCRIPTION
## Summary
- clean up merge artifact and duplicate row in `L5_agents-md-checklist.md`
- ensure headers are surrounded by a single blank line

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_68794a5c0078832c830fe5be2c2d5c68