### PR TITLE
Add medical device testing prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -188,6 +188,9 @@
 ## Testing Prompts
 
 - [E2e Test Discovery](../testing_prompts/01_e2e_test_discovery.md)
+- [Design Verification Test Plan](../testing_prompts/02_design_verification_test_plan.md)
+- [Human Factors & Validation Study Protocol](../testing_prompts/03_human_factors_validation_study_protocol.md)
+- [Risk-Based Test-Case Suite](../testing_prompts/04_risk_based_test_case_suite.md)
 - [Overview](../testing_prompts/overview.md)
 
 ## Documentation

--- a/testing_prompts/02_design_verification_test_plan.md
+++ b/testing_prompts/02_design_verification_test_plan.md
@@ -1,0 +1,28 @@
+# Design Verification Test Plan Prompt
+
+## Role & Goal
+
+You are a *Senior Regulatory Test Engineer* for Class II medical devices.
+
+## Task
+
+Create a complete *Design Verification Test Plan* for the "[DEVICE_NAME]".
+
+## Context & Constraints
+
+• Must comply with FDA 21 CFR §820, ISO 13485 and any device-specific standards (e.g., IEC 60601-1, ISO 10993).  
+• Use only peer-reviewed literature or official standards for justification.  
+• Do **not** include any PHI.  
+• Ask up to **5 clarifying questions** if requirements or design inputs are missing.
+
+## Required Output (Markdown)
+
+1. **Introduction** – brief device description & scope.
+1. **Traceability Matrix**
+
+    | Requirement_ID | Verification_Method | Sample_Size | Acceptance_Criteria | Standard_Ref |
+    |----------------|--------------------|-------------|---------------------|--------------|
+
+1. **Detailed Test Procedures** – numbered, step-by-step.
+1. **Rationale** – why each method is appropriate.
+1. **References** – formatted per ISO 13485 section 7.3.6.

--- a/testing_prompts/03_human_factors_validation_study_protocol.md
+++ b/testing_prompts/03_human_factors_validation_study_protocol.md
@@ -1,0 +1,27 @@
+# Human Factors & Validation Study Protocol Prompt
+
+## Role & Goal
+
+You are a *Human-Factors Specialist* preparing the Design Validation protocol for "[DEVICE_NAME]".
+
+## Task
+
+Draft a *User Validation / Human-Factors Study* in accordance with FDA Human Factors Guidance, ISO 62366-1, and ISO 13485.
+
+## Context & Constraints
+
+• Class (I/II/III): [CLASS] • Intended users & use environments provided below.  
+• Plan must demonstrate the device "meets user needs and intended use" (per §820.30(g)).  
+• Output length ≤ 2 000 words; Formal tone suitable for a regulatory submission.  
+• Ask any clarifying questions needed before proceeding.
+
+## Required Output (Structured Outline)
+
+1. Purpose & Regulatory Basis
+1. Study Objectives & Success Metrics
+1. Participant Profile (N, demographics, inclusion/exclusion)
+1. Test Environment & Scenarios (simulate worst-case where applicable)
+1. Task Analysis & Data-Collection Methods (quantitative + qualitative)
+1. Risk-Mitigation Triggers & Stop Rules
+1. Data Analysis Plan
+1. Deliverables & Acceptance Criteria

--- a/testing_prompts/04_risk_based_test_case_suite.md
+++ b/testing_prompts/04_risk_based_test_case_suite.md
@@ -1,0 +1,27 @@
+# Risk-Based Test-Case Suite & Traceability Prompt
+
+## Role & Goal
+
+You are a *Risk-Management Analyst* applying ISO 14971.
+
+## Task
+
+Using the Hazard Analysis table (attached or to be provided), generate a **Risk-Prioritized Test-Case Suite** that verifies all controls for High & Medium residual risks.
+
+## Context & Constraints
+
+• Device: "[DEVICE_NAME]" • Development stage: Pre-clinical.  
+• Follow ISO 14971 clauses 6–7 and reference IEC 62304 for software items if relevant.  
+• Provide rationales; cite standards, not web blogs.  
+• Ask up to 3 clarifying questions if data are missing.
+
+## Required Output
+
+1. **Risk-Control Traceability Matrix**
+
+    | Hazard_ID | Risk_Severity | Control_ID | Test_Case_ID | Verification_Method | Acceptance_Criteria |
+    |-----------|--------------|------------|--------------|--------------------|---------------------|
+
+1. **Detailed Test-Case Catalog** – for each Test_Case_ID: objective, setup, steps, expected result, sample size justification.
+
+1. Summary of any uncovered high-risk areas needing additional controls.


### PR DESCRIPTION
## Summary
- add a design verification test plan prompt
- add a human factors validation study prompt
- add a risk-based test-case suite prompt
- list the new prompts in the Testing Prompts section of the docs

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a4c32c508832ca54e5f31c7d44fa6