### PR TITLE
Add non-GLP preclinical study prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -116,6 +116,13 @@
 - [Final Glp Study Report Outline](../glp_prompts/03_final_glp_study_report_outline.md)
 - [Overview](../glp_prompts/overview.md)
 
+## Non-Glp Prompts
+
+- [Design Study Objectives And Endpoints](../non_glp_prompts/01_design_study_objectives_and_endpoints.md)
+- [Protocol Outline And Risk Mitigation](../non_glp_prompts/02_protocol_outline_and_risk_mitigation.md)
+- [Poc Study Report Template](../non_glp_prompts/03_poc_study_report_template.md)
+- [Overview](../non_glp_prompts/overview.md)
+
 ## Leadership Prompts
 
 - [Strategic Alignment Innovation](../leadership_prompts/01_strategic_alignment_innovation.md)

--- a/non_glp_prompts/01_design_study_objectives_and_endpoints.md
+++ b/non_glp_prompts/01_design_study_objectives_and_endpoints.md
@@ -1,0 +1,19 @@
+# Design Study Objective & Endpoint
+
+You are a senior preclinical scientist.
+A biotech startup wants to run a non-GLP proof-of-concept in vivo study for [DEVICE_NAME] designed to [FUNCTION].
+Define:
+
+1. Primary and secondary objectives.
+1. Relevant biological or functional endpoints.
+1. Appropriate animal model (species, number, sex), with justification.
+1. Suggested study timeline and key milestones.
+
+Format:
+
+- Objectives:
+  • Primary: …
+  • Secondary: …
+- Endpoints: …
+- Model: …
+- Timeline: …

--- a/non_glp_prompts/02_protocol_outline_and_risk_mitigation.md
+++ b/non_glp_prompts/02_protocol_outline_and_risk_mitigation.md
@@ -1,0 +1,11 @@
+# Protocol Outline and Risk Mitigation
+
+As a preclinical study design expert, outline a protocol for a non-GLP proof-of-concept study of [DEVICE_NAME] for [INDICATION]. Include:
+
+• Study design (control vs treated groups).
+• Dosing or device application strategy.
+• Key measurements (imaging, biomarkers, functional tests).
+• Risk minimization (animal welfare, experimental bias).
+• Data analysis plan (statistical tests, acceptance criteria).
+
+Then provide a brief rationale for each section.

--- a/non_glp_prompts/03_poc_study_report_template.md
+++ b/non_glp_prompts/03_poc_study_report_template.md
@@ -1,0 +1,13 @@
+# Generate Report Template
+
+You are drafting a proof-of-concept study report for a non-GLP preclinical investigation of [DEVICE_NAME].
+Produce an outline with:
+
+1. Title and summary.
+1. Intro & device description.
+1. Methods (animals, procedures, endpoints).
+1. Results (tables/figures placeholder).
+1. Discussion (performance, limitations, next steps).
+1. Conclusion and recommendations.
+
+Then write a sample paragraph for the Methods section.

--- a/non_glp_prompts/overview.md
+++ b/non_glp_prompts/overview.md
@@ -1,0 +1,3 @@
+# Non-GLP Prompts
+
+Prompts for planning and reporting non-GLP proof-of-concept preclinical studies for medical devices.


### PR DESCRIPTION
## Summary
- add prompt collection for non-GLP preclinical proof-of-concept studies
- document prompts in table of contents

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a574117f4832c8cede6e73f362b52