### PR TITLE
Add RTSM prompt suite

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,13 @@
 - [Quality Improvement Rca Action Plan](../regulatory_quality_prompts/03_quality_improvement_rca_action_plan.md)
 - [Overview](../regulatory_quality_prompts/overview.md)
 
+## Rtsm Prompts
+
+- [Patient-Centered Randomization Scheme](../rtsm_prompts/01_patient_centered_randomization_scheme.md)
+- [Site-Level Supply Resupply Strategy](../rtsm_prompts/02_site_level_supply_resupply_strategy.md)
+- [Risk-Based Monitoring SOP](../rtsm_prompts/03_risk_based_monitoring_sop.md)
+- [Overview](../rtsm_prompts/overview.md)
+
 ## Starter Pack
 
 - [Project Starter Pack](../starter_pack/01_project_starter_pack.md)

--- a/rtsm_prompts/01_patient_centered_randomization_scheme.md
+++ b/rtsm_prompts/01_patient_centered_randomization_scheme.md
@@ -1,0 +1,29 @@
+# Design a Patient-Centered Randomization Scheme
+
+You are an RTSM architect with 10 years' experience in global phase 3 studies.
+
+## Context
+
+• Trial phase: 3  
+• Sites: 42  
+• Arms: active 1 : placebo 1  
+• Stratification factors: region (3 levels), prior therapy (yes/no)  
+• Blinding: double-dummy  
+• Desired balance: 1:1 per stratum  
+• Regulatory regions: FDA, EMA, PMDA
+
+## Task
+
+1. Propose the optimal randomization method (e.g., permuted blocks, dynamic / minimization).
+1. Justify block sizes or algorithm parameters to minimize predictability yet keep logistical simplicity.
+1. Draft a concise Randomization Specification (≤ 600 words) ready for RTSM vendor build, covering:
+   • Algorithm description and parameters  
+   • Seed management and audit-trail requirements  
+   • Dummy-code structure and masking plan  
+   • Simulation results showing expected imbalance < 2 patients per arm within each stratum at N = 600.
+
+## Output
+
+- Start with a 4-bullet executive summary.  
+- Follow with the specification in a markdown table (sections as rows, < 80 chars per cell).  
+- Omit internal reasoning; present only the final deliverable.

--- a/rtsm_prompts/02_site_level_supply_resupply_strategy.md
+++ b/rtsm_prompts/02_site_level_supply_resupply_strategy.md
@@ -1,0 +1,28 @@
+# Forecast Site-Level Drug Supply & Resupply Strategy
+
+You are a senior clinical supply planner specializing in RTSM forecasting algorithms.
+
+## Context
+
+• Trial: 18-month, adaptive dose-escalation  
+• Sites: 28 across US/EU/APAC  
+• Average enrollment rate: 10 patients/site/month (Poisson λ = 10)  
+• Packaging: 2-visit kits (28-day supply)  
+• Lead times: 8 weeks (manufacture) + 2 weeks (shipping)  
+• Depot capacities: 3 (USA, Germany, Singapore)  
+• Shelf-life: 24 months, temperature-controlled (2-8 °C)  
+• Supply strategy preference: trigger-based resupply
+
+## Task
+
+1. Calculate initial shipment quantities per site to keep ≥ 95 % service level for first 6 weeks.
+1. Design an RTSM resupply algorithm (n-threshold/percentage or predictive) that balances stock-out risk ≤ 1 % vs. waste ≤ 10 %.
+1. Present a timeline identifying manufacturing start, depot release, and first three automatic resupply points.
+1. Provide a one-paragraph rationale that a study manager can paste into the Supply Plan appendix.
+
+## Output
+
+- A markdown table with rows = sites, columns = initial kits, reorder threshold, expected monthly consumption, safety stock.  
+- A Gantt-style text timeline (ASCII).  
+- Conclude with the rationale paragraph.  
+- Do NOT reveal chain-of-thought.

--- a/rtsm_prompts/03_risk_based_monitoring_sop.md
+++ b/rtsm_prompts/03_risk_based_monitoring_sop.md
@@ -1,0 +1,23 @@
+# Create a Risk-Based Monitoring & Mitigation SOP for RTSM
+
+You are a GxP compliance officer drafting SOPs for RTSM operations.
+
+## Context
+
+• Study portfolio: 5 concurrent trials, IMPs with 12-month expiry  
+• Integrated systems: RTSM ↔ EDC ↔ Temperature-monitoring IOT  
+• Common risks observed: kit expiry, temperature excursions, inventory discrepancies, mid-study design changes
+
+## Task
+
+1. List top 10 RTSM operational risks ranked by severity × likelihood.
+1. For the top 5, define detection signals (from RTSM/IoT/EDC), action limits, and escalation path.
+1. Draft step-by-step mitigation procedures, mapping each to ICH E6 R3 and 21 CFR §312 references.
+1. Include a one-page flowchart description suitable for QA training handouts.
+
+## Output
+
+- A two-column markdown table: Risk \| Detection & Escalation Path.
+- Numbered mitigation procedures (≤ 150 words each).  
+- Finish with a text description of the flowchart (so it can be diagrammed later).  
+- Provide only the final SOP content.

--- a/rtsm_prompts/overview.md
+++ b/rtsm_prompts/overview.md
@@ -1,0 +1,3 @@
+# RTSM Prompts
+
+Prompts focused on randomization, trial supply management, and risk monitoring for clinical studies.


### PR DESCRIPTION
## Summary
- create `rtsm_prompts` with overview
- add prompts for randomization scheme, supply resupply strategy and monitoring SOP
- link new prompts in `docs/index.md`

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a4bc5bb10832cb3f36c425a244366