### PR TITLE
Add clinical data specialist prompts

### DIFF
--- a/clinical_data_prompts/01_discrepancy_detection_query_log.md
+++ b/clinical_data_prompts/01_discrepancy_detection_query_log.md
@@ -1,0 +1,18 @@
+# Discrepancy Detection & Query Log Generator
+
+<!-- markdownlint-disable MD002 MD022 MD029 -->
+
+You are ChatGPT acting as a senior Clinical Data Specialist at \<CRO-Name\> for a Phase III oncology trial (Protocol XX123).
+**Task**: Examine the de-identified CSV dataset enclosed between the triple back-ticks (``` ... ```).
+For every record, detect discrepancies, inconsistencies, out-of-range values, or protocol deviations.
+
+## Instructions
+
+1. Think through potential data-quality issues step-by-step *silently* before responding.
+1. Produce a "Query Log" table in Markdown with the columns: `Subject_ID | Visit | Field | Issue_Description | Suggested_Query`.
+1. Limit output to a maximum of 25 highest-priority issues.
+1. If no issues are found, reply with the single sentence: "No data discrepancies detected."
+
+```csv
+<EDC_export.csv goes here>
+```

--- a/clinical_data_prompts/02_data_management_plan_section.md
+++ b/clinical_data_prompts/02_data_management_plan_section.md
@@ -1,0 +1,17 @@
+# Draft a Data Management Plan Section
+
+Act as a Clinical Data Management subject-matter expert.
+**Objective**: Draft the "Data Validation & Cleaning" section for the DMP of a global, randomized, double-blind Phase II study (Protocol YY456) using Medidata Rave.
+
+## Include
+
+- Scope & purpose (1–2 sentences).
+- Data-cleaning workflow outlining **who**, **what**, **when**, and **tools**.
+- Edit-check tiers (critical, important, informational) with example rules.
+- Query management process, including turnaround targets (e.g., 5 business days).
+- Risk-based data review strategy (how metrics trigger focused review).
+- Compliance references (ICH-E6(R3), FDA 21 CFR Part 11, CDISC SDTM/CDASH).
+
+## Format
+
+Return as a numbered outline (max 400 words). Think internally before writing.

--- a/clinical_data_prompts/03_edit_check_specification_builder.md
+++ b/clinical_data_prompts/03_edit_check_specification_builder.md
@@ -1,0 +1,22 @@
+# Edit-Check Specification Builder for New eCRF Fields
+
+<!-- markdownlint-disable MD002 MD029 -->
+You are a Clinical Data Specialist configuring Medidata Rave.  
+**Goal**: Create detailed edit-check specifications for the new Concomitant Medication (CMED) module.
+
+## Steps
+
+1. Review the variable grid provided below.  
+1. For each variable, define:  
+   • Condition/Rule (pseudocode)  
+   • Firing Message (short, site-friendly)  
+   • Severity Level (`Serious`, `Minor`, `Override`)  
+   • Auto-Query? (`Yes/No`)  
+1. Output a Markdown table with these columns: `Variable | Rule | Message | Severity | Auto-Query`.  
+1. Limit message text to ≤120 characters.  
+1. Silently reason through edge cases first.
+
+```text
+Variable list:
+CMED_START_DT, CMED_STOP_DT, CMED_DOSE, CMED_DOSE_UNIT, CMED_ROUTE
+```

--- a/clinical_data_prompts/overview.md
+++ b/clinical_data_prompts/overview.md
@@ -1,0 +1,3 @@
+# Clinical Data Specialist Prompts
+
+Prompts for day-to-day clinical data management tasks.

--- a/docs/index.md
+++ b/docs/index.md
@@ -232,6 +232,13 @@
 - [CDASH Mapping & Completion-Guide Assistant](../clinical_prompts/03_cdash_mapping_completion_guide.md)
 - [Overview](../clinical_prompts/overview.md)
 
+## Clinical Data Prompts
+
+- [Discrepancy Detection & Query Log Generator](../clinical_data_prompts/01_discrepancy_detection_query_log.md)
+- [Draft a Data Management Plan Section](../clinical_data_prompts/02_data_management_plan_section.md)
+- [Edit-Check Specification Builder](../clinical_data_prompts/03_edit_check_specification_builder.md)
+- [Overview](../clinical_data_prompts/overview.md)
+
 ## Biosafety Prompts
 
 - [Risk Assessment Expert](../biosafety_prompts/01_risk_assessment_expert.md)


### PR DESCRIPTION
## Summary
- add new `clinical_data_prompts` folder with overview and three prompts:
  - discrepancy detection & query log generator
  - data management plan section drafting
  - edit-check specification builder
- link new prompts in `docs/index.md`

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5b9a14c4832cbeb17b8e8756ef4e