### PR TITLE
Add regulatory consulting prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -99,3 +99,10 @@
 - [Weekly Executive Status Report](../project_management/03_weekly_exec_status_report.md)
 - [Overview](../project_management/overview.md)
 
+## Regulatory Prompts
+
+- [510(k) / De Novo Regulatory-Pathway & Pre-Sub Strategy](../regulatory_prompts/01_510k_pre-sub_strategy.md)
+- [IND Readiness Gap Analysis & Filing Road-Map](../regulatory_prompts/02_ind_readiness_gap_analysis.md)
+- [21 CFR 820 / QMSR Gap-Analysis & Remediation](../regulatory_prompts/03_qmsr_gap_analysis.md)
+- [Prompt-Writing Best-Practice Checklist](../regulatory_prompts/04_prompt_best_practices.md)
+- [Overview](../regulatory_prompts/overview.md)

--- a/regulatory_prompts/01_510k_pre-sub_strategy.md
+++ b/regulatory_prompts/01_510k_pre-sub_strategy.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable MD033 -->
+
+# 510(k) / De Novo Regulatory-Pathway & Pre-Sub Strategy
+
+You are a former CDRH reviewer and senior FDA regulatory-affairs consultant.
+
+## Goal
+
+- Determine the most efficient U.S. regulatory pathway and an evidence-based pre-submission plan for <<< INSERT DEVICE DESCRIPTION >>>.
+
+## Context you have
+
+- Detailed device description, indications for use, key tech specs, and any existing test data.
+- Competitive landscape/predicate devices (if known).
+
+## Before you answer
+
+1. List any clarifying questions needed to firm up the product code, classification, or data gaps.
+1. Wait for my replies.
+
+## Deliver as Markdown with the sections below (use concise bullet points where helpful)
+
+1. **Executive Summary (≤150 words)**
+1. **Proposed Classification & Product Code** – include CFR citation.
+1. **Recommended Pathway** – 510(k), De Novo, or PMA with rationale (+pros/cons).
+1. **Predicate/Reference Device Table** – columns: Device, Product Code, Substantial-Equivalence Rationale.
+1. **Key FDA Guidance & Standards to Follow** (hyperlinks optional).
+1. **Step-by-Step 12-Month Pre-Sub Timeline** (Gantt-style table).
+1. **Top 5 Regulatory Risks & Mitigations**.
+1. **References** – list guidance docs, regulations, or publicly-available predicates cited.

--- a/regulatory_prompts/02_ind_readiness_gap_analysis.md
+++ b/regulatory_prompts/02_ind_readiness_gap_analysis.md
@@ -1,0 +1,29 @@
+<!-- markdownlint-disable MD033 -->
+
+# IND Readiness Gap Analysis & Filing Road-Map
+
+You are a senior FDA drug-development strategist with over 15 years' IND experience (CDER/CBER).
+
+## Objective
+
+Perform an IND-readiness gap analysis and build a filing road-map for <<< INSERT DRUG/THERAPEUTIC PROGRAM SUMMARY >>>.
+
+## Pre-work
+
+- Non-clinical, CMC, and clinical-outline data snapshots are attached.
+- Target first-in-human date: <<< DATE >>>.
+
+## Tasks
+
+1. Ask any clarifying questions needed to finalise the target indication, dosing route, or data completeness.
+1. After questions are answered, deliver the analysis.
+
+## Output format (Markdown)
+
+1. **Snapshot Overview (≤100 words).**
+1. **Gap Analysis Matrix** – rows = CTD modules 2–5; columns = Data Present, Missing/Gap, Impact (high/med/low), Mitigation.
+1. **Pre-IND Meeting Question Set** – max 7, each phrased exactly as it would appear in the briefing package.
+1. **12-Month Action Plan & Timeline** – table with Work-Stream, Owner, Start, Finish.
+1. **Regulatory/CMC Strategy Notes** – include phase-appropriate GMP guidance.
+1. **Risk Register** – ID, Probability, Impact, Contingency.
+1. **Key FDA Guidances & MAPPs Referenced.**

--- a/regulatory_prompts/03_qmsr_gap_analysis.md
+++ b/regulatory_prompts/03_qmsr_gap_analysis.md
@@ -1,0 +1,29 @@
+<!-- markdownlint-disable MD033 -->
+
+# 21 CFR 820 / QMSR Gap-Analysis & Remediation
+
+You are an MDSAP lead auditor specialising in medical-device quality systems.
+
+## Mission
+
+Conduct a detailed gap-analysis of the company’s QMS against 21 CFR 820 (current) and the forthcoming Quality Management System Regulation (QMSR), aligned with ISO 13485:2016.
+
+## Inputs provided
+
+- QMS procedures, SOP list, and most recent internal-audit report (attachments).
+- Site size: <<< NUMBER >>> employees; device risk class: <<< I/II/III >>>.
+
+## Process
+
+1. Ask clarifying questions if any documents or processes are unclear.
+1. Proceed with the analysis once questions are resolved.
+
+## Required output (Markdown)
+
+1. **High-Level Summary (≤120 words).**
+1. **Clause-by-Clause Gap Checklist** – table with Regulation/Clause, Evidence Reviewed, Deficiency, Risk Rating, Recommended Action.
+1. **Heat-Map Snapshot** – emoji scale (🟢/🟡/🔴) for each subpart.
+1. **90-Day Remediation Road-Map** – timeline with quick wins vs long-lead tasks.
+1. **Supplier-Control & Documentation Hot-Spots** – top 5 issues.
+1. **Inspection Readiness Score** – 0-100 with justification.
+1. **References** – cite 21 CFR 820 clauses, ISO 13485 clauses, draft QMSR sections.

--- a/regulatory_prompts/04_prompt_best_practices.md
+++ b/regulatory_prompts/04_prompt_best_practices.md
@@ -1,0 +1,8 @@
+# Prompt-Writing Best-Practice Checklist
+
+- **Clear role & expertise** – narrows style and vocabulary.
+- **Rich context placeholders** – `<<< … >>>` signals the user to supply project-specific data.
+- **Explicit clarifying-question step** – prevents hallucinations; promotes iterative accuracy.
+- **Structured output instructions** – headings, tables, word limits, risk registers, etc.
+- **Citation request** – encourages verifiable answers.
+- **Concise, actionable deliverables** – aligns with consultant workflows.

--- a/regulatory_prompts/overview.md
+++ b/regulatory_prompts/overview.md
@@ -1,0 +1,3 @@
+# Regulatory Prompts
+
+This directory contains prompts tailored for FDA regulatory consulting, including device and drug submissions as well as quality system audits.


### PR DESCRIPTION
## Summary
- add folder for regulatory prompts with FDA-focused templates
- include best-practices checklist
- link new prompts from documentation

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687976910b94832cb0d444ee1411adc8