### PR TITLE
Add CRO Study Director prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -319,3 +319,10 @@
 - [Device–Tissue Interface Evaluation](../pathology_prompts/02_device_tissue_interface_evaluation.md)
 - [Slides & Reporting Workflow](../pathology_prompts/03_slides_and_reporting_workflow.md)
 - [Overview](../pathology_prompts/overview.md)
+
+## Study Director Prompts
+
+- [Draft a GLP-Compliant Study Protocol](../study_director_prompts/01_draft_glp_compliant_study_protocol.md)
+- [Audit Raw Data and Draft a CAPA Summary](../study_director_prompts/02_audit_raw_data_capa_summary.md)
+- [Generate an Executive Summary for the Final Report](../study_director_prompts/03_executive_summary_final_report.md)
+- [Overview](../study_director_prompts/overview.md)

--- a/study_director_prompts/01_draft_glp_compliant_study_protocol.md
+++ b/study_director_prompts/01_draft_glp_compliant_study_protocol.md
@@ -1,0 +1,13 @@
+# Draft a GLP-Compliant Study Protocol
+
+You are a senior toxicologist experienced in OECD and FDA GLP regulations.
+Context: We are planning a 28-day oral toxicity study (OECD TG 407) in Sprague-Dawley rats for Test Article X to support an IND.
+Task: Produce a detailed, regulator-ready study plan that includes:
+  • Objectives and scientific rationale
+  • Dose groups (rationale and mg kg⁻¹ day⁻¹ levels)
+  • Experimental design (n/group, randomization, critical endpoints, interim kills)
+  • Key timeline (Gantt-style list of milestones)
+  • Quality-assurance checkpoints and record-keeping requirements
+  • Potential protocol pitfalls and mitigation strategies (≤5 bullet points)
+Format: Numbered outline followed by a CSV-ready risk-mitigation table (columns: Phase, Risk, Impact, Mitigation).
+Reason step-by-step before writing; do not reveal your chain-of-thought.

--- a/study_director_prompts/02_audit_raw_data_capa_summary.md
+++ b/study_director_prompts/02_audit_raw_data_capa_summary.md
@@ -1,0 +1,15 @@
+# Audit Raw Data and Draft a CAPA Summary
+
+Assume the role of a GLP Quality-Assurance auditor.
+Input: raw body-weight and clinical-signs data from Day 15 of dermal toxicity Study ABC (see attached CSV).
+Task:
+
+1. Identify protocol deviations, data gaps, or statistical outliers that could affect study integrity.
+1. For each issue, rate the potential impact (Low/Med/High) and propose a corrective-action/preventive-action (CAPA).
+1. Draft a ≤300-word CAPA memo addressed to the Study Director.
+
+Constraints:
+  • Ignore trivial rounding differences.
+  • Use a markdown table (Issue ID | Impact | CAPA) followed by the memo.
+  • Cite the line numbers or record IDs you inspected so the Study Director can cross-verify.
+Think silently first; output only the table and memo.

--- a/study_director_prompts/03_executive_summary_final_report.md
+++ b/study_director_prompts/03_executive_summary_final_report.md
@@ -1,0 +1,14 @@
+# Generate an Executive Summary for the Final Report
+
+You are a regulatory medical writer specializing in CTD submissions.
+Input: draft non-clinical study report sections (Modules 4.2.3 & 4.2.5) plus statistical tables for Study DEF.
+Task: Create a two-page Executive Summary that:
+  • Succinctly describes study design, methodology, and key findings.
+  • States the NOAEL and its justification with reference to dose-response data.
+  • Highlights any deviations and their resolved impact on data integrity.
+  • Provides a bullet list of points supporting the proposed first-in-human (FIH) dose, linking to ICH M3(R2) expectations.
+Constraints & style:
+  • ≤800 words; clear, formal language suitable for FDA reviewers.
+  • Follow CTD heading hierarchy (e.g., 4.2.3.1 Objectives…).
+  • End with a 4-item checklist the Study Director must sign.
+Plan the document internally; reveal only the finished summary.

--- a/study_director_prompts/overview.md
+++ b/study_director_prompts/overview.md
@@ -1,0 +1,3 @@
+# Study Director Prompts
+
+Prompts for Study Directors at contract research organizations to craft protocols, audit data, and summarize findings.


### PR DESCRIPTION
## Summary
- add prompts for study director tasks
- create overview and doc index entries

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5c2ede30832cbec7aee97cd6fc3a