### PR TITLE
Add CRO innovation exec prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,9 @@
 - [Strategic Market Foresight](../executive_prompts/01_strategic_market_foresight.md)
 - [Crisis Management Playbook](../executive_prompts/02_crisis_management_playbook.md)
 - [Executive Brief Synthesizer](../executive_prompts/03_executive_brief_synthesizer.md)
+- [Digital-Transformation Roadmap](../executive_prompts/04_digital_transformation_roadmap.md)
+- [AI Governance Framework](../executive_prompts/05_ai_governance_framework.md)
+- [Innovation Radar](../executive_prompts/06_innovation_radar.md)
 - [Overview](../executive_prompts/overview.md)
 
 ## Glp Prompts

--- a/executive_prompts/04_digital_transformation_roadmap.md
+++ b/executive_prompts/04_digital_transformation_roadmap.md
@@ -1,0 +1,14 @@
+# Digital-Transformation Roadmap for Clinical Operations
+
+You are a senior digital-health strategist.  
+Context: Our mid-size CRO runs ~120 Phase I–III trials per year. 2024–25 market pressures include tighter budgets, sponsor demand for Functional Service Provider (FSP) models, and rapid growth of wearables and AI to manage rising data volumes.  
+Task: Build a 3-year technology roadmap that will cut cycle times ≥15 % and improve patient engagement.  
+Step-by-step, do the following (think silently):  
+
+1. List the 6–8 biggest pain points in current trial operations.  
+1. For each, propose a technology initiative (e.g., eSource + wearables, AI-driven data cleaning, cloud CTMS). Show rough cost, implementation time, and ROI.  
+1. Sequence the initiatives into a phased roadmap (Q3 2025-Q2 2028).  
+1. Flag key success metrics and governance checkpoints for each phase.  
+
+Output: A markdown table titled **“CRO Digital-Transformation Roadmap 2025-2028”** with columns [Pain Point \| Initiative \| Phase \| High-Level Budget \| Expected ROI \| KPI].  
+Answer rules: Do **not** reveal your chain-of-thought; show only the finished table.

--- a/executive_prompts/05_ai_governance_framework.md
+++ b/executive_prompts/05_ai_governance_framework.md
@@ -1,0 +1,14 @@
+# FDA-Aligned AI Governance Framework
+
+You are a life-sciences compliance consultant specializing in AI.
+Context: The FDA’s January 2025 draft guidance “Considerations for the Use of Artificial Intelligence to Support Regulatory Decision-Making” introduces a risk-based credibility framework. Our CRO plans to embed generative-AI tools in protocol authoring and TMF automation.
+Task: Draft an internal AI Governance Framework that will satisfy regulators and sponsors.
+Follow these steps (think silently):
+
+1. Summarize the five most relevant obligations from the 2025 FDA draft (model documentation, context-of-use, data-quality, bias testing, audit trail).
+1. Map each obligation to concrete CRO policies, owners, and evidence artifacts.
+1. Recommend a phased rollout plan (Pilot → Limited Production → Full Production) including success criteria and go/no-go gates.
+1. Provide a one-page risk register (top 5 risks, likelihood, impact, mitigation).
+
+Output: A structured outline (Heading 2 for each major section) no longer than 600 words.
+Answer rules: Only output the outline; hide your inner reasoning.

--- a/executive_prompts/06_innovation_radar.md
+++ b/executive_prompts/06_innovation_radar.md
@@ -1,0 +1,17 @@
+# Quarterly Innovation Radar for Decentralized & Hybrid Trials
+
+You are an innovation-scouting analyst.
+Context: By Q2 2025 the DCT market is projected to exceed $21 B by 2030, with wearables, remote eConsent, and digital biomarkers driving adoption.
+Task: Produce a “Q3 2025 CRO Innovation Radar” covering the 10 most promising technologies for decentralized or hybrid trials.
+Process silently:
+
+1. Categorize candidates under [Patient Data Capture \| Participant Engagement \| Site Enablement \| Back-End Analytics].
+1. For each, rate Impact (1-5) and Implementation Feasibility (1-5) specifically for a CRO of our size.
+1. Plot them in a 2×2 Prioritization Matrix (High/Low Impact vs. High/Low Feasibility) and list recommended next actions for the top-right quadrant.
+
+Output:
+
+* Part A – A markdown table “Innovation Shortlist” with columns [Tech \| Category \| Impact \| Feasibility \| 12-Month Action].
+* Part B – A textual summary (≤200 words) interpreting the matrix and advising where to place immediate bets.
+
+Answer rules: Do not reveal chain-of-thought.


### PR DESCRIPTION
## Summary
- add digital transformation roadmap prompt
- add AI governance framework prompt
- add quarterly innovation radar prompt
- update executive prompts section in docs

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5b789d60832ca7c00906bd85e30f