### PR TITLE
Add business development prompts

### DIFF
--- a/business_development_prompts/01_market_intelligence_radar.md
+++ b/business_development_prompts/01_market_intelligence_radar.md
@@ -1,0 +1,28 @@
+# Market-Intelligence Radar
+
+You are an experienced CRO Business-Development Strategist.
+
+## Goal
+
+Prioritize 10 high-potential biotech or pharma companies for partnership that could benefit from our pre-clinical and Phase I–II capabilities.
+
+## Your inputs
+
+• Preferred therapeutic areas: oncology, rare disease
+• Geography focus: North America & EU
+• Company size: Series B or later, ≥ $50 M total funding
+• Data sources to reference: public funding databases, 2025 conference attendee lists, recent press releases
+
+## Task
+
+1. Create a scored short-list (0–100) using the factors below (weight in parentheses): market attractiveness (30), strategic fit (30), funding strength (20), partnership likelihood (20).
+1. Present the results in a markdown table sorted by total score, then briefly summarise the top 3 rationale in ≤ 150 words.
+1. Suggest one next-step outreach idea for each of the top 3.
+
+## Output format
+
+```
+| Rank | Company | Score | Key Strengths | Suggested First Touch |
+| ---- | ------- | ----- | ------------- | --------------------- |
+| ...  |         |       |               |                       |
+```

--- a/business_development_prompts/02_rapid_proposal_builder.md
+++ b/business_development_prompts/02_rapid_proposal_builder.md
@@ -1,0 +1,18 @@
+# Rapid Proposal Builder
+
+Act as a senior proposal manager at a mid-size CRO.
+
+**Context**
+We have an upcoming pitch to [CLIENT NAME], a biotech developing a first-in-class bispecific antibody (IND planned Q4 2026). They requested a capabilities & budget outline for GLP toxicology plus Phase I clinical services.
+
+## Task
+
+Draft a concise proposal (max 2,000 words) that includes:  
+A. Executive summary (≤ 120 words, persuasive tone)  
+B. CRO differentiators (bullet list, each ≤ 20 words)  
+C. Proposed study design (sub-headers: Study Objectives, Key Assays, Timeline Gantt in text form)  
+D. High-level budget table (currency USD, three cost buckets: Pre-clinical, Clinical, Project Management)  
+E. Two optional accelerators we can upsell (e.g., biomarker assay panel, eSource set-up)  
+F. Clear call-to-action paragraph
+
+Wrap the whole document in Markdown for easy copy-paste into our template.

--- a/business_development_prompts/03_competitor_positioning_brief.md
+++ b/business_development_prompts/03_competitor_positioning_brief.md
@@ -1,0 +1,19 @@
+# Competitor-Positioning Brief
+
+Role: Competitive-intelligence analyst for our CRO leadership team.
+
+## Objective
+
+Compare our service portfolio with three main competitors (ICON plc, Labcorp Drug Development, and Charles River Labs) to highlight differentiators for an upcoming board review.
+
+## Instructions
+
+1. Build a comparison matrix covering: Pre-clinical breadth, Geographic lab footprint, Specialty assays, Digital trial-enablement tools, 2024 revenue.  
+1. Use latest public filings, 2025 press releases, and analyst reports; cite each data point inline [(source abbreviated)].  
+1. After the matrix, craft a SWOT-style narrative (≤ 300 words) focused on where we should invest in the next 12 months.  
+1. Finish with three concise messaging bullets we can embed in sales decks.
+
+**Output**
+Markdown with two sections:  
+*Table 1. CRO Competitive Landscape*  
+*Section 2. Analysis & Messaging*

--- a/business_development_prompts/overview.md
+++ b/business_development_prompts/overview.md
@@ -1,0 +1,3 @@
+# Business Development Prompts
+
+Prompts for CRO business development strategists covering market intelligence, proposal creation, and competitor positioning.

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,13 @@
 - [Regulatory Commercial Barrier Mapping](../market_research_prompts/03_regulatory_commercial_barrier_mapping.md)
 - [Overview](../market_research_prompts/overview.md)
 
+## Business Development Prompts
+
+- [Market-Intelligence Radar](../business_development_prompts/01_market_intelligence_radar.md)
+- [Rapid Proposal Builder](../business_development_prompts/02_rapid_proposal_builder.md)
+- [Competitor-Positioning Brief](../business_development_prompts/03_competitor_positioning_brief.md)
+- [Overview](../business_development_prompts/overview.md)
+
 ## Meta Prompts
 
 - [L0 Master-ultrameta](../meta_prompts/L0_master-ultrameta.md)


### PR DESCRIPTION
## Summary
- add Business Development prompts for CRO market intelligence, proposal development, and competitor positioning
- include overview and update docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5c1de7f4832c8f826a44e847f530