### PR TITLE
Clean communication prompts

### DIFF
--- a/communication_prompts/06_storyboard_my_idea.md
+++ b/communication_prompts/06_storyboard_my_idea.md
@@ -7,5 +7,3 @@
 1. Generate exactly 6 frames.
 1. For each frame give (a) scene description, (b) on-screen text ≤ 15 words, (c) suggested voice-over ≤ 20 words.
 1. End with a one-sentence emotional takeaway for the viewer.”**
-
-*Why it rocks:* Storyboarding used to be a designer-only skill, but creator blogs now recommend a structured, frame-by-frame prompt to crank out draft visuals in minutes.

--- a/communication_prompts/07_rapid_risk_matrix.md
+++ b/communication_prompts/07_rapid_risk_matrix.md
@@ -7,5 +7,3 @@
 • Build a table with columns: Risk, Likelihood (1-5), Impact (1-5), Raw-Score (L×I), Mitigation.
 • Sort the table by highest Raw-Score.
 • Follow with a 100-word narrative on the top two risks and how to monitor them.”**
-
-*Why it rocks:* Risk-scoring tables are showing up in “100 best prompts of 2025” lists because they translate classic probability-impact matrices into a single copy-paste block.

--- a/communication_prompts/08_data_to_insight_analyst.md
+++ b/communication_prompts/08_data_to_insight_analyst.md
@@ -9,5 +9,3 @@ Task list:
 1. Return three high-impact insights (≤ 40 words each).
 1. Suggest one simple chart for each insight—name chart type and axes.
 1. Finish with one follow-up experiment I could run next week.”**
-
-*Why it rocks:* Data-analysis blogs highlight this four-step pattern—clarify, insight, visualize, next step—as the fastest way to turn raw tables into decisions without drowning in stats jargon.

--- a/communication_prompts/09_socratic_coach.md
+++ b/communication_prompts/09_socratic_coach.md
@@ -7,5 +7,3 @@ Rule set:
 • Reply only with one probing question at a time—no advice yet.
 • Continue until you’ve uncovered my assumptions and knowledge gaps (up to 7 questions).
 • Then summarise my position in ≤ 75 words and give 3 concrete next actions.”**
-
-*Why it rocks:* Medium essays and Reddit “Prompt of the Day” posts report that forcing an AI into question-only mode prevents premature advice and deepens reflection before action.

--- a/communication_prompts/10_red_team_stress_test.md
+++ b/communication_prompts/10_red_team_stress_test.md
@@ -9,5 +9,3 @@ Scenario: “[IDEA / STRATEGY]”.
 1. Consolidate attacks into a ranked list by severity.
 1. For the top 3 attacks, propose a mitigation playbook (≤ 50 words each).
 1. End with one metric to track that signals the mitigation is working.”**
-
-*Why it rocks:* “Red-team your idea before the market does” is the rallying cry in recent AI-security circles; multi-persona attack prompts uncover blind spots far earlier than friendly chats.


### PR DESCRIPTION
## Summary
- remove explanatory lines from storyboard, risk matrix, data analyst, Socratic coach, and red-team prompts

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687972a526b8832cb17a64eea554381b