### PR TITLE
Add CFO finance prompts

### DIFF
--- a/cfo_prompts/01_scenario_cash_flow_forecast.md
+++ b/cfo_prompts/01_scenario_cash_flow_forecast.md
@@ -1,0 +1,23 @@
+# Scenario-Based Clinical-Trial Cash-Flow Forecast
+
+## Context
+
+You are my senior FP&A analyst inside a mid-size global CRO. Rising Phase II/III costs and client delays are compressing margins. I need a 12-quarter cash-flow forecast under three scenarios (Base, +15% cost inflation, –20% patient-recruitment pace).
+
+## Task
+
+1. Import and parse the attached Excel pipeline (`{Paste latest trial pipeline xlsx}`).
+1. For each active study, model revenue recognition vs. direct/indirect cost curves (use the phase-specific U.S. cost bands in the data table below).
+1. Generate consolidated cash-flow statements for each scenario.
+1. Highlight quarters where free cash flow < 0 and flag required working-capital headroom.
+
+## Data Inputs
+
+• Cost bands: Phase I = $1.4–6.6 M, Phase II = $7.0–19.6 M, Phase III = $11.5–52.9 M
+• WACC = 9.5%, Tax rate = 23%
+
+## Response Rules
+
+• Present each scenario in a separate markdown table.
+• Summarize key risks in ≤ 5 bullet points.
+• End with a 50-word executive takeaway for the board.

--- a/cfo_prompts/02_competitive_bid_pricing.md
+++ b/cfo_prompts/02_competitive_bid_pricing.md
@@ -1,0 +1,21 @@
+# Competitive-Bid Pricing & Margin Optimizer
+
+## Context
+
+Act as my strategic pricing manager. We are bidding on a multi-year oncology study against two top-10 CROs.
+
+## Task
+
+1. Using the cost drivers below, craft three pricing options (Time & Materials, Fixed Fee with Change-Order triggers, and Risk-Share Milestones).
+1. For each option, calculate gross margin, probability-weighted downside, and upside.
+1. Recommend the option that keeps EBITDA ≥ 18% while remaining price-competitive (assume competitors’ quotes are 5% below industry median).
+
+## Data Inputs
+
+• Direct costs, indirect overhead % and historic change-order frequency here → `{Insert CSV}`
+• Regulatory/monitoring premiums = +12% (oncology)
+
+## Response Rules
+
+• Output a comparison table plus a 200-word rationale.
+• Use CFO-friendly language—no jargon.

--- a/cfo_prompts/03_regulatory_risk_dashboard.md
+++ b/cfo_prompts/03_regulatory_risk_dashboard.md
@@ -1,0 +1,22 @@
+# Regulatory-Risk & ESG Impact Dashboard Builder
+
+## Context
+
+You are my compliance-analytics officer. New EU CTR requirements and U.S. FDA diversity-reporting rules may raise study costs and ESG disclosure obligations.
+
+## Task
+
+1. Create a dashboard outline that tracks (a) upcoming regulatory milestones, (b) estimated cost impact per study, and (c) ESG scorecard metrics.
+1. Recommend the minimum data stack (systems & fields) needed for automated monthly updates.
+1. Suggest three early-warning KPIs a CFO should monitor to avoid margin erosion.
+
+## Reference Regulations
+
+• EU CTR Article 83 timelines
+• U.S. FDA Diversity Action Plan (final rule Jan 2025)
+
+## Response Rules
+
+• Deliver the dashboard spec in a three-level nested bullet list.
+• Keep each bullet ≤ 20 words.
+• End with a one-sentence call-to-action.

--- a/cfo_prompts/overview.md
+++ b/cfo_prompts/overview.md
@@ -1,0 +1,3 @@
+# CFO Prompts
+
+Prompts focused on financial forecasting, pricing strategy, and compliance dashboards for clinical research organizations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,13 @@
 - [Adaptive Design & Interim Monitoring](../biostatistics_prompts/09_adaptive_design_interim_monitoring.md)
 - [Overview](../biostatistics_prompts/overview.md)
 
+## CFO Prompts
+
+- [Scenario-Based Clinical-Trial Cash-Flow Forecast](../cfo_prompts/01_scenario_cash_flow_forecast.md)
+- [Competitive-Bid Pricing & Margin Optimizer](../cfo_prompts/02_competitive_bid_pricing.md)
+- [Regulatory-Risk & ESG Impact Dashboard Builder](../cfo_prompts/03_regulatory_risk_dashboard.md)
+- [Overview](../cfo_prompts/overview.md)
+
 ## Codebase Analysis
 
 - [DRY Codebase Analysis](../codebase_analysis/DRY_Codebase_Analysis.md)


### PR DESCRIPTION
## Summary
- add CFO prompts for financial forecasting, pricing, and regulatory dashboards
- include new CFO section in prompt index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5c5100c0832cbbe9a36c9d17aad2