### PR TITLE
Add imaging operations prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -200,3 +200,10 @@
 - [Tailored Feasibility-Questionnaire Builder](../site_acquisition_prompts/02_tailored_feasibility_questionnaire.md)
 - [Personalized Investigator-Outreach Email Generator](../site_acquisition_prompts/03_investigator_outreach_email_generator.md)
 - [Overview](../site_acquisition_prompts/overview.md)
+
+## Imaging Prompts
+
+- [Generate a Study-Specific Imaging Charter Draft](../imaging_prompts/01_imaging_charter_draft.md)
+- [Automated Site Upload QC & Query Generator](../imaging_prompts/02_site_upload_qc.md)
+- [Design an Optimal Central Reading Paradigm](../imaging_prompts/03_central_reading_design.md)
+- [Overview](../imaging_prompts/overview.md)

--- a/imaging_prompts/01_imaging_charter_draft.md
+++ b/imaging_prompts/01_imaging_charter_draft.md
@@ -1,0 +1,44 @@
+<!-- markdownlint-disable MD029 -->
+
+# Generate a Study-Specific Imaging Charter Draft
+
+## Role
+
+You are a senior Imaging Core Lab compliance specialist who has written 200+ FDA- and EMA-accepted Imaging Charters.
+
+## Context
+
+Trial synopsis ⟶ {{paste protocol synopsis}}
+Imaging modalities & sequences ⟶ {{list}}
+Primary/secondary imaging endpoints ⟶ {{list}}
+Participating regions/sites ⟶ {{list}}
+Key regulations to respect ⟶ 21 CFR Part 11, ICH E6(R2), ICH E17, GDPR/HIPAA
+
+## Task
+
+Draft a complete Imaging Charter (v0.1) that includes:
+
+1. Standardized acquisition parameters per modality & site
+1. Site QC workflow/checklists (pre-scan, real-time, post-upload)
+1. De-identification & secure transfer specs (DICOM tags to scrub, sFTP/S3 details)
+1. Central review paradigm (reader roles, blinding, adjudication rules)
+1. Data storage/archiving plan (format, retention, disaster recovery)
+1. Governance (version control, deviation handling, audit trail)
+1. Appendices: abbreviations, document history, reference standards
+
+## Process
+
+First reason step-by-step off-screen; then output the charter in **Markdown** with H2 section headings.
+
+## Output format
+
+```markdown
+## 1 Purpose …
+## 2 Roles & Responsibilities …
+…
+## Appendix C – Revision History
+```
+
+If any information is missing, ask up to three concise follow-up questions **before** drafting.
+
+<!-- markdownlint-enable MD029 -->

--- a/imaging_prompts/02_site_upload_qc.md
+++ b/imaging_prompts/02_site_upload_qc.md
@@ -1,0 +1,40 @@
+<!-- markdownlint-disable MD029 -->
+
+# Automated Site Upload QC & Query Generator
+
+## Role
+
+You are a Clinical-Trial Imaging Quality-Control analyst at a central lab.
+
+## Context
+
+You will receive a CSV called `daily_upload_log.csv` with columns:
+Site_ID, Subject_ID, Visit, Modality, SeriesUID, Upload_Timestamp, QC_Flag (pass/warn/fail), QC_Notes.
+
+## Task
+
+1. Parse the file and identify rows where QC_Flag ≠ "pass".
+1. For each unique Site_ID, summarise:
+   • count_warn, count_fail
+   • top three recurring issues (from QC_Notes)
+1. Draft a site query e-mail template that:
+   • lists affected subjects/visits
+   • describes each issue in plain language
+   • requests corrective action or re-upload deadline
+
+## Process
+
+Think step-by-step, then output:
+
+```json
+{
+  "summary_table": [ { "site": "", "warn": 0, "fail": 0, "common_issues": ["",…] }, … ],
+  "emails": { "<Site_ID>": "Dear …" }
+}
+```
+
+Conclude by flagging any systemic issues (≥25 % fail) that merit escalation.
+
+If the header schema differs, ask for the correct column names.
+
+<!-- markdownlint-enable MD029 -->

--- a/imaging_prompts/03_central_reading_design.md
+++ b/imaging_prompts/03_central_reading_design.md
@@ -1,0 +1,34 @@
+<!-- markdownlint-disable MD029 -->
+
+# Design an Optimal Central Reading Paradigm
+
+## Role
+
+You are a Blinded Independent Central Review (BICR) architect specializing in oncology trials.
+
+## Context
+
+Disease: {{e.g., NSCLC}}
+Imaging time-points: {{baseline + q8w}}
+Target endpoints: {{PFS per RECIST 1.1}}
+Reader pool size available: {{N}}
+Budget constraint: {{e.g., ≤$X/read}}
+
+## Task
+
+Recommend a central reading plan that balances reader variability, cost, and regulatory expectations:
+
+1. Reading model (dual 2 + adjudicator, 2 × consensus, or single) with rationale
+1. Reader training & calibration schedule (incl. dry-runs, kappa targets)
+1. Ongoing variability monitoring KPIs and re-training triggers
+1. Tie-breaker/adjudication rules and decision timelines
+
+1. Expected FTE & cost impact vs. alternatives
+
+## Process
+
+Think step-by-step, cite empirical variability data where helpful, then output in a two-column Markdown table: **Component \| Recommendation**.
+
+Ask clarifying questions if trial details are insufficient.
+
+<!-- markdownlint-enable MD029 -->

--- a/imaging_prompts/overview.md
+++ b/imaging_prompts/overview.md
@@ -1,0 +1,3 @@
+# Imaging Prompts
+
+This folder contains prompt templates for managing imaging operations in clinical trials, from charter creation to site QC and central reader workflow design.


### PR DESCRIPTION
## Summary
- add imaging prompts folder with three new prompt templates
- link imaging prompts from docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a4b2efbfc832c961f2224284c4d33