### PR TITLE
Add clinical operations VP prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -280,6 +280,9 @@
 - [AI-Powered Site & Recruitment Strategy](../trial_execution_prompts/02_ai_powered_site_recruitment.md)
 - [Compliance, Data Quality & Monitoring Plan](../trial_execution_prompts/03_compliance_data_quality_monitoring_plan.md)
 - [Adaptive Recruitment & Retention Strategy](../trial_execution_prompts/04_adaptive_recruitment_retention_strategy.md)
+- [Portfolio-Level Clinical Operations Roadmap](../trial_execution_prompts/05_portfolio_clin_ops_roadmap.md)
+- [Risk-Based Monitoring & Quality Plan](../trial_execution_prompts/06_risk_based_monitoring_plan.md)
+- [Patient Recruitment & Diversity Acceleration Plan](../trial_execution_prompts/07_recruitment_diversity_acceleration.md)
 - [Overview](../trial_execution_prompts/overview.md)
 
 ## Adjudication Prompts

--- a/trial_execution_prompts/05_portfolio_clin_ops_roadmap.md
+++ b/trial_execution_prompts/05_portfolio_clin_ops_roadmap.md
@@ -1,0 +1,15 @@
+<!-- markdownlint-disable MD029 -->
+# Portfolio-Level Clinical Operations Roadmap
+
+You are an expert clinical-operations strategist.  
+Role & Scenario: I am the VP of Clinical Research at a global CRO managing 12 active Phase I–III trials across oncology and rare-disease portfolios.  
+Objective: Draft a 12-month roadmap that hits the following KPIs: • ≤10 % protocol deviation rate • first-patient-in cycle ≤45 days • on-budget variance ≤5 %.  
+Include:
+
+1. Quarterly milestones (timeline view).
+1. Resourcing plan (FTEs & key vendors) with cost estimates.
+1. Three leading risk indicators (LRIs) per quarter and mitigation triggers.
+1. “Quick-win” actions achievable in ≤30 days that can show early progress.  
+
+Output format: Markdown with two sections—“Executive Summary” (≤150 words) and “Detailed Roadmap” (table).  
+Ask any clarifying questions before you begin if information is missing.

--- a/trial_execution_prompts/06_risk_based_monitoring_plan.md
+++ b/trial_execution_prompts/06_risk_based_monitoring_plan.md
@@ -1,0 +1,14 @@
+<!-- markdownlint-disable MD029 -->
+# Risk-Based Monitoring & Quality Plan
+
+Act as a senior GCP compliance advisor.  
+Context: We are about to start a 340-patient, multi-region Phase II oncology trial using both on-site and decentralized elements.  
+Task: Create a Risk-Based Monitoring (RBM) plan that:
+
+• Identifies the top 10 critical-to-quality (CTQ) factors.
+• Assigns risk scores and detection/mitigation tactics (e.g., central-statistical monitoring, triggered visits).
+• Maps each CTQ to ICH-E6(R3) and FDA draft guidance expectations.
+• Includes an escalation workflow and communication matrix.
+• Recommends digital tools/metrics to track risk in real time.  
+
+Output: Provide an executive slide outline (bulleted) plus an editable risk register (Markdown table). Request additional inputs if needed.

--- a/trial_execution_prompts/07_recruitment_diversity_acceleration.md
+++ b/trial_execution_prompts/07_recruitment_diversity_acceleration.md
@@ -1,0 +1,15 @@
+<!-- markdownlint-disable MD029 -->
+# Patient Recruitment & Diversity Acceleration Plan
+
+Assume the role of a patient-engagement strategist.  
+Situation: Enrollment has stalled at 45 % of target in a Phase III rare-disease study (22 countries, 70 sites). The sponsor is pressing for recovery.  
+Goal: Produce a 6-month action plan that boosts monthly randomizations by ≥35 % while improving demographic diversity to match FDA 2024 guidance.  
+Deliverables:
+
+1. Data-driven root-cause analysis framework (site, startup, outreach, eligibility).
+1. Country-by-country recruitment tactics (e.g., community advocacy partnerships, telehealth pre-screening).
+1. Budget impact estimate (±15 %) and ROI projection.
+1. Metrics dashboard layout (leading & lagging indicators).  
+
+Constraints: Maintain current protocol and budget cap increase ≤8 %.  
+Output: Concise report (≤1,000 words) + a one-slide KPI dashboard sketch in text form. Ask clarifying questions first if required.


### PR DESCRIPTION
## Summary
- add portfolio-level clinical operations roadmap prompt
- add risk-based monitoring & quality plan prompt
- add patient recruitment & diversity acceleration plan prompt
- link new prompts in docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5c88d998832c9c504061de5fc29b