### PR TITLE
Fix Markdown validation workflow

### DIFF
--- a/.github/workflows/generate-overviews.yml
+++ b/.github/workflows/generate-overviews.yml
@@ -27,6 +27,8 @@ jobs:
         run: python3 scripts/generate_overviews.py
       - name: Update docs index
         run: python3 scripts/update_docs_index.py
+      - name: Install markdownlint (mdl)
+        run: sudo gem install mdl
       - name: Validate Markdown
         run: ./scripts/validate_markdown.sh
       - name: Check for changes


### PR DESCRIPTION
## Summary
- ensure markdown validator `mdl` is installed in the generate-overviews workflow

## Testing
- `./scripts/validate_markdown.sh`


------
https://chatgpt.com/codex/tasks/task_e_687a8f6dac98832caab987bfa0f7781e