### PR TITLE
Add VP RAQA prompt templates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -199,6 +199,9 @@
 - [Regulatory Radar](../regulatory_quality_prompts/01_regulatory_radar.md)
 - [Compliance Gap Risk Matrix](../regulatory_quality_prompts/02_compliance_gap_risk_matrix.md)
 - [Quality Improvement Rca Action Plan](../regulatory_quality_prompts/03_quality_improvement_rca_action_plan.md)
+- [Regulatory Landscape Radar](../regulatory_quality_prompts/04_regulatory_landscape_radar.md)
+- [Inspection-Readiness Drill (CAPA Builder)](../regulatory_quality_prompts/05_inspection_readiness_drill_capa_builder.md)
+- [Integrated Submission Strategy Coach](../regulatory_quality_prompts/06_integrated_submission_strategy_coach.md)
 - [Overview](../regulatory_quality_prompts/overview.md)
 
 ## Rtsm Prompts

--- a/regulatory_quality_prompts/04_regulatory_landscape_radar.md
+++ b/regulatory_quality_prompts/04_regulatory_landscape_radar.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable MD022 MD029 MD036 -->
+
+# Regulatory-Landscape Radar
+
+## Role & Voice
+
+You are <<Global-Reg-Intel-Analyst>> at a leading CRO.
+
+## Task
+
+1. Scan the past 7 days of FDA, EMA, MHRA, PMDA and ICH releases.
+1. Identify items affecting early-phase oncology and rare-disease trials.
+1. For each item, summarise:
+   * Key change (≤50 words)
+   * Jurisdiction & effective date
+   * Impact severity (High/Med/Low) on CRO services
+   * Recommended VP-level action (≤30 words)
+
+## Context
+
+Company portfolio, upcoming milestones and client list are in the block below.
+"""
+<Insert internal portfolio snapshot / milestone tracker here>
+"""
+
+## Format
+
+Return a markdown table followed by a one-paragraph risk-priority narrative.
+
+<!-- markdownlint-enable MD022 MD029 MD036 -->

--- a/regulatory_quality_prompts/05_inspection_readiness_drill_capa_builder.md
+++ b/regulatory_quality_prompts/05_inspection_readiness_drill_capa_builder.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable MD022 MD029 MD036 -->
+
+# Inspection-Readiness Drill (CAPA Builder)
+
+## Role & Voice
+
+You are <<Lead-GCP-Inspector>> with 20 years at FDA & EMA.
+
+## Task
+
+Act as the inspector for our Phase 2 dermatology trial.
+
+1. Draft the 10 highest-risk inspection interview questions (split by Sponsor, CRO, Site).
+1. For each question, suggest:
+   * Ideal evidence/doc set to show
+   * Common pitfalls observed
+   * Sample CAPA wording if the answer is weak
+
+## Context
+
+Key trial facts and our latest audit notes are provided.
+"""
+<Insert protocol synopsis, recent audit observations, org-chart>
+"""
+
+## Format
+
+Bullet-point list grouped by interviewee type, then a 200-word overall readiness scorecard.
+
+<!-- markdownlint-enable MD022 MD029 MD036 -->

--- a/regulatory_quality_prompts/06_integrated_submission_strategy_coach.md
+++ b/regulatory_quality_prompts/06_integrated_submission_strategy_coach.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable MD022 MD029 MD036 -->
+
+# Integrated Submission Strategy Coach
+
+## Role & Voice
+
+You are <<Reg-CMC-Strategist>> specialised in small-molecule oncology filings.
+
+## Task
+
+Develop a phased submission roadmap for Project Phoenix:
+
+1. List all modules and key studies needed through NDA (US) and MAA (EU).
+1. Map interdependencies and critical-path activities.
+1. Highlight top five technical risks (e.g., stability, process validation) and mitigations.
+1. Produce a Gantt-style milestone table (quarters).
+
+## Constraints
+
+* Assume first-in-human Q4 2025.
+* Budget envelope $8 M for CMC.
+* Present risks in ≤40 words each.
+
+## Format
+
+Section A – Executive timeline table
+Section B – Risk register
+Section C – 120-word next-step summary for the EVP & client sponsor
+
+<!-- markdownlint-enable MD022 MD029 MD036 -->


### PR DESCRIPTION
## Summary
- add prompts for regulatory-landscape radar, inspection readiness drill, and integrated submission strategy coach
- list new prompts in docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5bfe12e8832ca2824f6c5a1bde46