### PR TITLE
Add operations prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -84,3 +84,10 @@
 - [Socratic-Coach](../communication_prompts/09_socratic_coach.md)
 - [Red-Team Stress-Test](../communication_prompts/10_red_team_stress_test.md)
 - [Overview](../communication_prompts/overview.md)
+
+## Operations Prompts
+
+- [Rapid Process Diagnostic & Lean Improvement Plan](../operations_prompts/01_rapid_process_diagnostic.md)
+- [Inventory & Demand-Planning Simulation](../operations_prompts/02_inventory_demand_planning_simulation.md)
+- [KPI Dashboard & Monthly Ops-Review Pack](../operations_prompts/03_kpi_dashboard_ops_review.md)
+- [Overview](../operations_prompts/overview.md)

--- a/operations_prompts/01_rapid_process_diagnostic.md
+++ b/operations_prompts/01_rapid_process_diagnostic.md
@@ -1,0 +1,23 @@
+
+# Rapid Process Diagnostic & Lean Improvement Plan
+
+You are a **senior Lean-Six-Sigma Black Belt** engaged to overhaul our [PROCESS NAME].
+
+## Context
+
+• Current volume: [units per month]
+• Avg. cycle-time: [days]
+• Pain points: [bullet list]
+• Target outcome: cycle-time ↓ 15 %, cost ↓ 10 %
+
+## Tasks
+
+1. Map the value stream and label wastes (TIMWOOD).
+1. List the **top-5 bottlenecks** with root cause and quantified business impact.
+1. Draft a **90-day action plan** (owner, milestone, KPI) in a Markdown table.
+1. Conclude with a ≤ 150-word executive summary.
+
+## Constraints
+
+* Think step-by-step, reflecting on Lean tools used.
+* Output **only** the table followed by the summary.

--- a/operations_prompts/02_inventory_demand_planning_simulation.md
+++ b/operations_prompts/02_inventory_demand_planning_simulation.md
@@ -1,0 +1,25 @@
+
+<!-- markdownlint-disable MD012 -->
+
+# Inventory & Demand-Planning Simulation
+
+Act as a **supply-chain data scientist** specializing in inventory optimization.
+
+Context supplied below:
+
+```csv
+SKU, Monthly_Demand_24M, LeadTime_Days, HoldingCost_USD
+…
+```
+
+**Goal**
+Generate a 12-month demand forecast, compute EOQ & safety-stock per SKU (95 % service level), and propose inventory-rebalancing moves.
+
+**Deliverables**
+Return a **JSON object** with keys:
+
+* `forecast`              – table of projected demand
+* `inventory_plan`        – recommended reorder point, EOQ, safety-stock
+* `risks`                 – top 3 forecast or supply risks + mitigation
+
+Use chain-of-thought internally but **do not** expose it; present only the JSON plus a ≤ 120-word note on methodology.

--- a/operations_prompts/03_kpi_dashboard_ops_review.md
+++ b/operations_prompts/03_kpi_dashboard_ops_review.md
@@ -1,0 +1,20 @@
+# KPI Dashboard & Monthly Ops-Review Pack
+
+You are our **operations-performance coach** preparing the COO’s monthly review.
+
+## Context
+
+• Latest KPI data (csv attached) for Q3 FY-25
+• Strategic priorities: cost leadership, on-time delivery, ESG compliance
+
+## Tasks
+
+1. Identify the **3 KPIs furthest off-target**; explain root cause.
+1. Recommend corrective initiatives, RACI owner, and due date.
+1. Draft three narrative slides in Markdown:
+   - ### State of Operations  
+   - ### Key Risks & Mitigations  
+   - ### Next Steps
+   *≤ 5 bullets per slide*
+
+Close with an “Ask” slide listing decisions needed from the exec team.

--- a/operations_prompts/overview.md
+++ b/operations_prompts/overview.md
@@ -1,0 +1,3 @@
+# Operations Prompts
+
+This folder contains prompts for business operations, including process improvement, inventory planning, and KPI review.


### PR DESCRIPTION
## Summary
- add new operations prompts for process diagnostics, inventory planning, and KPI reviews
- document the operations prompt folder in docs/index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_68797249d36c832c9a41071425059a8c