### PR TITLE
Add CRO business ops prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,9 @@
 - [Rapid Process Diagnostic](../operations_prompts/01_rapid_process_diagnostic.md)
 - [Inventory Demand Planning Simulation](../operations_prompts/02_inventory_demand_planning_simulation.md)
 - [Kpi Dashboard Ops Review](../operations_prompts/03_kpi_dashboard_ops_review.md)
+- [CRO Trial-Performance KPI Dashboard Blueprint](../operations_prompts/04_cro_trial_performance_kpi_dashboard_blueprint.md)
+- [Multistudy Resource & Capacity Forecast Plan](../operations_prompts/05_multistudy_resource_capacity_forecast_plan.md)
+- [Fair-Market-Value Budget Negotiation Brief](../operations_prompts/06_fair_market_value_budget_negotiation_brief.md)
 - [Overview](../operations_prompts/overview.md)
 
 ## Payment Prompts

--- a/operations_prompts/04_cro_trial_performance_kpi_dashboard_blueprint.md
+++ b/operations_prompts/04_cro_trial_performance_kpi_dashboard_blueprint.md
@@ -1,0 +1,26 @@
+# CRO Trial-Performance KPI Dashboard Blueprint
+
+You are an expert clinical-trial operations analyst at a global CRO.
+
+## Context
+
+I need to build a Power BI/Excel dashboard that lets senior leadership see, at a glance, how our active studies are performing. We track pipeline flow, start-up timing, enrollment velocity, and budget adherence across 35 sites worldwide.
+
+## Task
+
+1. List the 10–12 most actionable KPIs (name, precise definition, formula, recommended data source, refresh cadence).
+1. Recommend the best visual for each KPI (e.g., gauge, line, stacked bar) and justify the choice in one sentence.
+1. Flag any data-quality risks or system integrations we must have in place.
+
+### Constraints
+
+- Prioritize metrics that CRO sponsors explicitly value (e.g., study start-up timing, opportunity close rate).
+- Keep explanations concise (≤40 words per bullet).
+
+### Output Format
+
+Markdown table with columns: `KPI | Formula | Visual | Data Source | Refresh Cadence | Notes`.
+
+## Why It Matters
+
+Pipeline health, start-up speed and sponsor-facing metrics are decisive for CRO site selection and revenue growth.

--- a/operations_prompts/05_multistudy_resource_capacity_forecast_plan.md
+++ b/operations_prompts/05_multistudy_resource_capacity_forecast_plan.md
@@ -1,0 +1,27 @@
+# Multistudy Resource & Capacity Forecast Plan
+
+Act as a senior CRO resource-planning consultant.
+
+## Context
+
+Over the next 9 months we expect 12 new Phase II/III trials. Each requires different FTE mixes (project management, data management, site monitoring) and technology costs.
+
+## Task
+
+1. Show a step-by-step approach (with formulas) for forecasting head-count and spend using historical utilization data.
+1. Provide a sample RACI matrix for cross-functional collaboration (Ops, Finance, HR, IT).
+1. Suggest three automation opportunities to streamline capacity planning.
+
+### Constraints
+
+Use best-practice workflow-optimization principles and emphasize data-driven decision-making.
+
+### Output Format
+
+- Section A: numbered methodology steps (max 7).
+- Section B: Markdown RACI table.
+- Section C: bullet list of automation ideas (≤25 words each).
+
+## Why It Matters
+
+Workflow optimization, resource allocation and cross-department collaboration are core duties for Business Operations Specialists.

--- a/operations_prompts/06_fair_market_value_budget_negotiation_brief.md
+++ b/operations_prompts/06_fair_market_value_budget_negotiation_brief.md
@@ -1,0 +1,27 @@
+# Fair-Market-Value Budget Negotiation Brief
+
+You are an experienced CRO contract-budget negotiator.
+
+## Context
+
+We’re entering FMV talks with a top-10 pharma sponsor across diverse global sites (urban U.S., EU, APAC). The sponsor wants a one-size-fits-all rate card; our sites need locality adjustments to stay sustainable.
+
+## Task
+
+1. Draft a two-page briefing that:
+   - summarizes common FMV pain points for sponsors vs. sites,
+   - proposes a tiered, region-sensitive compensation model, and
+   - outlines a transparent calculation template we can share.
+1. Include three evidence-based talking points on how flexible FMV improves study start-up speed and overall cost control.
+
+### Constraints
+
+Professional tone, bullet style, cite peer-reviewed or industry sources where possible.
+
+### Output Format
+
+Structured Markdown with H2 headings and nested bullets.
+
+## Why It Matters
+
+Balancing transparent FMV with cost-efficiency is a growing priority highlighted in industry analyses.


### PR DESCRIPTION
## Summary
- add CRO trial-performance KPI dashboard blueprint
- add multistudy resource & capacity forecast plan
- add FMV budget negotiation brief
- list these prompts in docs/index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5abfc970832caa29adf02f45eacf