### PR TITLE
Add bioskills training prompts

### DIFF
--- a/bioskills_prompts/01_hands_on_procedure_coaching.md
+++ b/bioskills_prompts/01_hands_on_procedure_coaching.md
@@ -1,0 +1,16 @@
+# Hands-On Procedure Coaching
+
+## Instruction
+
+You are a senior interventional cardiologist guiding a trainee through a new vascular access technique on a training model.
+
+## Context
+
+Trainee is familiar with basic anatomy but new to ultrasound-guided puncture. Use bullet-point steps with rationale and highlight common mistakes.
+
+## Provide
+
+1. Step-by-step instructions (5–7 steps).
+1. Key anatomical landmarks to watch via ultrasound.
+1. Tips/troubleshooting.
+1. At least one safety checkpoint.

--- a/bioskills_prompts/02_simulated_clinical_scenario_feedback.md
+++ b/bioskills_prompts/02_simulated_clinical_scenario_feedback.md
@@ -1,0 +1,16 @@
+# Simulated Clinical Scenario Debrief
+
+## Instruction
+
+Simulate a training debrief after a bioskills session where a trainee performs an endoscopic device insertion on a cadaver model.
+
+## Context
+
+Trainee completed the procedure; now needs feedback.
+
+## Provide
+
+- A summary of performance (3 positives, 3 areas to improve).
+- Ask one follow-up reflective question.
+- Offer a corrective tip with rationale.
+- Use professional, supportive tone.

--- a/bioskills_prompts/03_objective_skills_assessment.md
+++ b/bioskills_prompts/03_objective_skills_assessment.md
@@ -1,0 +1,15 @@
+# Objective Skills Assessment
+
+## Instruction
+
+You are an expert clinical educator designing an objective checklist for trainee proficiency in a surgical stapler deployment lab.
+
+## Context
+
+Task: apply endoscopic stapler on tissue analog. Choose 6–8 measurable criteria.
+
+## Output format
+
+| Criterion | Description | Pass threshold |
+|-----------|-------------|----------------|
+|           |             |                |

--- a/bioskills_prompts/overview.md
+++ b/bioskills_prompts/overview.md
@@ -1,0 +1,3 @@
+# Bioskills Prompts
+
+Prompts for hands-on medical device training and skills assessment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -224,6 +224,13 @@
 - [Regulatory Submission Support](../biosafety_prompts/03_regulatory_submission_support.md)
 - [Overview](../biosafety_prompts/overview.md)
 
+## Bioskills Prompts
+
+- [Hands-On Procedure Coaching](../bioskills_prompts/01_hands_on_procedure_coaching.md)
+- [Simulated Clinical Scenario Debrief](../bioskills_prompts/02_simulated_clinical_scenario_feedback.md)
+- [Objective Skills Assessment](../bioskills_prompts/03_objective_skills_assessment.md)
+- [Overview](../bioskills_prompts/overview.md)
+
 ## Site Acquisition Prompts
 
 - [Site Landscape Mapping & Prioritization](../site_acquisition_prompts/01_site_landscape_mapping.md)


### PR DESCRIPTION
## Summary
- create *bioskills_prompts* directory for physician training prompts
- add hands-on procedure coaching prompt
- add simulated clinical scenario debrief prompt
- add objective skills assessment prompt
- document prompts in docs/index.md

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a527ea410832cb197b89be9ad3f0e