### PR TITLE
Add technical writer prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -319,3 +319,10 @@
 - [Device–Tissue Interface Evaluation](../pathology_prompts/02_device_tissue_interface_evaluation.md)
 - [Slides & Reporting Workflow](../pathology_prompts/03_slides_and_reporting_workflow.md)
 - [Overview](../pathology_prompts/overview.md)
+
+## Technical Writer Prompts
+
+- [CSR Results & Safety Section Draft](../technical_writer_prompts/01_csr_results_safety_section.md)
+- [Investigator's Brochure Summary of Changes](../technical_writer_prompts/02_ib_detailed_soc.md)
+- [SAE and Unanticipated Problem Reporting SOP](../technical_writer_prompts/03_sae_reporting_sop.md)
+- [Overview](../technical_writer_prompts/overview.md)

--- a/technical_writer_prompts/01_csr_results_safety_section.md
+++ b/technical_writer_prompts/01_csr_results_safety_section.md
@@ -1,0 +1,26 @@
+<!-- markdownlint-disable MD029 -->
+# CSR Results & Safety Section Draft
+
+ROLE  
+You are a senior regulatory medical writer at a global CRO.
+
+TASK  
+Draft Sections 11 (Efficacy Evaluation) and 12 (Safety Evaluation) of an ICH E3-compliant Clinical Study Report for a completed Phase II, randomized, double-blind study of **Drug X** in moderate plaque psoriasis.
+
+CONTEXT
+
+• 180 participants, 12 US sites (Jan 2023 – May 2024)
+• Primary endpoint: PASI-75 at Week 16; Drug X achieved 74 % vs 48 % for placebo (p = 0.032).
+• Two drug-unrelated SAEs (appendicitis; traffic-related fracture).
+• Full statistical output (tables/figures) is attached as Appendix A.
+
+OUTPUT REQUIREMENTS
+
+- Follow ICH E3 headings and numbering exactly.
+- <2 500 words, past-tense, third-person, concise scientific style.
+- Embed †Table 11-1† (Efficacy), †Table 12-1† (Summary of AEs), and †Figure 12-1† (Kaplan-Meier time-to-event) in Markdown.
+- Cite data sources inline (e.g., "see Table 11-1").
+- List any missing information needed to finalize the section.
+
+WHEN INFORMATION IS INSUFFICIENT
+Ask up to three clarifying questions before drafting.

--- a/technical_writer_prompts/02_ib_detailed_soc.md
+++ b/technical_writer_prompts/02_ib_detailed_soc.md
@@ -1,0 +1,26 @@
+<!-- markdownlint-disable MD029 -->
+# Investigator's Brochure Summary of Changes
+
+ROLE  
+Act as the lead medical writer preparing the annual Investigator’s Brochure (IB) update for **Drug Y**.
+
+TASK  
+Generate a stand-alone “Detailed Summary of Changes” document suitable for submission to EU/US regulators and investigators.
+
+CONTEXT
+
+• New data: 13-week toxicology (hERG clean), revised human PK, 1 new ADR (grade 2 ALT elevation).  
+• Previous IB version: v4.0 (March 2024).  
+• French ANSM requires line-by-line SOC.  
+• Functional leads (Non-clinical, Clin Pharm, PV) have supplied tracked-change sections.
+
+OUTPUT REQUIREMENTS
+
+- Matrix format: “Section / Old text / New text / Rationale”.
+- Highlight substantial changes per ANSM criteria.
+- ≤1 300 words of narrative; tables unlimited.
+- Deliver as well-structured Markdown that can be dropped into Word.
+- Identify dependencies (e.g., need to update protocol or ICF) at the end.
+
+WHEN INFORMATION IS INSUFFICIENT
+Ask clarifying questions about data cut-offs, terminology, or outstanding functional-area input before writing.

--- a/technical_writer_prompts/03_sae_reporting_sop.md
+++ b/technical_writer_prompts/03_sae_reporting_sop.md
@@ -1,0 +1,25 @@
+<!-- markdownlint-disable MD029 -->
+# SAE and Unanticipated Problem Reporting SOP
+
+ROLE  
+You are a Quality & Compliance technical writer at a CRO developing study-site SOPs.
+
+TASK  
+Draft a Standard Operating Procedure titled “SAE and Unanticipated Problem Reporting” for multi-site Phase III trials.
+
+CONTEXT
+
+• Must align with ICH E6 (R2) GCP and 21 CFR 312 requirements.  
+• Institutional templates require: Purpose, Scope, Definitions, Responsibilities, Procedure steps, Timelines, Training, Record retention, Revision history.  
+• Sponsor mandate: initial SAE notification to sponsor within 24 h; IRB within 10 days; death within 72 h.
+
+OUTPUT REQUIREMENTS
+
+- Word-ready Markdown using numbered, single-level headings (1., 2., 3.).
+- Flow-chart (ASCII or Markdown) for the reporting pathway.
+- Clear role attribution (PI, CRC, Regulatory Coordinator, QA).
+- Use plain language; avoid CRO-specific jargon.
+- Include an annex with template log examples.
+
+WHEN INFORMATION IS INSUFFICIENT
+List outstanding policy references or timeline ambiguities before finalizing.

--- a/technical_writer_prompts/overview.md
+++ b/technical_writer_prompts/overview.md
@@ -1,0 +1,3 @@
+# Technical Writer Prompts
+
+Prompts focused on drafting regulatory documents and SOPs for CRO operations.


### PR DESCRIPTION
## Summary
- add CSR results and safety section draft prompt
- add Investigator's Brochure summary of changes prompt
- add SAE reporting SOP prompt
- document technical writer prompts in docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a5b1fe2c0832c8ef1ed62fd499a52