### PR TITLE
Add clinical payment workflow prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -135,6 +135,13 @@
 - [Kpi Dashboard Ops Review](../operations_prompts/03_kpi_dashboard_ops_review.md)
 - [Overview](../operations_prompts/overview.md)
 
+## Payment Prompts
+
+- [Build an Audit-Ready Site-Payment Schedule](../payment_prompts/01_audit_ready_site_payment_schedule.md)
+- [Sunshine Act + FMV Compliance Check](../payment_prompts/02_sunshine_act_fmv_compliance_check.md)
+- [Payment-Process Risk Assessment & Mitigation](../payment_prompts/03_payment_process_risk_assessment.md)
+- [Overview](../payment_prompts/overview.md)
+
 ## Project Management
 
 - [Project Charter Scope](../project_management/01_project_charter_scope.md)

--- a/payment_prompts/01_audit_ready_site_payment_schedule.md
+++ b/payment_prompts/01_audit_ready_site_payment_schedule.md
@@ -1,0 +1,30 @@
+# Build an Audit-Ready Site-Payment Schedule
+
+## Role & Goal
+
+You are a clinical-trial financial analyst specialising in site payments.
+Your goal is to generate an audit-ready, fully transparent payment schedule.
+
+## Context (provided as attachments)
+
+- Final protocol visit grid
+- Executed CTA/budget (showing per-procedure rates, screen-failure rules, pass-throughs, taxes)
+- Country FX table (spot rates)
+- Fair-Market-Value benchmark sheet
+
+## Instructions
+
+1. Parse the visit grid and CTA to list every billable milestone.
+1. Map each milestone to its trigger in EDC (e.g., SDV complete, query-free).
+1. Calculate gross, tax, and net amounts using the FX table; round to 2 decimals.
+1. Cross-check each line against FMV benchmarks; flag out-of-range variances > ±10 %.
+1. Produce an "Investigator Payment Schedule" table with: Milestone • Trigger • Rate (local & USD) • Tax • Net Payable • Expected Date.
+1. Append a summary that:
+   - states total budget vs. CTA cap,
+   - lists assumptions,
+   - cites any rows needing sponsor approval to exceed FMV.
+1. If any required data is missing, ask clarifying questions before proceeding.
+
+## Output
+
+Markdown table ➜ summary bullets ➜ outstanding questions.

--- a/payment_prompts/02_sunshine_act_fmv_compliance_check.md
+++ b/payment_prompts/02_sunshine_act_fmv_compliance_check.md
@@ -1,0 +1,26 @@
+# Sunshine Act + FMV Compliance Check
+
+## Role
+
+You are a compliance auditor preparing data for Open Payments (Sunshine Act) and internal FMV review.
+
+## Task
+
+Audit the attached site-payment ledger (CSV) for calendar-year 2025.
+
+## Steps
+
+1. Load the CSV into a dataframe; normalise currency to USD using provided FX.
+1. For each line item:
+   a. Check if single payment ≥ $13.46 **or** yearly aggregate for the same covered recipient > $134.54 (2025 threshold).
+   b. Verify required Sunshine-data fields (NPI, address, payment nature, related product).
+   c. Compare investigator-fee amounts to FMV benchmark (±10 %).
+1. Output two reports:
+   - **"Reportable Payments"** – all Sunshine-reportable rows, ready for CMS import.
+   - **"Compliance Exceptions"** – payments with missing data or FMV variance > 10 %, with recommended remediation note.
+1. Summarise key stats (# lines reviewed, % reportable, % exceptions).
+1. Ask follow-up questions if thresholds, FX, or FMV tables appear outdated.
+
+## Output
+
+Two CSV-formatted tables + 5-line executive summary.

--- a/payment_prompts/03_payment_process_risk_assessment.md
+++ b/payment_prompts/03_payment_process_risk_assessment.md
@@ -1,0 +1,29 @@
+# Payment-Process Risk Assessment & Mitigation
+
+## You are
+
+A process-improvement lead engaged to cut payment errors and opacity.
+
+## Inputs
+
+- Current swim-lane diagram (or narrative) of the site-payment workflow
+- KPI metrics: average payment cycle time, % on-time payments, 90-day-delay rate
+- Technology stack description (EDC, CTMS, payment platform, manual steps)
+
+## Deliverables
+
+1. List the top 5 accuracy/transparency risks in the present workflow.
+   - Root-cause each risk (e.g., manual invoice matching → data entry errors).
+1. For each risk, propose 1–2 mitigations drawing on industry best practice, such as:
+   - EDC-triggered automated disbursements
+   - Real-time payment dashboards for sites
+   - Up-front milestone advances to avoid cash-flow gaps
+   - Blockchain or virtual-card solutions for instantaneous audit trails
+1. Prioritise mitigations via a RICE or effort-vs-impact matrix.
+1. Outline a 90-day implementation roadmap with checkpoints and metrics.
+
+## Constraints
+
+- Use bullet lists and a 1-page roadmap Gantt (text format).
+- Cite any external benchmarks or stats used.
+- Ask clarifying questions if the workflow description lacks detail.

--- a/payment_prompts/overview.md
+++ b/payment_prompts/overview.md
@@ -1,0 +1,3 @@
+# Payment Prompts
+
+Prompts focused on clinical-trial payment workflows, compliance checks, and process improvements.


### PR DESCRIPTION
## Summary
- add `payment_prompts` folder with three new prompts
- link the new prompts in docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a4b50e7ec832c989704ac3a5517cc