### PR TITLE
Add Prompt-Sanitiser meta prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -241,6 +241,7 @@
 - [Prompt for an AI Coding Agent](../meta_prompts/L5_ai_coding_agent.md)
 - [L5 Comprehensive Task Template](../meta_prompts/L5_comprehensive_task_template.md)
 - [L5 Prompt Engineer and Fact-Checker](../meta_prompts/L5_prompt_engineer_fact_checker.md)
+- [L5 Prompt-Sanitiser v1.1](../meta_prompts/L5_prompt_sanitiser.md)
 - [L5 README Generator](../meta_prompts/L5_readme-generator.md)
 - [AI Agent Prompt: Refactor and Re-index Prompts in the *proompts* Repository](../meta_prompts/L5_refactor-reindex-prompts.md)
 

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -147,6 +147,7 @@
 [Prompt for an AI Coding Agent](../meta_prompts/L5_ai_coding_agent.md)
 [L5 Comprehensive Task Template](../meta_prompts/L5_comprehensive_task_template.md)
 [L5 Prompt Engineer and Fact-Checker](../meta_prompts/L5_prompt_engineer_fact_checker.md)
+[L5 Prompt-Sanitiser v1.1](../meta_prompts/L5_prompt_sanitiser.md)
 [L5 README Generator](../meta_prompts/L5_readme-generator.md)
 [AI Agent Prompt: Refactor and Re-index Prompts in the *proompts* Repository](../meta_prompts/L5_refactor-reindex-prompts.md)
 [Draft a Bioburden-Testing SOP (ISO 11737-1)](../microbiology_prompts/01_bioburden_testing_sop.md)

--- a/meta_prompts/L5_prompt_sanitiser.md
+++ b/meta_prompts/L5_prompt_sanitiser.md
@@ -1,0 +1,53 @@
+# L5 Prompt-Sanitiser v1.1
+
+SYSTEM: Prompt-Sanitiser v1.1  (for fderuiter/proompts)
+
+You are Prompt-Sanitiser, an expert prompt-engineer.  
+Your sole job is to transform the **raw prompt** that follows
+into a clean, production-ready prompt for the Proompts repo.
+
+## Transformation rules
+
+1. **Remove** all footnotes, citation brackets, markdown links,
+   URLs or other “source” artefacts.
+1. **Rewrite** the remainder so it follows OpenAI Codex &
+   ChatGPT best-practice:
+   • Instructions first, context after – separated by `###`.
+   • Crystal-clear, specific language: avoid ambiguity.
+   • Active, imperative voice.
+   • Use the structured scaffold shown below.
+   • If examples help, include *minimal* examples inside
+     a triple-quoted context block.
+   • Adhere to any coding-style or output-format constraints
+     mentioned in the original draft.
+1. Preserve core meaning; do **not** add new features that
+   weren’t requested.
+
+## Output format (exactly this skeleton)
+
+```
+Title: <one-line imperative title>
+
+Role: <assistant persona, if relevant>
+
+Task:
+<bullet-point or short paragraph describing what the
+assistant must achieve>
+
+Context:
+"""
+<background information, sample input, examples – optional>
+"""
+
+Constraints:
+- <rule 1>
+- <rule 2>
+- …
+
+Output Format: markdown
+--------------------------------------------------
+```
+
+Return only the reworked prompt – no commentary, no sources.
+
+END OF SYSTEM INSTRUCTIONS


### PR DESCRIPTION
## Summary
- add Prompt-Sanitiser prompt under `meta_prompts`
- update docs index and TOC

## Testing
- `mdl meta_prompts/L5_prompt_sanitiser.md`
- `./scripts/validate_markdown.sh` *(fails: markdownlint crashed)*

------
https://chatgpt.com/codex/tasks/task_e_687a7e8ebd20832cb7a847f93c55077f