### PR TITLE
Add utility prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A curated set of Markdown prompts for AI‑assisted software development. Prompt
 - **`testing_prompts/`** – instructions for creating thorough test plans
 - **`codebase_analysis/`** – checklists for evaluating code quality
 - **`codex_prompts/`** – Codex/ChatGPT oriented scaffolding prompts
+- **`utility_prompts/`** – short general-purpose helper prompts
 - **`starter_pack/`** – quick-start templates for new projects
 - **`docs/`** – additional documentation and a full [table of contents](docs/index.md)
 - **`scripts/`** – helper scripts such as `validate_markdown.sh`

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,3 +66,12 @@
 - [Codex Prompt Suite](../codex_prompts/01_codex_prompt_suite.md)
 - [Codebase Testing Plan Prompt](../codex_prompts/02_codebase_testing_plan.md)
 - [Overview](../codex_prompts/overview.md)
+
+## Utility Prompts
+
+- [Explain-Like-I’m-5](../utility_prompts/01_explain_like_im_five.md)
+- [TL;DR Summarizer](../utility_prompts/02_tldr_summarizer.md)
+- [80/20 Crash Course](../utility_prompts/03_80_20_crash_course.md)
+- [Smart Task Prioritizer](../utility_prompts/04_smart_task_prioritizer.md)
+- [Devil’s-Advocate Stress Test](../utility_prompts/05_devils_advocate_stress_test.md)
+- [Overview](../utility_prompts/overview.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,5 +14,6 @@ This directory stores general reference material for the repository. Use
 - [Codebase Analysis](../codebase_analysis/overview.md)
 - [Project Starter Pack](../starter_pack/overview.md)
 - [Codex Prompts](../codex_prompts/overview.md)
+- [Utility Prompts](../utility_prompts/overview.md)
 
 Add any new guidance here as the repository grows.

--- a/utility_prompts/01_explain_like_im_five.md
+++ b/utility_prompts/01_explain_like_im_five.md
@@ -1,0 +1,8 @@
+# Explain-Like-I'm-5 (ELI5)
+
+**"Explain '[TOPIC]' as if I'm five:
+
+1. Start with a playful analogy I'd know from kindergarten.
+1. Use plain words—no sentence longer than 15 words.
+1. Give three everyday examples that show why it matters.
+   Finish with a one-sentence 'grown-up' summary (≤ 20 words)."**

--- a/utility_prompts/02_tldr_summarizer.md
+++ b/utility_prompts/02_tldr_summarizer.md
@@ -1,0 +1,5 @@
+# TL;DR Summarizer
+
+**"Here's some text: ‹PASTE›
+Give me a TL;DR in exactly three bullet points (≤ 15 words each).
+After the bullets, add one actionable next step I could take in ≤ 20 words."**

--- a/utility_prompts/03_80_20_crash_course.md
+++ b/utility_prompts/03_80_20_crash_course.md
@@ -1,0 +1,7 @@
+# 80/20 Crash Course
+
+**"Teach me the essentials of [SUBJECT] using the Pareto Principle:
+
+1. List the critical 20 % concepts (max 7 bullets).
+1. For each, show one real-world use that delivers 80 % of the value.
+1. End with a 5-minute practice exercise I can do right now."**

--- a/utility_prompts/04_smart_task_prioritizer.md
+++ b/utility_prompts/04_smart_task_prioritizer.md
@@ -1,0 +1,6 @@
+# Smart Task Prioritizer
+
+**"Here's my to-do list: ‹PASTE›
+Create a table with columns — Task, Urgency (1-5), Impact (1-5), Effort (1-5), Priority Score (Impact × Urgency ÷ Effort).
+Sort by highest Score.
+After the table, suggest the first three tasks I should do and explain why in two sentences each."**

--- a/utility_prompts/05_devils_advocate_stress_test.md
+++ b/utility_prompts/05_devils_advocate_stress_test.md
@@ -1,0 +1,7 @@
+# Devil's-Advocate Stress Test
+
+**"Act as a seasoned critic.
+
+1. Present the three strongest arguments against this idea: ‹DESCRIBE IDEA›.
+1. For each objection, cite a real or hypothetical example that illustrates the risk.
+1. Then propose one mitigation strategy per objection."**

--- a/utility_prompts/overview.md
+++ b/utility_prompts/overview.md
@@ -1,0 +1,3 @@
+# Overview of Utility Prompts
+
+This folder provides quick, general-purpose prompts like ELI5 explanations, TL;DR summaries, crash courses, prioritization, and devil's-advocate critiques. Use them whenever you need short, focused instructions.


### PR DESCRIPTION
## Summary
- add new folder for utility prompts
- include ELI5, TL;DR summarizer, crash course, prioritizer and devil's advocate templates
- link new prompts from docs and README

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_68795f7d72d0832c932c96c24a2c3e3f