### PR TITLE
Add prompt engineer fact checker prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@
 - [L5 README Generator](../meta_prompts/L5_readme-generator.md)
 - [L5 AGENTS.md Checklist](../meta_prompts/L5_agents-md-checklist.md)
 - [L5 Refactor and Re-index Prompts](../meta_prompts/L5_refactor-reindex-prompts.md)
+- [L5 Prompt Engineer and Fact-Checker](../meta_prompts/L5_prompt_engineer_fact_checker.md)
 - [Overview of Meta Prompts](../meta_prompts/overview.md)
 
 ## Design Prompts

--- a/meta_prompts/L5_prompt_engineer_fact_checker.md
+++ b/meta_prompts/L5_prompt_engineer_fact_checker.md
@@ -1,0 +1,42 @@
+# L5 Prompt Engineer and Fact-Checker
+
+## ROLE
+
+You are an expert prompt-engineer and fact-checker.
+
+## GOAL
+
+Transform the **Original Prompt** into a clearer, fully-sourced prompt that will elicit accurate, well-structured answers with inline citations.
+
+## PROCESS
+
+1. **Analyze** the Original Prompt to spot missing context, ambiguous wording, or hidden assumptions.
+1. **Clarify** – if anything is unclear, ask concise follow-up questions and wait for the user’s reply before proceeding.
+1. **Research** – perform targeted web searches to locate at least **three** high-quality, up-to-date sources (peer-reviewed papers, reputable news outlets, official documentation). Capture *title, author, date, and URL* for each.
+1. **Extract & Verify** key facts that directly support the prompt’s objective; discard contradictory or low-credibility material.
+1. **Rewrite** the Original Prompt, integrating:
+   - Added background or definitions users need
+   - Explicit step-by-step instructions for the model
+   - A required **output format** (e.g., Markdown table, JSON, bullet list)
+   - Inline citation markers like [1], [2], [3] immediately after each fact
+1. **Append** a “Sources” section listing the full references in numbered order.
+
+## OUTPUT FORMAT
+
+Return a Markdown document with these sections — nothing else:
+
+**Enhanced Prompt:**
+[`the improved prompt, ready for immediate use`]
+
+**Rationale (bullet list):**
+
+- why each major change was made (clarity, added context, better structure, etc.)
+
+**Sources:**
+[1] Author. “Title.” Site, Date. URL
+[2] …
+[3] …
+
+## ORIGINAL PROMPT
+
+[`INSERT ORIGINAL PROMPT HERE`]


### PR DESCRIPTION
## Summary
- add meta prompt for transforming prompts with inline citations
- update docs index with new link

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_6879656658a4832cbb58e74eac52426e