### PR TITLE
Add clinical project management prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -174,6 +174,9 @@
 - [Detailed Project Blueprint & Timeline](../project_management/04_detailed_project_blueprint_timeline.md)
 - [Risk & Pre-Mortem Analysis](../project_management/05_risk_pre_mortem_analysis.md)
 - [Status Update & Task Prioritization](../project_management/06_status_update_task_prioritization.md)
+- [Clinical-Trial Timeline & Risk Radar](../project_management/07_clinical_trial_timeline_risk_radar.md)
+- [Sponsor-Ready Monthly Status Brief](../project_management/08_sponsor_ready_monthly_status_brief.md)
+- [TMF Gap-Analysis & Audit Readiness Check](../project_management/09_tmf_gap_analysis_audit_readiness_check.md)
 - [Overview](../project_management/overview.md)
 
 ## Regulatory Prompts

--- a/project_management/07_clinical_trial_timeline_risk_radar.md
+++ b/project_management/07_clinical_trial_timeline_risk_radar.md
@@ -1,0 +1,26 @@
+<!-- markdownlint-disable MD029 -->
+
+# Clinical-Trial Timeline & Risk Radar
+
+**"You are a senior Clinical Project Manager at a global CRO.
+Goal → Evaluate the current study timeline for schedule or budget threats and draft a ranked risk-mitigation plan.
+
+Context ###
+CSV_DATA:
+"""
+Task,Planned_Start,Planned_End,Actual_Start,Actual_End,Slack_Days
+Screening,2025-08-01,2025-10-15,2025-08-03,,
+Site_Activation,2025-07-15,2025-09-01,2025-07-20,2025-09-12,-11
+...
+"""
+
+## Instructions
+
+1. Compare *Planned* versus *Actual* dates; calculate schedule variance in days.
+1. Flag any task where variance > 7 days **or** negative Slack.
+1. Build a 5-row **Risk Register** with columns: `Risk`, `Probability (High/Med/Low)`, `Impact (High/Med/Low)`, `Mitigation Action`, `Owner`.
+1. End with a concise "Top-3 Next Actions" list.
+
+## Output format (Markdown table + bullet list only)
+
+Think step-by-step and reference tasks by name; then output."**

--- a/project_management/08_sponsor_ready_monthly_status_brief.md
+++ b/project_management/08_sponsor_ready_monthly_status_brief.md
@@ -1,0 +1,27 @@
+<!-- markdownlint-disable MD029 -->
+
+# Sponsor-Ready Monthly Status Brief
+
+**"You are a communications specialist ghost-writing for a CRO Project Manager.
+Goal → Draft a sponsor-facing Monthly Status Report that is clear, data-driven, and escalation-ready.
+
+Context ###
+NOTES:
+"""
+• Patients enrolled this month: 14 (plan = 18)
+• Budget burned: 42 % (plan = 40 %)
+• Protocol amendment v2.1 approved IRB 2025-07-10
+• Two sites delayed SIV due to pharmacy renovations
+...
+"""
+
+## Instructions
+
+1. Summarize overall study health in ≤ 75 words (Green/Amber/Red signal).
+1. Create sections: *Enrollment*, *Budget*, *Milestones*, *Risks & Mitigations*, *Requests/Decisions Needed*.
+1. For any metric off-plan >10 %, label it **BOLD RED** and suggest one corrective action.
+1. Keep tone professional and concise (max 450 words).
+
+## Output: Markdown with H2 section headers
+
+"**

--- a/project_management/09_tmf_gap_analysis_audit_readiness_check.md
+++ b/project_management/09_tmf_gap_analysis_audit_readiness_check.md
@@ -1,0 +1,27 @@
+<!-- markdownlint-disable MD029 -->
+
+# TMF Gap-Analysis & Audit Readiness Check
+
+**"You are a regulatory compliance auditor specializing in ICH-GCP.
+Goal → Identify missing or outdated documents in the Trial Master File (TMF) and produce an action list.
+
+Context ###
+TMF_INDEX (excerpt):
+"""
+Doc_ID,Section,Version,Date_Last_Updated
+INV-CV-001,Investigator CV,2.0,2024-12-01
+IRB-APPROVAL-MAIN,Ethics/IRB,1.0,2024-11-15
+SITE_INIT_REPORT-102,Site Mgmt,,
+2255-RAD-SAE-FORM-04,Safety,4.0,2025-06-30
+...
+"""
+
+## Instructions
+
+1. Compare the index against ICH-GCP essential-document list (Annex E); flag any document that is †Missing, †Out-of-date (> 12 months old), or †Version Blank.
+1. Return a table with columns: `Doc_ID`, `Gap_Type`, `Corrective Action`.
+1. Provide a numbered plan to close the gaps within 10 business days.
+
+## Output: Markdown table + numbered action plan
+
+"**


### PR DESCRIPTION
## Summary
- add clinical trial timeline and risk radar prompt
- add sponsor-ready monthly status brief prompt
- add TMF gap analysis & audit readiness prompt
- update docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5add9fe4832c846dd4caaebcf340