### PR TITLE
Add communication prompts

### DIFF
--- a/communication_prompts/01_explain_like_im_5.md
+++ b/communication_prompts/01_explain_like_im_5.md
@@ -1,0 +1,12 @@
+<!-- markdownlint-disable MD029 -->
+
+# Explain-Like-I’m-5 (ELI5)
+
+**“Explain ‘[TOPIC]’ as if I’m five:
+
+1. Start with a playful analogy I’d know from kindergarten.
+1. Use plain words—no sentence longer than 15 words.
+1. Give three everyday examples that show why it matters.
+   Finish with a one-sentence ‘grown-up’ summary (≤ 20 words).”**
+
+*Why it’s better:* specifies tone, vocabulary ceiling, example count, and an executive summary so adults can share it onward.

--- a/communication_prompts/02_tldr_summarizer.md
+++ b/communication_prompts/02_tldr_summarizer.md
@@ -1,0 +1,7 @@
+# TL;DR Summarizer
+
+**“Here’s some text: ‹PASTE›
+Give me a TL;DR in exactly three bullet points (≤ 15 words each).
+After the bullets, add one actionable next step I could take in ≤ 20 words.”**
+
+*Why it’s better:* locks down length, structure, and ends with a clear call-to-action instead of a passive abstract.

--- a/communication_prompts/03_80_20_crash_course.md
+++ b/communication_prompts/03_80_20_crash_course.md
@@ -1,0 +1,11 @@
+<!-- markdownlint-disable MD029 -->
+
+# 80/20 Crash Course
+
+**“Teach me the essentials of [SUBJECT] using the Pareto Principle:
+
+1. List the critical 20 % concepts (max 7 bullets).
+1. For each, show one real-world use that delivers 80 % of the value.
+1. End with a 5-minute practice exercise I can do right now.”**
+
+*Why it’s better:* turns “teach me” into a mini-curriculum—concise theory, high-impact examples, and immediate practice.

--- a/communication_prompts/04_smart_task_prioritizer.md
+++ b/communication_prompts/04_smart_task_prioritizer.md
@@ -1,0 +1,8 @@
+# Smart Task Prioritizer
+
+**“Here’s my to-do list: ‹PASTE›
+Create a table with columns — Task, Urgency (1-5), Impact (1-5), Effort (1-5), Priority Score (Impact × Urgency ÷ Effort).
+Sort by highest Score.
+After the table, suggest the first three tasks I should do and explain why in two sentences each.”**
+
+*Why it’s better:* combines MoSCoW-style scoring with an explicit formula, auto-sorts, and adds concise coaching.

--- a/communication_prompts/05_devils_advocate_stress_test.md
+++ b/communication_prompts/05_devils_advocate_stress_test.md
@@ -1,0 +1,11 @@
+<!-- markdownlint-disable MD029 -->
+
+# Devil’s-Advocate Stress Test
+
+**“Act as a seasoned critic.
+
+1. Present the three strongest arguments against this idea: ‹DESCRIBE IDEA›.
+1. For each objection, cite a real or hypothetical example that illustrates the risk.
+1. Then propose one mitigation strategy per objection.”**
+
+*Why it’s better:* forces the model to move beyond generic pushback—requiring concrete evidence and built-in solutions makes the critique actionable.

--- a/communication_prompts/overview.md
+++ b/communication_prompts/overview.md
@@ -1,0 +1,3 @@
+# Communication Prompts Overview
+
+Short prompts for clearer conversations, summaries and prioritization.

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,3 +66,12 @@
 - [Codex Prompt Suite](../codex_prompts/01_codex_prompt_suite.md)
 - [Codebase Testing Plan Prompt](../codex_prompts/02_codebase_testing_plan.md)
 - [Overview](../codex_prompts/overview.md)
+
+## Communication Prompts
+
+- [Explain-Like-I’m-5 (ELI5)](../communication_prompts/01_explain_like_im_5.md)
+- [TL;DR Summarizer](../communication_prompts/02_tldr_summarizer.md)
+- [80/20 Crash Course](../communication_prompts/03_80_20_crash_course.md)
+- [Smart Task Prioritizer](../communication_prompts/04_smart_task_prioritizer.md)
+- [Devil’s-Advocate Stress Test](../communication_prompts/05_devils_advocate_stress_test.md)
+- [Overview](../communication_prompts/overview.md)


### PR DESCRIPTION
## Summary
- introduce `communication_prompts` directory with quick templates
- add Explain-Like-I'm-5, TL;DR Summarizer, 80/20 Crash Course, Smart Task Prioritizer and Devil's-Advocate Stress Test
- document new prompts in `docs/index.md`

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_68795f7d72d0832c932c96c24a2c3e3f