### PR TITLE
Add site acquisition prompt set

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -190,3 +190,10 @@
 - [Biological Safety Plan Developer](../biosafety_prompts/02_biological_safety_plan_developer.md)
 - [Regulatory Submission Support](../biosafety_prompts/03_regulatory_submission_support.md)
 - [Overview](../biosafety_prompts/overview.md)
+
+## Site Acquisition Prompts
+
+- [Site Landscape Mapping & Prioritization](../site_acquisition_prompts/01_site_landscape_mapping.md)
+- [Tailored Feasibility-Questionnaire Builder](../site_acquisition_prompts/02_tailored_feasibility_questionnaire.md)
+- [Personalized Investigator-Outreach Email Generator](../site_acquisition_prompts/03_investigator_outreach_email_generator.md)
+- [Overview](../site_acquisition_prompts/overview.md)

--- a/site_acquisition_prompts/01_site_landscape_mapping.md
+++ b/site_acquisition_prompts/01_site_landscape_mapping.md
@@ -1,0 +1,35 @@
+# Site Landscape Mapping & Prioritization
+
+You are a senior clinical-operations strategist at a global CRO.
+
+## Objective
+
+Provide a ranked short-list of the 20 most suitable investigative sites for the study described below.
+
+## Study Synopsis
+
+<<PASTE FINAL PROTOCOL SUMMARY>>
+
+## Deliverables
+
+- Provide a table with these columns:
+
+  1. Rank
+  1. Institution / Site name
+  1. Principal Investigator
+  1. City & Country
+  1. Prior trials in this indication (past 5 yrs)
+  1. Average monthly recruitment rate (last trial)
+  1. Key capacity metric (e.g., open beds)
+  1. Contact e-mail / phone
+  1. Source links
+
+## Constraints
+
+- Include only sites whose current trial load is ≤ 80 % of historical maximum.
+- Cover ≥ 3 geographic regions.
+- Base recommendations on public registries (ClinicalTrials.gov, EU CTR, etc.) plus any sponsor-supplied data.
+- Cite every data source in column 9.
+
+Before you start, ask up to three clarifying questions if anything is missing.
+Return the output as Markdown.

--- a/site_acquisition_prompts/02_tailored_feasibility_questionnaire.md
+++ b/site_acquisition_prompts/02_tailored_feasibility_questionnaire.md
@@ -1,0 +1,31 @@
+# Tailored Feasibility-Questionnaire Builder
+
+You are a clinical-feasibility specialist with 15 years' experience designing site-qualification questionnaires for Phase II oncology trials.
+
+## Context
+
+Draft protocol summary → <<PASTE HERE>>
+
+## Task
+
+Create a site-feasibility questionnaire that will
+
+1. Validate true patient availability against nuanced I/E criteria.
+1. Surface staffing, equipment or start-up timeline gaps.
+1. Flag operational risks such as competing trials.
+
+## Required Structure
+
+- Section A – Patient Population (≤ 8 questions)
+- Section B – Facilities & Equipment (≤ 6)
+- Section C – Staffing & Experience (≤ 6)
+- Section D – Regulatory & Budget (≤ 5)
+- Section E – Open-ended risk questions (≤ 3)
+
+## Rules
+
+- Phrase every question so it can be answered quantitatively where possible.
+- Keep medical acronyms consistent with protocol.
+- Output a numbered list under each section in plain text.
+
+If key protocol details are missing, list them and stop.

--- a/site_acquisition_prompts/03_investigator_outreach_email_generator.md
+++ b/site_acquisition_prompts/03_investigator_outreach_email_generator.md
@@ -1,0 +1,37 @@
+# Personalized Investigator-Outreach Email Generator
+
+You are the business-development lead at [CRO_NAME], crafting first-contact emails to potential investigators.
+
+## Input Variables (JSON)
+
+```json
+{
+  "investigator_name": "",
+  "site_name": "",
+  "city_country": "",
+  "recent_relevant_trials": "",
+  "unique_site_strength": "",
+  "study_synopsis": "",
+  "sponsor_name": ""
+}
+```
+
+Write an email that
+
+- Opens with a site-specific hook referencing their recent work.
+- Summarizes the study value proposition and why their patient mix aligns.
+- Briefly explains the CRO support provided (e.g., rapid start-up, dedicated CTAs).
+- Closes with a clear CTA: a 15-min intro call link.
+
+Tone – professional, collaborative; 180-220 words.
+
+## Return Format
+
+```json
+{
+  "subject_line": "",
+  "email_body": ""
+}
+```
+
+If any variable is blank, ask for it rather than guessing.

--- a/site_acquisition_prompts/overview.md
+++ b/site_acquisition_prompts/overview.md
@@ -1,0 +1,3 @@
+# Site Acquisition Prompts
+
+Prompts for identifying, qualifying, and engaging clinical trial sites.


### PR DESCRIPTION
## Summary
- add prompts for site landscape mapping, feasibility questionnaires, and outreach emails
- index the new site acquisition section

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_6879a5270de0832c958987b48dda5939