### PR TITLE
Add executive prompt set

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -84,3 +84,10 @@
 - [Socratic-Coach](../communication_prompts/09_socratic_coach.md)
 - [Red-Team Stress-Test](../communication_prompts/10_red_team_stress_test.md)
 - [Overview](../communication_prompts/overview.md)
+
+## Executive Prompts
+
+- [Strategic Market Foresight & Action Plan](../executive_prompts/01_strategic_market_foresight.md)
+- [Crisis-Management Playbook Generator](../executive_prompts/02_crisis_management_playbook.md)
+- [Executive-Ready Brief & Talking Points Synthesizer](../executive_prompts/03_executive_brief_synthesizer.md)
+- [Overview](../executive_prompts/overview.md)

--- a/executive_prompts/01_strategic_market_foresight.md
+++ b/executive_prompts/01_strategic_market_foresight.md
@@ -1,0 +1,27 @@
+<!-- markdownlint-disable MD029 MD033 MD036 -->
+
+# Strategic Market Foresight & Action Plan
+
+**“You are a seasoned strategy advisor who has guided multiple Fortune 500 CEOs through disruptive market shifts.
+
+**Objective:**
+• Detect the next major inflection in the [INDUSTRY] landscape and craft a concrete response plan for [COMPANY].
+
+**Inputs:**
+• Summaries (below) of our last-five-year P&L, product launches, and customer-insight reports.
+• Public data: top competitors’ annual reports, the most recent Gartner “Magic Quadrant,” and macro-economic forecasts for the next 24 months.
+
+**Tasks:**
+
+ 1. Identify 3–4 emergent trends (give evidence and probability).
+ 1. For the most probable trend, outline a 90-day, 1-year, and 3-year action plan addressing:
+   • product/portfolio moves
+   • talent or capability gaps
+   • financial impact (high-level numbers)
+ 1. Flag key assumptions and risks in a bullet list.
+
+**Output format:**
+Markdown report → Section A: Trend Radar (table) → Section B: Action Plan (timeline) → Section C: Risk Register.
+
+**Quality check:**
+End with three questions you need me to answer to improve fidelity.”**

--- a/executive_prompts/02_crisis_management_playbook.md
+++ b/executive_prompts/02_crisis_management_playbook.md
@@ -1,0 +1,24 @@
+<!-- markdownlint-disable MD029 MD033 MD036 -->
+
+# Crisis-Management Playbook Generator
+
+**“Act as my Chief Risk Officer with a background in Fortune 100 crisis response.
+
+**Scenario:**
+Last night we discovered a critical vulnerability in our flagship SaaS platform that could expose customer data.
+
+**Deliverable:**
+Create a concise, 4-page Crisis-Management Playbook covering:
+
+ 1. Decision-making tree (who approves what, within what timeframe).
+ 1. Immediate comms templates (internal, media, regulator).
+ 1. Technical containment steps (high-level; engineers will fill details).
+ 1. After-action review criteria and timeline.
+
+**Constraints:**
+• Follow ISO 22361 terminology.
+• Tone: calm, authoritative.
+• Use bullet lists and tables where clarity improves speed of reading.
+
+**Reflection step:**
+After each main section, add one question to confirm assumptions before finalization.”**

--- a/executive_prompts/03_executive_brief_synthesizer.md
+++ b/executive_prompts/03_executive_brief_synthesizer.md
@@ -1,0 +1,26 @@
+<!-- markdownlint-disable MD029 MD033 MD036 -->
+
+# Executive-Ready Brief & Talking Points Synthesizer
+
+**“You are my senior communications director with 15 years briefing global CEOs.
+
+**Source material:**
+• Five quarterly performance dashboards (attached).
+• The latest external audit letter and analyst call transcript.
+
+**Task:**
+
+ 1. Synthesize the material into a one-page executive brief (≤ 300 words).
+ 1. Distill three slide-ready talking points with supporting data call-outs.
+ 1. Highlight any numbers likely to draw analyst scrutiny (bold them).
+
+**Style:**
+Formal but persuasive; use plain-language headlines followed by dense, data-rich bullets.
+
+**Output:**
+
+Return:
+\<EXECUTIVE_BRIEF>
+\<THREE_TALKING_POINTS>
+
+Add a 30-word “Further Questions” section at the end.”**

--- a/executive_prompts/overview.md
+++ b/executive_prompts/overview.md
@@ -1,0 +1,3 @@
+# Executive Prompts Overview
+
+Prompts for leaders needing strategic foresight, crisis planning, and concise communications.


### PR DESCRIPTION
## Summary
- add Strategic Market Foresight, Crisis Management, and Executive Brief prompts
- document these in new `executive_prompts` folder
- update table of contents

## Testing
- `./scripts/validate_markdown.sh`


------
https://chatgpt.com/codex/tasks/task_e_6879726c1240832ca4301ddca05a4e3a