### PR TITLE
Add eClinical integration prompt set

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,13 @@
 - [Clinical ETL Pipeline Review and Optimisation](../data_management_prompts/06_clinical_etl_pipeline_review.md)
 - [Overview](../data_management_prompts/overview.md)
 
+## eClinical Integration Prompts
+
+- [Architect the Integration Blueprint](../eclinical_integration_prompts/01_architect_integration_blueprint.md)
+- [Generate a Data-Mapping & Transformation Playbook](../eclinical_integration_prompts/02_data_mapping_transformation_playbook.md)
+- [Compile the Regulatory & Validation Checklist](../eclinical_integration_prompts/03_regulatory_validation_checklist.md)
+- [Overview](../eclinical_integration_prompts/overview.md)
+
 ## Design Prompts
 
 - [Design Md Template](../design_prompts/01_design_md_template.md)

--- a/eclinical_integration_prompts/01_architect_integration_blueprint.md
+++ b/eclinical_integration_prompts/01_architect_integration_blueprint.md
@@ -1,0 +1,34 @@
+# Architect the Integration Blueprint
+
+**Role:** You are a Senior Clinical Data Architect experienced in eSource and real-world-data workflows.
+
+**Context:** We are running a multicentre Phase III trial that must move structured patient data from site EHRs into our EDC and CTMS with minimal duplicate entry. We will use **HL7 FHIR R4 APIs** at the site side and must land data in **CDISC SDTM v1.8** domains. Our tech stack already supports RESTful APIs and message queues.
+
+**Task:**
+
+1. Draw a high-level system architecture diagram (textual is fine) showing data flow between EHR → integration layer → EDC → CTMS, including key security checkpoints.
+1. List the FHIR resources to invoke and which SDTM tables each maps to.
+1. Recommend middleware patterns (e.g., publish-subscribe, ETL, event streaming) and why each fits.
+1. Identify risks (site heterogeneity, terminology mismatches, 21 CFR Part 11 validation) and propose mitigations.
+
+**Output format:**
+
+```
+## Architecture Overview
+(ASCII diagram)
+
+## Resource-to-SDTM Mapping
+|FHIR Resource|SDTM Domain|Notes|
+...
+
+## Middleware Recommendation
+- Pattern
+- Justification
+...
+
+## Risk & Mitigation Table
+```
+
+**If any assumption is unclear, ask follow-up questions before answering.**
+
+*Why it helps:* It leverages proven standards (FHIR ↔ CDISC mappings) and forces the model to surface both design and risk controls.

--- a/eclinical_integration_prompts/02_data_mapping_transformation_playbook.md
+++ b/eclinical_integration_prompts/02_data_mapping_transformation_playbook.md
@@ -1,0 +1,34 @@
+# Generate a Data-Mapping & Transformation Playbook
+
+**Role:** You are a Clinical ETL Lead who has delivered >20 trial integrations.
+
+**Context:** We must map incoming JSON FHIR bundles (US Core profile) to our SDTM IG 3.4-compliant EDC tables. The trial spans cardiology, oncology, and metabolic cohorts. Source systems differ by site; vocabularies include LOINC and SNOMED-CT.
+
+**Task:**
+
+1. Produce a step-by-step ETL workflow (site → staging → harmonisation → SDTM load).
+1. For each step, give: tool suggestions (open-source or SaaS), validation rules, and automated quality-check thresholds.
+1. Supply a sample mapping for ten common data elements (e.g., Blood Pressure, HbA1c, ECOG status).
+1. Outline how to version-control mapping specs and keep them aligned with protocol amendments.
+
+**Output format:**
+
+```
+### ETL Workflow Steps
+1. ...
+
+### Detailed Step Tables
+|Step|Tool/Tech|Validation|QC Threshold|
+...
+
+### Example Mapping Snippets
+{code blocks or tables}
+
+### Governance & Versioning
+- Git branching strategy
+- Change-control checklist
+```
+
+**Ask questions if source vocabularies, platforms, or validation depth are unclear.**
+
+*Why it helps:* Medidata and Real-Time eClinical both stress early data-mapping, open standards, and rigorous QC to avoid silos and re-work.

--- a/eclinical_integration_prompts/03_regulatory_validation_checklist.md
+++ b/eclinical_integration_prompts/03_regulatory_validation_checklist.md
@@ -1,0 +1,27 @@
+# Compile the Regulatory & Validation Checklist
+
+**Role:** You are a Regulatory Compliance Officer specializing in digital trials.
+
+**Context:** Our sponsor must demonstrate that all data integrations are **GxP-compliant**, validated under **21 CFR Part 11**, **ICH E6(R3)**, and **GDPR**. The integration covers EHR, eConsent, wearables, and lab data feeds.
+
+**Task:**
+
+1. Create a comprehensive checklist covering: computerized-system validation, audit trails, data-protection impact assessment, role-based access, encryption in transit/at rest, and incident response.
+1. Suggest evidence artifacts (SOPs, test scripts, vendor certificates) that satisfy each requirement.
+1. Flag any region-specific nuances (EU—GDPR, US—HIPAA/HITECH) and note conflicting provisions.
+
+**Output format:**
+
+```
+## Integration Validation & Compliance Checklist
+|Requirement|Reg. Source|Evidence Artifact|Responsible|Frequency|
+...
+## Region-Specific Considerations
+- EU
+- US
+...
+```
+
+**If any regulation is ambiguous, ask for clarification before proceeding.**
+
+*Why it helps:* Governance frameworks insist on traceable validation; pairing each requirement with an artifact makes audits smoother and aligns with FAIR & Part 11 ideals discussed in recent literature.

--- a/eclinical_integration_prompts/overview.md
+++ b/eclinical_integration_prompts/overview.md
@@ -1,0 +1,3 @@
+# eClinical Integration Prompts
+
+This folder contains prompts for integrating electronic clinical systems such as EHR, EDC, and CTMS. Use them to design architecture, map data, and address regulatory compliance.


### PR DESCRIPTION
## Summary
- add prompts for planning EHR/EDC integrations
- document data mapping & transformation tasks
- compile regulatory checklist
- include section in table of contents

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a4b69f898832c9d770c024b10398f