### PR TITLE
Add project management prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -84,3 +84,10 @@
 - [Socratic-Coach](../communication_prompts/09_socratic_coach.md)
 - [Red-Team Stress-Test](../communication_prompts/10_red_team_stress_test.md)
 - [Overview](../communication_prompts/overview.md)
+
+## Project Management Prompts
+
+- [Project Charter & Scope Definition](../project_management/01_project_charter_scope.md)
+- [Comprehensive Risk Register & Mitigation Plan](../project_management/02_risk_register_mitigation.md)
+- [Weekly Executive Status Report](../project_management/03_weekly_exec_status_report.md)
+- [Overview](../project_management/overview.md)

--- a/project_management/01_project_charter_scope.md
+++ b/project_management/01_project_charter_scope.md
@@ -1,0 +1,9 @@
+<!-- markdownlint-disable MD029 -->
+
+# Project Charter & Scope Definition
+
+**"Role: You are a senior project-management consultant.
+Context: I'm kicking off [PROJECT NAME], a [brief description & industry] effort with a preliminary budget of [amount] and a deadline of [date]. Key stakeholders are [names/roles], and the high-level objective is [business outcome].
+Task: Draft a complete project charter that includes: background, objectives, in-scope/out-of-scope items, major deliverables, success criteria/KPIs, assumptions, constraints, top three risks, milestone schedule, high-level budget table, and required approval signatures.
+Output style: Return the charter as a Markdown document with H2 section headings and a two-column table for the milestone schedule. Keep each paragraph under 120 words.
+Quality-check: Ask any clarifying questions you need before you begin."**

--- a/project_management/02_risk_register_mitigation.md
+++ b/project_management/02_risk_register_mitigation.md
@@ -1,0 +1,9 @@
+<!-- markdownlint-disable MD029 -->
+
+# Comprehensive Risk Register & Mitigation Plan
+
+**"Role: Act as an enterprise risk-management analyst.
+Context: Here is the overview of [PROJECT NAME]: [paste summary]. We are in the [phase] phase with a budget of [amount].
+Task: Produce a risk register in Markdown that includes for each risk: ID, category, description, probability (1-5), impact (1-5), qualitative RAG score, owner, proposed mitigation actions, and residual risk score. Conclude with three overarching risk-response strategies.
+Output style: Use a Markdown table; wrap text in cells at 40 characters max; sort by highest combined risk score.
+Quality-check: If any project data are insufficient for a sound assessment, list the missing inputs and pause."**

--- a/project_management/03_weekly_exec_status_report.md
+++ b/project_management/03_weekly_exec_status_report.md
@@ -1,0 +1,14 @@
+<!-- markdownlint-disable MD029 -->
+
+# Weekly Executive Status Report
+
+**"Role: You are a PMO reporting analyst.
+Context: Below is this week's raw update feed for [PROJECT NAME]. The audience is C-level executives who prefer concise, data-rich summaries. [Paste bullet notes, metrics, blockers, etc.]
+Task: Transform the notes into a one-page weekly status report that includes:
+• RAG summary (scope, schedule, budget)
+• Top achievements (max 5 bullets)
+• Upcoming work (next 7 days, max 5 bullets)
+• Current risks/issues with owner and mitigation status
+• Requests/decisions needed.
+Output style: Return as Markdown; use a 5-column table for the RAG section (Area, Status, Delta vs Plan, Commentary, Action); keep bullets ≤ 15 words.
+Quality-check: Flag any missing metrics you need before producing the final report."**

--- a/project_management/overview.md
+++ b/project_management/overview.md
@@ -1,0 +1,3 @@
+# Project Management Prompts Overview
+
+Prompts for planning, risk assessment and status reporting.


### PR DESCRIPTION
## Summary
- create `project_management` folder with project management prompts
- add project charter prompt
- add risk register prompt
- add weekly executive status report prompt
- document the new prompts in the index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687972cf400c832c83d82d46e5c6f573