### PR TITLE
Standardize VP statistics prompts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -421,5 +421,5 @@
 ## Vp Statistics Prompts
 
 - [Interim Results Executive Brief](../vp_statistics_prompts/01_interim_results_executive_brief.md)
-- [Statistical Analysis Plan First-Draft Builder](../vp_statistics_prompts/02_sap_first_draft_builder.md)
-- [Data-Quality Risk Heat-Map & Mitigation Plan](../vp_statistics_prompts/03_data_quality_risk_heatmap.md)
+- [Statistical Analysis Plan Draft Builder](../vp_statistics_prompts/02_sap_first_draft_builder.md)
+- [Data-Quality Risk Heat Map](../vp_statistics_prompts/03_data_quality_risk_heatmap.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -270,5 +270,5 @@
 [Risk-Based Monitoring & Quality Plan](../trial_execution_prompts/06_risk_based_monitoring_plan.md)
 [Patient Recruitment & Diversity Acceleration Plan](../trial_execution_prompts/07_recruitment_diversity_acceleration.md)
 [Interim Results Executive Brief](../vp_statistics_prompts/01_interim_results_executive_brief.md)
-[Statistical Analysis Plan First-Draft Builder](../vp_statistics_prompts/02_sap_first_draft_builder.md)
-[Data-Quality Risk Heat-Map & Mitigation Plan](../vp_statistics_prompts/03_data_quality_risk_heatmap.md)
+[Statistical Analysis Plan Draft Builder](../vp_statistics_prompts/02_sap_first_draft_builder.md)
+[Data-Quality Risk Heat Map](../vp_statistics_prompts/03_data_quality_risk_heatmap.md)

--- a/vp_statistics_prompts/01_interim_results_executive_brief.md
+++ b/vp_statistics_prompts/01_interim_results_executive_brief.md
@@ -1,41 +1,41 @@
-<!-- markdownlint-disable MD022 MD029 MD032 MD033 MD012 -->
-
+---
+id: vp-interim-results-brief
+title: Interim Results Executive Brief
+category: vp_statistics_prompts
+author: proompts team
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [statistics, summary]
 # Interim Results Executive Brief
+---
 
-## ROLE
+## Purpose
+Summarize interim analysis findings for cross-functional leadership.
 
-You are a senior regulatory biostatistician with more than 15 years of experience preparing FDA and EMA briefing packages.
+## Context
+You are a senior regulatory biostatistician with secure access to the following files:
+- `{{analysis_results}}` – PDF with interim results
+- `{{statistical_plan}}` – latest Statistical Analysis Plan
+- `{{safety_listings}}` – safety listings spreadsheet
 
-## CONTEXT
+## Instructions
+1. Confirm the three source files are accessible.
+2. Summarize each file in ≤120 words to demonstrate understanding.
+3. Draft a concise executive brief using headings **Introduction | Key Findings | Risk Assessment | Recommended Actions**.
+4. Highlight efficacy estimates, key safety signals, and any risks that could delay database lock.
+5. Recommend next-step actions for the Governance Committee.
+6. Limit bullet lists to six items and keep total length under 900 words.
+7. Ask clarifying questions if requirements are ambiguous.
 
-You have secure access to:
+## Inputs
+- `{{analysis_results}}`
+- `{{statistical_plan}}`
+- `{{safety_listings}}`
 
-- interim_analysis_results.pdf
-- statistical_analysis_plan_v3.docx
-- safety_listing_Q2.xlsx
+## Output Format
+Markdown document with the specified headings.
 
-## OBJECTIVE
-
-Draft a two-page executive summary (maximum 900 words) that:
-
-- Highlights primary-endpoint efficacy estimates and key safety signals
-- Flags any statistical or data-quality risks that could affect database lock
-- Recommends next-step actions for the Governance Committee
-
-## CONSTRAINTS
-
-- Write for a mixed audience of clinicians and non-technical executives (reading level around Grade 10).
-- Use Markdown headings: **Introduction \| Key Findings \| Risk Assessment \| Recommended Actions**.
-- Support every numeric claim with an inline source note (for example, "OR = 1.34, 95% CI 1.05-1.72 — results p. 5").
-- Limit bullet lists to six items or fewer.
-
-## PROCESS
-
-1. Confirm that the three source files are accessible.
-1. Summarise each file in 120 words or less to show understanding.
-1. Ask any clarifying questions if requirements are ambiguous.
-1. Produce the final executive summary.
-
-## OUTPUT FORMAT
-
-Return only the finished Markdown document.
+## Additional Notes
+Support every numeric claim with an inline source note. Write for clinicians and nontechnical executives at a grade 10 reading level.

--- a/vp_statistics_prompts/02_sap_first_draft_builder.md
+++ b/vp_statistics_prompts/02_sap_first_draft_builder.md
@@ -1,37 +1,42 @@
-<!-- markdownlint-disable MD022 MD029 MD032 MD033 MD012 -->
+---
+id: vp-sap-first-draft
+title: Statistical Analysis Plan Draft Builder
+category: vp_statistics_prompts
+author: proompts team
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [statistics, SAP]
+# Statistical Analysis Plan Draft Builder
+---
 
-# Statistical Analysis Plan First-Draft Builder
+## Purpose
+Create the initial draft of a Statistical Analysis Plan (SAP) for a Phase II oncology trial.
 
-## ROLE
-
-You are an ICH E9–savvy biostatistician tasked with authoring SAPs for Phase II oncology trials.
-
-## CONTEXT
-
-Protocol synopsis for Study \<ID\> is pasted below between triple quotes.
+## Context
+You are an ICH E9–savvy biostatistician. The protocol synopsis is provided below.
 
 """
-\<Insert protocol synopsis here\>
+{{protocol_synopsis}}
 """
 
-## TASK
+## Instructions
+1. Outline study objectives and estimands.
+2. Define analysis populations: ITT, PP, and Safety.
+3. Specify primary and key secondary analyses including models, covariates, and handling of missing data.
+4. Describe interim-analysis strategy and stopping boundaries.
+5. Detail multiplicity control and Type I error allocation.
+6. Provide Table, Listing, and Figure shells.
+7. Include SAS-style pseudocode for each primary analysis.
+8. Add a "Reviewer Checklist" box at the end of each major section.
+9. Use numbering aligned with the FDA chronological SAP template and CDISC/ADaM terminology.
 
-Generate a first-draft SAP focusing on:
+## Inputs
+- `{{protocol_synopsis}}`
 
-- Study objectives and estimands
-- Analysis populations (ITT, PP, Safety)
-- Primary and key secondary analyses (models, covariates, handling of missing data)
-- Interim-analysis strategy and stopping boundaries
-- Multiplicity control and Type I error allocation
-- Table, Listing and Figure (TLF) shells
+## Output Format
+Structured Markdown suitable for Word import.
 
-## CONSTRAINTS
-
-- Follow CDISC/ADaM terminology.
-- Use section numbering that matches the FDA chronological SAP template.
-- Provide statistical-software pseudo-code (SAS) for each primary analysis.
-- Include “Reviewer Checklist” boxes at the end of each major section.
-
-## DELIVERY
-
-Return a structured Markdown file that can be imported into MS Word.
+## Additional Notes
+Ensure technical accuracy and clarity for regulatory review.

--- a/vp_statistics_prompts/03_data_quality_risk_heatmap.md
+++ b/vp_statistics_prompts/03_data_quality_risk_heatmap.md
@@ -1,41 +1,43 @@
-<!-- markdownlint-disable MD022 MD029 MD032 MD033 MD012 -->
+---
+id: vp-data-quality-heatmap
+title: Data-Quality Risk Heat Map
+category: vp_statistics_prompts
+author: proompts team
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [data quality, risk]
+# Data-Quality Risk Heat Map
+---
 
-# Data-Quality Risk Heat-Map & Mitigation Plan
+## Purpose
+Assess site-level data quality and recommend mitigation actions.
 
-## ROLE
+## Context
+You are a clinical-data quality auditor specializing in risk-based monitoring. Inputs include:
+- `{{raw_eds_dump}}` – patient-level dataset
+- `{{query_log}}` – open and closed queries
 
-You are a clinical-data quality auditor specialising in risk-based monitoring for global trials.
-
-## CONTEXT
-
-You have the following inputs in memory:
-
-- raw_eds_dump.csv (patient-level data)
-- query_log.csv (open/closed queries)
-
-## OBJECTIVE
-
-1. Calculate and visualise a risk score (0–100) for each study site based on:
+## Instructions
+1. Confirm dataset shapes and key columns.
+2. Declare the risk-score formula and compute scores (0–100) for each site using:
    - Query burden per subject
    - Major protocol deviations per visit
-   - Timeliness of data entry (∆ DBL)
-1. Output a table “Top 10 High-Risk Sites” with driver metrics.
-1. Recommend three concrete mitigations for each high-risk site.
+   - Timeliness of data entry (Δ DBL)
+3. Show a table of the top ten high-risk sites with driver metrics.
+4. Generate an ASCII heat map (rows = sites, columns = risk deciles).
+5. Recommend three specific mitigations for each high-risk site.
+6. Include the Python (pandas) code used for calculations.
+7. Ask for confirmation before closing outstanding queries automatically.
+8. Keep total output under 800 words.
 
-## CONSTRAINTS
+## Inputs
+- `{{raw_eds_dump}}`
+- `{{query_log}}`
 
-- Summaries must be reproducible; include the Python (pandas) code block you used.
-- Risk score formula must be declared explicitly.
-- Generate a heat-map in ASCII (rows = sites, columns = risk deciles) for easy email viewing.
-- Keep total output 800 words or fewer.
+## Output Format
+Risk table → heat map → mitigation bullets.
 
-## STEP-BY-STEP
-
-- Confirm dataset shapes and key columns.
-- Show the computed risk table.
-- Present mitigations in bullet form.
-- Ask for confirmation before closing outstanding queries automatically.
-
-## OUTPUT FORMAT
-
-Return the table → heat-map → mitigation bullets in that order.
+## Additional Notes
+Ensure summaries are reproducible.


### PR DESCRIPTION
## Summary
- normalize prompts in `vp_statistics_prompts` with repository style
- regenerate documentation index

## Testing
- `mdl -r ~MD013 vp_statistics_prompts/01_interim_results_executive_brief.md vp_statistics_prompts/02_sap_first_draft_builder.md vp_statistics_prompts/03_data_quality_risk_heatmap.md`
- `./scripts/validate_markdown.sh` *(fails: MD029 etc. in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_687abf7985e4832c9d55527e5394c8ef