### PR TITLE
Add clinical TFL generation prompts

### DIFF
--- a/biostatistics_prompts/04_universal_template_table_prompt.md
+++ b/biostatistics_prompts/04_universal_template_table_prompt.md
@@ -1,0 +1,26 @@
+<!-- markdownlint-disable MD029 -->
+# Universal Template-Table Prompt
+
+*Purpose — create a fully formatted safety Table (e.g., TEAEs by SOC/PT) from an ADaM ADAE dataset in either R or SAS, at the user’s option.*
+
+```text
+**System (one-time):**  
+You are a *senior clinical-trial statistical programmer* expert in CDISC ADaM, R (tidyverse/gt) and SAS 9.4.  
+Always think step-by-step, then output **ONLY** a clean, runnable code block in the language requested.
+
+**User:**  
+Task ▸ Produce Table 14-1 “Treatment-Emergent Adverse Events by System Organ Class and Preferred Term”.  
+Data ▸ ADAE; key variables = TRT01A, AESOC, AEDECOD, SAFFL.  
+Rules ▸ • Include subjects with SAFFL='Y'.  
+    • Count n and % within TRT01A for each SOC/PT; overall row first.  
+    • Order rows by descending n in active arm.  
+Output ▸ – Language = **R** (if “R” else “SAS”)  
+    – Return a **gt**/PROC REPORT table ready for CSR (no extra prose).  
+    – Footnote: “Percent based on safety population (N displayed in header)”.  
+Confirm understanding in one sentence, then emit the code block only.
+
+Why it’s a “top” prompt
+
+* ✔ Uses a role directive and separates **Task / Data / Rules / Output**, matching the structured-prompt format shown to reduce prompt brittleness and improve reproducibility.
+* ✔ Language toggle enables reuse across R and SAS.
+* ✔ Explicit “code only” constraint prevents narrative spill-over.

--- a/biostatistics_prompts/05_dual_language_figure_prompt.md
+++ b/biostatistics_prompts/05_dual_language_figure_prompt.md
@@ -1,0 +1,27 @@
+<!-- markdownlint-disable MD029 -->
+# Dual-Language Figure Prompt
+
+*Purpose — generate a Kaplan-Meier Figure in both R and SAS from ADaM ADTTE, ready for shell insertion.*
+
+```text
+**System:**  
+You are a bilingual (R & SAS) biostat programmer.  
+When asked for “dual”, output two separate code blocks: first R (survfit/ggplot2), then SAS (PROC LIFETEST/SGPLOT).
+
+**User:**  
+Create Figure 15-2 “Time-to-Progression” Kaplan-Meier plot.  
+Inputs ▸ ADTTE with variables TRT01P, AVALL=:time, CNSR.  
+Specifications ▸ • Stratify by TRT01P; risk table required.  
+    • Censor marks = vertical ticks.  
+    • X-axis: 0-1825 days, major every 180 days.  
+    • Y-axis: Survival probability (0-1).  
+    • Add HR (95% CI) using Cox model in plot subtitle.  
+Output ▸ dual = TRUE.  Return two pristine code blocks, labeled ```R``` and ```SAS``` only.
+
+```
+
+Why it’s a “top” prompt
+
+* ✔ Demonstrates prompt chaining without losing determinism.
+* ✔ Mirrors real-world need to keep R & SAS graphics in sync for health-authority review.
+* ✔ Matches a successful KM-curve prompt pattern validated in recent studies.

--- a/biostatistics_prompts/06_qc_listing_cross_check_prompt.md
+++ b/biostatistics_prompts/06_qc_listing_cross_check_prompt.md
@@ -1,0 +1,25 @@
+<!-- markdownlint-disable MD029 -->
+# QC Listing & Cross-check Prompt
+
+*Purpose — automate a Listing plus QC cross-check between independent R and SAS runs.*
+
+```text
+**System:**  
+Act as Lead Programmer overseeing double-programming.
+
+**User:**  
+Goal ▸ Produce Listing 16-3 of concomitant medications (ADCM) for subjects with serious AEs.  
+Steps ▸ 1⃣ Use **R** to pull ADCM where USUBJID ∈ ADAE[SAEFL=='Y'] and list USUBJID, CMTRT, CMDECOD, CMSTDTC, CMENDTC.  
+    2⃣ Use **SAS** to replicate the same logic independently.  
+    3⃣ Perform a record-level compare (key = USUBJID+CMDECOD+CMSTDTC) and report “PASS” or “DIFF” summary.  
+Constraints ▸ Return three code blocks in the order: R-extract, SAS-extract, R-compare.  
+    If differences exist, print a diff table; else print “QC PASS – R and SAS identical”.  
+    No additional commentary.
+
+```
+
+Why it’s a “top” prompt
+
+* ✔ Embeds self-QC inside the prompt, reflecting industry guidance that LLM outputs must be programmatically verifiable.
+* ✔ Leverages negative prompting to suppress unwanted chatty text.
+* ✔ Transforms the workflow into a double-programming simulator.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,9 @@
 - [Statistical Analysis Plan Generator](../biostatistics_prompts/01_statistical_analysis_plan_generator.md)
 - [Time To Event Analysis Coach](../biostatistics_prompts/02_time_to_event_analysis_coach.md)
 - [Peer Review Methods Checklist](../biostatistics_prompts/03_peer_review_methods_checklist.md)
+- [Universal Template-Table Prompt](../biostatistics_prompts/04_universal_template_table_prompt.md)
+- [Dual-Language Figure Prompt](../biostatistics_prompts/05_dual_language_figure_prompt.md)
+- [QC Listing & Cross-check Prompt](../biostatistics_prompts/06_qc_listing_cross_check_prompt.md)
 - [Overview](../biostatistics_prompts/overview.md)
 
 ## Codebase Analysis


### PR DESCRIPTION
## Summary
- add universal table, dual-language figure, and QC listing prompts
- list new prompts in the biostatistics section of the docs

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a4c88a540832ca5fc0a48881ee34e