### PR TITLE
Add standardize prompt schema

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -243,6 +243,7 @@
 - [L5 Prompt Engineer and Fact-Checker](../meta_prompts/L5_prompt_engineer_fact_checker.md)
 - [L5 README Generator](../meta_prompts/L5_readme-generator.md)
 - [AI Agent Prompt: Refactor and Re-index Prompts in the *proompts* Repository](../meta_prompts/L5_refactor-reindex-prompts.md)
+- [Standardize Prompt Files](../meta_prompts/L5_standardize-prompt-files.md)
 
 ## Microbiology Prompts
 

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -149,6 +149,7 @@
 [L5 Prompt Engineer and Fact-Checker](../meta_prompts/L5_prompt_engineer_fact_checker.md)
 [L5 README Generator](../meta_prompts/L5_readme-generator.md)
 [AI Agent Prompt: Refactor and Re-index Prompts in the *proompts* Repository](../meta_prompts/L5_refactor-reindex-prompts.md)
+[Standardize Prompt Files](../meta_prompts/L5_standardize-prompt-files.md)
 [Draft a Bioburden-Testing SOP (ISO 11737-1)](../microbiology_prompts/01_bioburden_testing_sop.md)
 [Create an EO-Sterilization Validation Protocol (ISO 11135 + ISO 11737-2)](../microbiology_prompts/02_eo_sterilization_validation_protocol.md)
 [Build an Endotoxin-Control & 510(k) Risk Plan (USP <85> / AAMI ST72)](../microbiology_prompts/03_endotoxin_control_510k_risk_plan.md)

--- a/meta_prompts/L5_standardize-prompt-files.md
+++ b/meta_prompts/L5_standardize-prompt-files.md
@@ -1,0 +1,90 @@
+# Standardize Prompt Files
+
+id: migration-standardize-prompts
+title: "Standardize Prompt Files"
+category: maintenance
+author: "\<YOUR_NAME\>"
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [maintenance, prompts, formatting]
+-----------------------------------------
+
+## Objective
+
+Standardize all prompt Markdown files in the **proompts** repository so they follow a single, maintainable schema that aligns with the latest prompt‑engineering best practices.
+
+## Target Schema
+
+> Every prompt file **must** contain the following elements.
+
+### YAML front‑matter (required)
+
+```yaml
+id: <kebab-case-unique-id>
+title: <Concise descriptive title>
+category: <folder/topic>
+author: <original author or maintainer>
+created: <YYYY-MM-DD>
+last_modified: <YYYY-MM-DD>
+tested_model: <model name/version>
+temperature: <0‑2>
+tags: [tag1, tag2, ...]
+```
+
+### Body sections (each an H2 heading)
+
+## Purpose
+
+A one‑sentence statement of the prompt’s goal.
+
+## Context
+
+Essential background and assumptions the model needs.
+
+## Instructions
+
+Step‑by‑step directives phrased imperatively.
+
+## Inputs
+
+Bullet list of `{{placeholders}}` with a short description or type.
+
+## Output Format
+
+Description (or example) of the expected result, including any delimiters.
+
+## Additional Notes
+
+Tips, constraints, edge cases, or token budget remarks.
+
+## Example Usage *(optional)*
+
+Copy‑pasteable demonstration: caller input ➜ expected model output.
+
+## References *(optional)*
+
+Links or relative paths to supporting docs/resources.
+
+## Migration Workflow
+
+1. **Clone** the repo and create a new branch (default: `feat/standardize-prompt-format`).
+1. **Iterate** through every `*.md` file inside prompt directories:
+
+   * Detect existing headings; map their content to the new schema.
+   * Add or update YAML front‑matter (preserve original dates unless instructed otherwise).
+   * Move any unmapped text under **Additional Notes**.
+1. **Run** `./scripts/validate_markdown.sh` to ensure Markdown linting passes.
+1. **Commit** changes in logical chunks and push the branch.
+1. **Open** a PR and request review from repository maintainers.
+
+## Interaction Checklist
+
+Before executing, ask the caller to confirm:
+
+* Branch name (press **Enter** to use default).
+* Whether to overwrite `created` / `last_modified` dates.
+* Any folders or files to exclude from migration.
+
+Await confirmation before proceeding.


### PR DESCRIPTION
## Summary
- add a new meta prompt `Standardize Prompt Files`
- update docs index

## Testing
- `./scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a806840ac832cac2896b3be122a29