### PR TITLE
Add CRO payment prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -164,6 +164,9 @@
 - [Build an Audit-Ready Site-Payment Schedule](../payment_prompts/01_audit_ready_site_payment_schedule.md)
 - [Sunshine Act + FMV Compliance Check](../payment_prompts/02_sunshine_act_fmv_compliance_check.md)
 - [Payment-Process Risk Assessment & Mitigation](../payment_prompts/03_payment_process_risk_assessment.md)
+- [Investigator-Site Payment Forecast](../payment_prompts/04_investigator_site_payment_forecast.md)
+- [Payment Reconciliation and Discrepancy Report](../payment_prompts/05_payment_reconciliation_discrepancy_report.md)
+- [Global Regulatory & Tax Matrix](../payment_prompts/06_global_regulatory_tax_matrix.md)
 - [Overview](../payment_prompts/overview.md)
 
 ## Project Management

--- a/payment_prompts/04_investigator_site_payment_forecast.md
+++ b/payment_prompts/04_investigator_site_payment_forecast.md
@@ -1,0 +1,29 @@
+# Investigator-Site Payment Forecast
+
+## Role & Objective
+
+You are a senior clinical payments analyst at a global CRO. Your objective is to build a month-by-month cash-flow forecast for investigator-site payments on the upcoming Phase III oncology study "Onco-1234."
+
+## Context
+
+- The CTA defines four milestone buckets: Start-up, Per-Visit, Close-out, and Screen-Failure fees.
+- First-patient-first-visit (FPFV) occurs on 15 Sep 2025.
+- Planned study duration is 30 months.
+
+## Inputs
+
+1. Site_ID, Country, Contract_Currency, Enrollment_Target, Contract_Milestone_Amounts.
+1. Enrollment curve (% of target expected per month).
+1. FX rates sheet `FX_2025Q3`.
+
+## Instructions
+
+1. Convert milestone amounts to USD using the supplied FX rates.
+1. Build a table showing monthly and cumulative totals per site and overall.
+1. Highlight any month with >20 % variance versus the previous forecast in red.
+1. Write a short narrative summarizing key drivers such as seasonality or enrollment ramp-up.
+1. Ask clarifying questions before starting if any assumptions are unclear.
+
+## Output
+
+Markdown table followed by a narrative summary.

--- a/payment_prompts/05_payment_reconciliation_discrepancy_report.md
+++ b/payment_prompts/05_payment_reconciliation_discrepancy_report.md
@@ -1,0 +1,28 @@
+# Payment Reconciliation and Discrepancy Report
+
+## You are
+
+A compliance auditor specializing in investigator payments.
+
+## Goal
+
+Identify and categorize all payment discrepancies for Study "Cardio-5678" before close-out.
+
+## Data Provided
+
+- `Payment_Ledger.xlsx` – actual payments made (date, site, currency, amount, invoice #).
+- `CTA_Budget.xlsx` – contract-agreed milestone amounts and payment terms.
+- `Site_Queries.csv` – open payment-related queries logged in the CTMS.
+
+## Instructions
+
+1. Cross-check each payment against the negotiated milestone amounts and payment terms (e.g., NET30 after data entry).
+1. Classify discrepancies as **Over-payment, Under-payment, Late Payment, Missing Invoice, Currency Mis-match**.
+1. For each discrepancy, recommend a corrective action (e.g., claw-back, manual top-up, FX true-up).
+1. Summarize the overall financial exposure in USD and risk level (Low/Med/High).
+1. Confirm any data-quality questions before starting.
+
+## Deliverable
+
+- A markdown table with columns: `Site_ID | Issue_Type | Amount_USD | Root_Cause | Recommended_Action`.
+- A bullet list of systemic issues and preventative next steps.

--- a/payment_prompts/06_global_regulatory_tax_matrix.md
+++ b/payment_prompts/06_global_regulatory_tax_matrix.md
@@ -1,0 +1,26 @@
+# Global Regulatory and Tax Requirements for Site Payments
+
+## Role
+
+You are a senior regulatory payments expert.
+
+## Task
+
+Produce an at-a-glance matrix of key compliance requirements for investigator-site payments in the U.S., EU (CTR 536/2014), U.K., Japan, and Australia.
+
+## Focus Areas
+
+- Payment timing rules (e.g., 45-day limits)
+- Reporting obligations (Sunshine Act/Open Payments, EU transparency, JPMA guidelines)
+- Tax withholding and documentation (W-8BEN-E, VAT, GST)
+- Currency-control or foreign-exchange restrictions
+- Record-retention and audit expectations
+
+## Output
+
+| Region | Timing Rule | Mandatory Reports | Tax Docs | FX/Banking Notes | Record Retention | Recent Updates (≤ 12 mo) |
+|--------|-------------|-------------------|----------|------------------|------------------|--------------------------|
+
+Follow the table with commentary (≤ 150 words) on emerging trends like increasing scrutiny of cross-border payments.
+
+Ask clarifying questions if any requirement is ambiguous.


### PR DESCRIPTION
## Summary
- add investigator-site payment forecast prompt
- add discrepancy reconciliation prompt
- add regulatory and tax requirements matrix prompt
- list new prompts in docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5c6e5820832c824b8710210c3d2a