### PR TITLE
Add CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # proompts
 
+[![Update Docs Index](https://github.com/fderuiter/proompts/actions/workflows/update-docs.yml/badge.svg)](https://github.com/fderuiter/proompts/actions/workflows/update-docs.yml)
 [![Markdown Validation](https://github.com/fderuiter/proompts/actions/workflows/markdown-validation.yml/badge.svg)](https://github.com/fderuiter/proompts/actions/workflows/markdown-validation.yml)
+[![Deploy Jekyll site](https://github.com/fderuiter/proompts/actions/workflows/deploy-pages.yml/badge.svg)](https://github.com/fderuiter/proompts/actions/workflows/deploy-pages.yml)
 
 A curated set of Markdown prompts for AI-assisted product development, regulatory workflows, and general operations. Prompts are organized by topic—ranging from code reviews to market research—so you can mix and match them in your own agentic workflows.
 


### PR DESCRIPTION
## Summary
- add badges for updating docs and site deployment in README

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a7e0973e8832ca84ac4f90853f057