### PR TITLE
Add regulatory imaging workflow prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -250,6 +250,9 @@
 - [Generate a Study-Specific Imaging Charter Draft](../imaging_prompts/01_imaging_charter_draft.md)
 - [Automated Site Upload QC & Query Generator](../imaging_prompts/02_site_upload_qc.md)
 - [Design an Optimal Central Reading Paradigm](../imaging_prompts/03_central_reading_design.md)
+- [Regulatory-Compliant Imaging Charter Generator](../imaging_prompts/04_regulatory_imaging_charter_generator.md)
+- [End-to-End Image-Acquisition & QC Workflow Blueprint](../imaging_prompts/05_image_acquisition_qc_workflow_blueprint.md)
+- [Regulatory Imaging-Data Package & Narrative for PMA / 510(k)](../imaging_prompts/06_regulatory_imaging_data_package.md)
 - [Overview](../imaging_prompts/overview.md)
 
 ## ePRO Prompts

--- a/imaging_prompts/04_regulatory_imaging_charter_generator.md
+++ b/imaging_prompts/04_regulatory_imaging_charter_generator.md
@@ -1,0 +1,11 @@
+# Regulatory-Compliant Imaging Charter Generator
+
+## Prompt
+
+> **Role & voice** – *You are an FDA regulatory-affairs specialist and senior imaging-science lead at an ISO 13485-certified ICL.*
+> **Context** – A multicenter, pivotal clinical study (Class III vascular implant). Primary endpoint: device-patency at 12 months measured by duplex ultrasound and CTA. Sites span US, EU, APAC. Follow the FDA "Clinical-Trial Imaging Endpoint Process Standards" guidance (2015) and current ISO 14155.
+> **Task** – Draft a comprehensive **Imaging Charter** with the following sections (use H2 headings): trial overview; image-acquisition protocols (scanner settings, contrast, patient prep); QC plan; blinded-read design (reader qualification & calibration); data management & transfer; adjudication workflow; risk-mitigation matrix; version-control log.
+> **Output rules** –
+> • concise bullet lists inside each section;
+> • highlight mandatory regulatory citations in *italic*;
+> • end with a one-page executive summary.

--- a/imaging_prompts/05_image_acquisition_qc_workflow_blueprint.md
+++ b/imaging_prompts/05_image_acquisition_qc_workflow_blueprint.md
@@ -1,0 +1,11 @@
+# End-to-End Image-Acquisition & QC Workflow Blueprint
+
+## Prompt
+
+> **Role & voice** – *You are an imaging-operations director setting up an ICL management system (ICTMS).*
+> **Context** – Design a site-facing workflow for a 30-site orthopedic-device study requiring MRI (3 T) and low-dose CT. Incorporate ISO 13485 documentation controls and decentralized-trial elements (remote upload, eConsent).
+> **Task** – Produce a step-by-step **SOP-style flowchart** plus a linked **checklist** covering: site qualification, scanner certification, phantom scans, real-time QC flags, re-acquisition triggers, data-privacy safeguards, and KPI dashboards.
+> **Output rules** –
+> • present flowchart as indented text (≤ 12 steps);
+> • checklist in a markdown table with “Owner”, “Timing”, “Audit-Trail Field”;
+> • bold any automated ICTMS step.

--- a/imaging_prompts/06_regulatory_imaging_data_package.md
+++ b/imaging_prompts/06_regulatory_imaging_data_package.md
@@ -1,0 +1,19 @@
+<!-- markdownlint-disable MD029 -->
+<!-- markdownlint-disable MD002 -->
+
+# Regulatory Imaging-Data Package & Narrative for PMA / 510(k)
+
+## Prompt
+
+> **Role & voice** – *You are a medical-writer on the ICL submission team, expert in DICOM metadata and statistical imaging endpoints.*
+> **Context** – The sponsor needs the imaging section of its PMA dossier for an AI-guided cardiac mapping device. Data come from blinded independent readers (n = 3) with adjudication. Endpoints: sensitivity/specificity vs. gold-standard angiography.
+> **Task** – Assemble a **submission package** consisting of:
+>
+> - 1-page narrative overview (purpose, endpoints, datasets).
+> - Table summarizing image-quality metrics & reader agreement (κ, ICC).
+> - Description of imaging data-handling process (capture → lock).
+> - Appendix template for FDA questions.
+>    **Output rules** –
+>    • narrative ≤ 300 words;
+>    • statistical table in markdown;
+>    • cross-reference ISO 13485 certification statement.


### PR DESCRIPTION
## Summary
- add regulatory-compliant imaging charter generator prompt
- add imaging acquisition & QC workflow blueprint prompt
- add regulatory imaging-data package & narrative prompt
- link new prompts in documentation

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a51c2ed80832cb0bed000f8520b5c