### PR TITLE
Add data management prompt set

### DIFF
--- a/data_management_prompts/01_unified_data_cleansing.md
+++ b/data_management_prompts/01_unified_data_cleansing.md
@@ -1,0 +1,25 @@
+# Unified Data Cleansing & Consolidation
+
+You are a senior data engineer.
+
+## Context
+- Source-1: 2024-Q4 e-commerce CSV (schema below)
+- Source-2: CRM export (JSON)
+- Goal: build a single, analysis-ready table by close of business.
+
+## Task
+1. Identify schema mismatches, missing values, and outliers.
+2. Propose normalization rules (naming, data types, units, time-zones).
+3. Generate Python-pandas pseudocode for:
+   a. loading both sources,
+   b. applying the rules,
+   c. returning a consolidated DataFrame.
+4. List any assumptions; ask clarifying questions if something is ambiguous.
+
+## Output format
+Use fenced Markdown blocks:
+```python
+# step-by-step pseudocode here
+```
+
+Follow with a bullet list of remaining open questions.

--- a/data_management_prompts/02_regulatory_gap_analysis.md
+++ b/data_management_prompts/02_regulatory_gap_analysis.md
@@ -1,0 +1,20 @@
+# Regulatory Data-Governance Gap Analysis
+
+You are the Chief Data Officer for a mid-size healthcare provider.
+
+## Context
+- Current data-governance policy excerpt (pasted below).
+- Target regulation: GDPR Art. 5 & EU AI Act Title IV.
+- Objective: find compliance gaps and draft a remediation roadmap.
+
+## Instructions
+1. Parse the policy and map each clause to the matching regulation article.
+2. Flag any *partial* or *missing* coverage.
+3. Rate the risk severity (High/Med/Low) and business impact.
+4. Recommend the top 5 remediation actions, ordered by risk-reduction ROI.
+5. Ask clarifying questions if policy details are insufficient.
+
+## Output format
+| Regulation article | Current coverage | Gap description | Risk | Recommended fix |
+|--------------------|------------------|-----------------|------|-----------------|
+*(fill the table, then provide a numbered action list)*

--- a/data_management_prompts/03_data_architecture_blueprint.md
+++ b/data_management_prompts/03_data_architecture_blueprint.md
@@ -1,0 +1,18 @@
+# Future-Proof Data-Architecture Blueprint
+
+Assume the role of an enterprise data-architect advisor.
+
+## Scenario
+- Current stack: on-prem SQL Server + nightly ETL to S3.
+- Forecast: 10× data growth over 18 months; need low-latency ML-serving.
+- Budget: $250 k capex + $6 k/mo opex.
+
+## Deliverables
+1. Compare at least 3 target architectures (lakehouse on Databricks, Snowflake with Iceberg tables, open-source Delta + DuckDB, etc.).
+2. For each, break down: storage layer, compute engine, governance tooling, estimated 3-year TCO.
+3. Recommend the best fit and justify with a decision matrix (criteria: scalability, cost, team skill alignment, vendor lock-in).
+4. List the first five migration milestones and rough duration.
+5. End with "Any questions?" if uncertainties remain.
+
+## Output format
+Decision matrix in Markdown, followed by a Gantt-style milestone table.

--- a/data_management_prompts/overview.md
+++ b/data_management_prompts/overview.md
@@ -1,0 +1,7 @@
+# Data Management Prompts
+
+This folder contains prompt templates for data engineering and governance tasks.
+
+- **Unified Data Cleansing & Consolidation** – guidance to merge multi-source datasets into an analysis-ready table.
+- **Regulatory Data-Governance Gap Analysis** – identifies compliance gaps and remediation actions.
+- **Future-Proof Data-Architecture Blueprint** – evaluates scalable architectures and migration milestones.

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,3 +99,10 @@
 - [Weekly Executive Status Report](../project_management/03_weekly_exec_status_report.md)
 - [Overview](../project_management/overview.md)
 
+## Data Management Prompts
+
+- [Unified Data Cleansing & Consolidation](../data_management_prompts/01_unified_data_cleansing.md)
+- [Regulatory Data-Governance Gap Analysis](../data_management_prompts/02_regulatory_gap_analysis.md)
+- [Future-Proof Data-Architecture Blueprint](../data_management_prompts/03_data_architecture_blueprint.md)
+- [Overview](../data_management_prompts/overview.md)
+


### PR DESCRIPTION
## Summary
- add `data_management_prompts` directory with three new templates
- update docs index with links to the new prompts

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687975ac13e4832cb6415d8d08164572