### PR TITLE
Add CRO business operations prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,9 @@
 - [Rapid Process Diagnostic](../operations_prompts/01_rapid_process_diagnostic.md)
 - [Inventory Demand Planning Simulation](../operations_prompts/02_inventory_demand_planning_simulation.md)
 - [Kpi Dashboard Ops Review](../operations_prompts/03_kpi_dashboard_ops_review.md)
+- [Rolling Resource & Capacity Forecast](../operations_prompts/04_rolling_resource_capacity_forecast.md)
+- [Quarterly Cro Kpi Executive Brief](../operations_prompts/05_quarterly_kpi_executive_brief.md)
+- [Vendor Performance Improvement Plan](../operations_prompts/06_vendor_performance_improvement_plan.md)
 - [Overview](../operations_prompts/overview.md)
 
 ## Payment Prompts

--- a/operations_prompts/04_rolling_resource_capacity_forecast.md
+++ b/operations_prompts/04_rolling_resource_capacity_forecast.md
@@ -1,0 +1,24 @@
+# Rolling Resource & Capacity Forecast
+
+You are a Director of Business Operations at a mid-size, global CRO.
+
+**Objective**  
+Build a 12-month rolling forecast that shows FTE demand, billable hours, and utilization % across our Phase I-III trial portfolio, broken out by function (Clinical Ops, Data Mgmt, Biostats, Regulatory) and geography (NA, EU, APAC).
+
+**What I’ll provide**  
+• Current project list with planned start/finish dates, scope, and awarded $  
+• Historical time-tracking export (CSV)  
+• Approved headcount + open requisitions per function
+
+## Instructions
+
+1. Ingest the data and project monthly FTE needs using trend-based forecasting (ARIMA or Prophet—choose the best fit).
+1. Identify capacity gaps or surpluses (> ±10 % of need).
+1. Recommend specific hiring, cross-training, or contractor actions to close gaps.
+1. Return:
+   - A summary table (month × function × region) with projected demand, supply, and variance.  
+   - A bulleted risk list highlighting any functions over 120 % or under 80 % utilization.  
+   - Plain-language rationale (≤ 200 words) for the recommended actions.
+
+**Style** Concise, business-formal. Use headings and bullet points.  
+Ask clarifying questions if any input is missing or ambiguous. Think step-by-step before answering.

--- a/operations_prompts/05_quarterly_kpi_executive_brief.md
+++ b/operations_prompts/05_quarterly_kpi_executive_brief.md
@@ -1,0 +1,22 @@
+# Quarterly CRO KPI Executive Brief
+
+Act as the Business Operations lead preparing the Q3 Executive Brief for our CRO.
+
+**Goal**  
+Transform raw operational data into a C-suite-ready dashboard narrative that instantly signals performance, risks, and required decisions.
+
+**Inputs available**  
+• Operational dataset (Redshift): study start-up cycle time, enrollment rate, CRF completion lag, protocol deviations, revenue vs. forecast, EBITDA, employee turnover.  
+• Internal KPI definitions & thresholds (Excel).  
+• Commentary from functional heads (Word docs).
+
+**Deliverables**  
+A. One-page written narrative that:  
+   ▸ Highlights 3 KPIs above target, 3 below target, root-cause hypotheses, and one actionable decision for each lagging KPI.  
+   ▸ Summarizes overall financial health in ≤ 75 words.  
+B. PowerPoint outline (slide titles + bullet points) for a 6-slide deck.  
+C. Suggested data-viz styles (e.g., bullet chart, sparkline) for each KPI.
+
+**Constraints** Avoid jargon; assume audience is time-pressed. Place any numbers in parentheses after the KPI name.  
+Invite follow-up questions if data anomalies appear. Use first-person plural (“we”, “our”).  
+Reason out loud internally before producing the final answer (but do not show that chain of thought).

--- a/operations_prompts/06_vendor_performance_improvement_plan.md
+++ b/operations_prompts/06_vendor_performance_improvement_plan.md
@@ -1,0 +1,27 @@
+# Risk-Based Vendor Performance Improvement Plan
+
+Role: Director, Business Operations (CRO)  
+Context: We rely on 14 preferred vendors (labs, imaging, central IRB, eCOA) that support > 80 % of active studies.
+
+**Task**  
+Draft a 90-day action plan to raise overall vendor performance and lower risk.
+
+**Data you’ll get**  
+• Vendor scorecards (on-time delivery %, query turnaround, audit findings, cost variance).  
+• Contract terms & SLAs.  
+• Last two QA audit reports.
+
+## Steps
+
+1. Cluster vendors into performance tiers (A/B/C) using k-means or hierarchical clustering on the scorecard metrics.
+1. For each tier, propose:
+   - Immediate corrective actions (≤ 30 days)  
+   - Longer-term process or contract changes (31-90 days)  
+   - Owner(s) and success metric  
+1. Identify systemic causes (e.g., unclear change-order workflow) and recommend enterprise-level fixes.
+1. Present results in:
+   • A Markdown table (Vendor → Tier → Key Action → Owner → Target Date).  
+   • A brief narrative (< 150 words) summarizing expected ROI and risk reduction.
+
+**Style** Direct and prescriptive. Use active voice.  
+Ask for missing data rather than assuming. Think step-by-step internally.


### PR DESCRIPTION
## Summary
- add rolling resource and capacity forecasting prompt
- add quarterly CRO KPI executive brief prompt
- add risk-based vendor performance improvement plan
- index new prompts in documentation

## Testing
- `./scripts/validate_markdown.sh`


------
https://chatgpt.com/codex/tasks/task_e_687a5b54b348832ca5d07c9c078b7d73