### PR TITLE
Fix deploy workflow to install markdownlint

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install markdownlint (mdl)
+        run: sudo gem install mdl
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Validate Markdown


### PR DESCRIPTION
## Summary
- update deploy-pages workflow to install `markdownlint` before running
  validation

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_68794b7d1f48832cb20626fbb03f214d