### PR TITLE
Add clinical ETL prompts

### DIFF
--- a/data_management_prompts/04_clinical_etl_mapping_spec.md
+++ b/data_management_prompts/04_clinical_etl_mapping_spec.md
@@ -1,0 +1,27 @@
+# Clinical ETL Mapping Specification
+
+You are a principal clinical-data engineer who has delivered multiple FDA-compliant Study Data Tabulation Model (SDTM) repositories. Think like a CDISC auditor.
+
+## User task
+
+1. Map raw Electronic Data Capture (EDC) tables to SDTM domains DM, AE, LB, VS.
+1. For each domain, list:
+   - source columns
+   - target variables
+   - derivation logic (pseudo-code)
+   - unit conversions
+   - codelist references.
+1. Flag any ambiguous or missing metadata.
+
+## Constraints
+
+- Use R (tidyverse) and Base SAS syntax examples.
+- Follow CDISC naming conventions.
+- Output two artefacts:
+   - A Markdown table for the mapping spec.
+   - A "next-actions" bullet list for unresolved gaps.
+
+## Quality gates
+
+- Double-check that all keys needed for merge() / PROC SORT are defined.
+- If a rule is uncertain, say "⚠ Needs SME review".

--- a/data_management_prompts/05_clinical_etl_transformation_qc.md
+++ b/data_management_prompts/05_clinical_etl_transformation_qc.md
@@ -1,0 +1,37 @@
+# Clinical ETL Transformation Code and QC
+
+You are a senior statistical-programming mentor.
+
+## Task
+
+Write production-ready code that transforms a raw Lab Results dataset into ADLB (analysis-ready), with identical logic in R and SAS.
+
+## Detailed instructions
+
+1. R section: tidyverse pipeline with explicit factor handling and `vctrs::vec_c` type safety.
+1. SAS section: PROC SQL + DATA step macro; include LOG checks for uninitialized variables and unit mismatches.
+1. Create mirrored unit-test scripts using testthat (R) and `%assert_compare` macro (SAS) to confirm the two outputs are byte-for-byte identical on sample data.
+
+## Output format
+
+## R code
+
+```r
+...code...
+```
+
+## SAS code
+
+```sas
+...code...
+```
+
+## QC tests
+
+...tests...
+
+## Check list before finishing
+
+- Match column order to ADaM IG v2.2
+- Set all date variables to ISO-8601 (`YYYY-MM-DD`).
+- Add inline comments for regulatory traceability.

--- a/data_management_prompts/06_clinical_etl_pipeline_review.md
+++ b/data_management_prompts/06_clinical_etl_pipeline_review.md
@@ -1,0 +1,19 @@
+# Clinical ETL Pipeline Review and Optimisation
+
+You are a performance-tuning specialist for large oncology Phase III trials.
+
+## Context
+
+The following GitHub gist (link) contains a multi-step ETL: `ingest_raw.R`, `transform.sas`, `load_to_db.sql`. Peak run-time is 4 h.
+
+## Tasks
+
+1. Code review – list the top 5 maintainability issues and any CDISC compliance risks.
+1. Benchmark plan – propose a reproducible approach (e.g., `bench::mark` in R, `/fullstimer` in SAS) to isolate slow steps, including metrics to capture.
+1. Optimisation suggestions – give concrete refactors (vectorisation, hash joins, partitioned loads) and estimate percentage run-time saved.
+
+## Constraints
+
+- Solutions must keep the code portable to on-prem SAS 9.4 and Posit Workbench.
+- No proprietary libraries.
+- Provide reasoning first, then the recommendations ("Thought process → Solution" pattern).

--- a/data_management_prompts/overview.md
+++ b/data_management_prompts/overview.md
@@ -5,3 +5,6 @@ This folder contains prompt templates for data engineering and governance tasks.
 - **Unified Data Cleansing & Consolidation** – guidance to merge multi-source datasets into an analysis-ready table.
 - **Regulatory Data-Governance Gap Analysis** – identifies compliance gaps and remediation actions.
 - **Future-Proof Data-Architecture Blueprint** – evaluates scalable architectures and migration milestones.
+- **Clinical ETL Mapping Specification** – map raw EDC tables to SDTM domains with R and SAS examples.
+- **Clinical ETL Transformation Code and QC** – produce mirrored R and SAS code with automated tests.
+- **Clinical ETL Pipeline Review and Optimisation** – audit and refactor existing pipelines for performance and compliance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,9 @@
 - [Unified Data Cleansing](../data_management_prompts/01_unified_data_cleansing.md)
 - [Regulatory Gap Analysis](../data_management_prompts/02_regulatory_gap_analysis.md)
 - [Data Architecture Blueprint](../data_management_prompts/03_data_architecture_blueprint.md)
+- [Clinical ETL Mapping Specification](../data_management_prompts/04_clinical_etl_mapping_spec.md)
+- [Clinical ETL Transformation Code and QC](../data_management_prompts/05_clinical_etl_transformation_qc.md)
+- [Clinical ETL Pipeline Review and Optimisation](../data_management_prompts/06_clinical_etl_pipeline_review.md)
 - [Overview](../data_management_prompts/overview.md)
 
 ## Design Prompts


### PR DESCRIPTION
## Summary
- add three clinical ETL prompts covering mapping specs, transformation code with QC, and pipeline review
- update data management overview
- include new entries in docs index

## Testing
- `bash scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a44f1a188832cb404a41780b04b9d