### PR TITLE
Standardize operations prompts

### DIFF
--- a/operations_prompts/01_rapid_process_diagnostic.md
+++ b/operations_prompts/01_rapid_process_diagnostic.md
@@ -1,23 +1,44 @@
+---
+id: operations-rapid-process-diagnostic
+title: Rapid Process Diagnostic & Lean Improvement Plan
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, lean]
+---
 
 # Rapid Process Diagnostic & Lean Improvement Plan
 
-You are a **senior Lean-Six-Sigma Black Belt** engaged to overhaul our [PROCESS NAME].
+## Purpose
+
+Create a concise process review and improvement roadmap.
 
 ## Context
 
-• Current volume: [units per month]
-• Avg. cycle-time: [days]
-• Pain points: [bullet list]
-• Target outcome: cycle-time ↓ 15 %, cost ↓ 10 %
+You are a senior Lean Six Sigma Black Belt working to overhaul **{{process_name}}**.
+Current volume, average cycle time, pain points and the target outcome are provided.
 
-## Tasks
+## Instructions
 
 1. Map the value stream and label wastes (TIMWOOD).
-1. List the **top-5 bottlenecks** with root cause and quantified business impact.
-1. Draft a **90-day action plan** (owner, milestone, KPI) in a Markdown table.
-1. Conclude with a ≤ 150-word executive summary.
+2. List the top five bottlenecks with root cause and business impact.
+3. Draft a 90‑day action plan with owner, milestone and KPI.
+4. Summarize findings in 150 words or fewer.
 
-## Constraints
+## Inputs
 
-* Think step-by-step, reflecting on Lean tools used.
-* Output **only** the table followed by the summary.
+- `{{current_volume}}` – units per month.
+- `{{avg_cycle_time}}` – days.
+- `{{pain_points}}` – bullet list.
+- `{{target_outcome}}` – cycle-time and cost targets.
+
+## Output Format
+
+Markdown table for the action plan followed by the summary paragraph.
+
+## Additional Notes
+
+Think step by step, referencing Lean tools. Return only the table and summary.

--- a/operations_prompts/02_inventory_demand_planning_simulation.md
+++ b/operations_prompts/02_inventory_demand_planning_simulation.md
@@ -1,25 +1,41 @@
-
-<!-- markdownlint-disable MD012 -->
+---
+id: operations-inventory-demand-planning
+title: Inventory & Demand-Planning Simulation
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, supply-chain]
+---
 
 # Inventory & Demand-Planning Simulation
 
-Act as a **supply-chain data scientist** specializing in inventory optimization.
+## Purpose
 
-Context supplied below:
+Create a forecast and inventory plan from historical demand data.
 
-```csv
-SKU, Monthly_Demand_24M, LeadTime_Days, HoldingCost_USD
-…
-```
+## Context
 
-**Goal**
-Generate a 12-month demand forecast, compute EOQ & safety-stock per SKU (95 % service level), and propose inventory-rebalancing moves.
+You are a supply-chain data scientist specializing in inventory optimization.
+A CSV file with SKU, demand, lead time and holding cost will be provided.
 
-**Deliverables**
-Return a **JSON object** with keys:
+## Instructions
 
-* `forecast`              – table of projected demand
-* `inventory_plan`        – recommended reorder point, EOQ, safety-stock
-* `risks`                 – top 3 forecast or supply risks + mitigation
+1. Generate a 12-month demand forecast.
+2. Compute EOQ and safety stock per SKU for a 95% service level.
+3. Recommend inventory rebalancing moves.
+4. Present results in a JSON object.
 
-Use chain-of-thought internally but **do not** expose it; present only the JSON plus a ≤ 120-word note on methodology.
+## Inputs
+
+- `{{inventory_csv}}` – CSV data with past demand and costs.
+
+## Output Format
+
+JSON with keys `forecast`, `inventory_plan` and `risks`, followed by a methodology note not exceeding 120 words.
+
+## Additional Notes
+
+Use chain-of-thought internally but do not expose it.

--- a/operations_prompts/03_kpi_dashboard_ops_review.md
+++ b/operations_prompts/03_kpi_dashboard_ops_review.md
@@ -1,20 +1,42 @@
+---
+id: operations-kpi-dashboard-review
+title: KPI Dashboard & Monthly Ops-Review Pack
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, kpi]
+---
+
 # KPI Dashboard & Monthly Ops-Review Pack
 
-You are our **operations-performance coach** preparing the COO’s monthly review.
+## Purpose
+
+Summarize operational performance and highlight required actions for the monthly review.
 
 ## Context
 
-• Latest KPI data (csv attached) for Q3 FY-25
-• Strategic priorities: cost leadership, on-time delivery, ESG compliance
+You are an operations-performance coach preparing the COO’s monthly review.
+Latest KPI data for Q3 FY‑25 and strategic priorities are provided.
 
-## Tasks
+## Instructions
 
-1. Identify the **3 KPIs furthest off-target**; explain root cause.
-1. Recommend corrective initiatives, RACI owner, and due date.
-1. Draft three narrative slides in Markdown:
-   - ### State of Operations  
-   - ### Key Risks & Mitigations  
-   - ### Next Steps
-   *≤ 5 bullets per slide*
+1. Identify the three KPIs furthest off‑target and explain their root causes.
+2. Recommend corrective initiatives with RACI owner and due date.
+3. Draft three narrative slides titled **State of Operations**, **Key Risks & Mitigations**, and **Next Steps** (up to five bullets each).
+4. End with an **Ask** slide listing decisions needed from the executive team.
 
-Close with an “Ask” slide listing decisions needed from the exec team.
+## Inputs
+
+- `{{kpi_data}}` – CSV of recent KPIs.
+- `{{strategic_priorities}}` – bullet list.
+
+## Output Format
+
+Markdown bullet lists for each slide.
+
+## Additional Notes
+
+Keep the briefing concise and action oriented.

--- a/operations_prompts/04_cro_trial_performance_kpi_dashboard_blueprint.md
+++ b/operations_prompts/04_cro_trial_performance_kpi_dashboard_blueprint.md
@@ -1,26 +1,39 @@
+---
+id: operations-cro-kpi-dashboard-blueprint
+title: CRO Trial-Performance KPI Dashboard Blueprint
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, dashboard]
+---
+
 # CRO Trial-Performance KPI Dashboard Blueprint
 
-You are an expert clinical-trial operations analyst at a global CRO.
+## Purpose
+
+Outline metrics and visuals for a CRO trial-performance dashboard.
 
 ## Context
 
-I need to build a Power BI/Excel dashboard that lets senior leadership see, at a glance, how our active studies are performing. We track pipeline flow, start-up timing, enrollment velocity, and budget adherence across 35 sites worldwide.
+You are an expert clinical-trial operations analyst. Leadership needs a Power BI or Excel dashboard showing pipeline flow, start-up timing, enrollment velocity and budget adherence across 35 sites.
 
-## Task
+## Instructions
 
-1. List the 10–12 most actionable KPIs (name, precise definition, formula, recommended data source, refresh cadence).
-1. Recommend the best visual for each KPI (e.g., gauge, line, stacked bar) and justify the choice in one sentence.
-1. Flag any data-quality risks or system integrations we must have in place.
+1. List 10‑12 actionable KPIs with definition, formula, data source and refresh cadence.
+2. Recommend the best visual for each KPI and justify the choice in one sentence.
+3. Flag any data-quality risks or required system integrations.
 
-### Constraints
+## Inputs
 
-- Prioritize metrics that CRO sponsors explicitly value (e.g., study start-up timing, opportunity close rate).
-- Keep explanations concise (≤40 words per bullet).
+- `{{portfolio_summary}}` – snapshot of active studies.
 
-### Output Format
+## Output Format
 
-Markdown table with columns: `KPI | Formula | Visual | Data Source | Refresh Cadence | Notes`.
+Markdown table with columns `KPI | Formula | Visual | Data Source | Refresh Cadence | Notes`.
 
-## Why It Matters
+## Additional Notes
 
-Pipeline health, start-up speed and sponsor-facing metrics are decisive for CRO site selection and revenue growth.
+Prioritize metrics sponsors value and keep explanations under 40 words per bullet. Dashboard clarity influences site selection and revenue growth.

--- a/operations_prompts/04_operational_excellence_risk_sweep.md
+++ b/operations_prompts/04_operational_excellence_risk_sweep.md
@@ -1,28 +1,41 @@
+---
+id: operations-excellence-risk-sweep
+title: Operational Excellence & Risk Sweep
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, risk]
+---
+
 # Operational Excellence & Risk Sweep
 
-Act as a **Lean Six Sigma Black Belt specialized in clinical-trial operations.**
+## Purpose
 
-**Context I Provide:**
-Average trial cycle time is 32 months; patient recruitment failure rate 18 %; we use Medidata & Veeva Vault.
+Deliver a 90-day action plan to cut cycle time and reduce recruitment failure.
 
-**Objective:**
-Design a 90-day action plan to cut cycle time by 10 % and lower recruitment failure to 12 %. Address technology, process, and talent levers.
+## Context
 
-**Constraints:**
-• Prioritize changes by ROI (high/medium/low) and implementation effort (low/medium/high)
-• Highlight compliance risks (ICH-GCP, GDPR, 21 CFR Part 11) in red text
-• Limit total output to 700 words
+Average trial cycle time is 32 months and recruitment failure rate is 18 %. We use Medidata and Veeva Vault.
 
-**Output Format:**
+## Instructions
 
-```markdown
-## 90-Day CRO Ops Optimization Plan
-| Initiative | ROI | Effort | Owner | Risk |
-|------------|-----|--------|-------|------|
-…
-## Quick-Win Checklist
-…
-```
+1. Prioritize technology, process and talent levers by ROI and implementation effort.
+2. Highlight compliance risks for ICH-GCP, GDPR and 21 CFR Part 11.
+3. Limit the response to 700 words.
+4. Present a markdown table titled **90-Day CRO Ops Optimization Plan** followed by a **Quick-Win Checklist**.
+5. Ask three clarifying questions if data gaps exist before drafting.
 
-**Verification Step:**
-Ask me three clarifying questions if data gaps exist before drafting.
+## Inputs
+
+- `{{trial_metrics}}` – cycle-time and recruitment data.
+
+## Output Format
+
+Markdown table as specified plus the checklist.
+
+## Additional Notes
+
+Risks should be clearly noted; compliance issues may be flagged in red text.

--- a/operations_prompts/04_operational_kpi_benchmark_review.md
+++ b/operations_prompts/04_operational_kpi_benchmark_review.md
@@ -1,16 +1,40 @@
+---
+id: operations-kpi-benchmark-review
+title: 360° Operational KPI & Benchmark Review
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, benchmark]
+---
+
 # 360° Operational KPI & Benchmark Review
 
-You are a senior operations-analytics consultant for a global CRO.
+## Purpose
 
-INSTRUCTIONS (do these steps in order)
+Compare internal KPIs to industry benchmarks and propose improvements.
 
-1. Ingest the quarterly KPI data provided below.
-1. Compare our metrics to current CRO-industry benchmarks (cite your public sources).
-1. Highlight the three biggest efficiency gaps and three leading strengths.
-1. Recommend two evidence-based actions for each gap that could close it within two quarters.
-1. Present everything in a Markdown table followed by a short executive-summary paragraph (≤150 words).
+## Context
 
-DATA STARTS HERE
-"""
-<<paste CSV or table of KPIs here>>
-"""
+You are a senior operations analytics consultant for a global CRO. Quarterly KPI data is provided.
+
+## Instructions
+
+1. Ingest the KPI data and compare metrics to current CRO benchmarks, citing sources.
+2. Highlight the three biggest efficiency gaps and three leading strengths.
+3. Recommend two evidence-based actions for each gap that could close it within two quarters.
+4. Present findings in a markdown table followed by a ≤150-word summary.
+
+## Inputs
+
+- `{{kpi_csv}}` – quarterly KPI data.
+
+## Output Format
+
+Markdown table then summary paragraph.
+
+## Additional Notes
+
+Include public benchmark sources alongside the comparison data.

--- a/operations_prompts/04_rolling_resource_capacity_forecast.md
+++ b/operations_prompts/04_rolling_resource_capacity_forecast.md
@@ -1,24 +1,42 @@
+---
+id: operations-rolling-capacity-forecast
+title: Rolling Resource & Capacity Forecast
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, forecasting]
+---
+
 # Rolling Resource & Capacity Forecast
 
-You are a Director of Business Operations at a mid-size, global CRO.
+## Purpose
 
-**Objective**  
-Build a 12-month rolling forecast that shows FTE demand, billable hours, and utilization % across our Phase I-III trial portfolio, broken out by function (Clinical Ops, Data Mgmt, Biostats, Regulatory) and geography (NA, EU, APAC).
+Generate a 12-month forecast of FTE demand and utilization by function and region.
 
-**What I’ll provide**  
-• Current project list with planned start/finish dates, scope, and awarded $  
-• Historical time-tracking export (CSV)  
-• Approved headcount + open requisitions per function
+## Context
+
+You are the Director of Business Operations at a mid-size CRO. Project lists, historical time tracking and approved headcount are available.
 
 ## Instructions
 
-1. Ingest the data and project monthly FTE needs using trend-based forecasting (ARIMA or Prophet—choose the best fit).
-1. Identify capacity gaps or surpluses (> ±10 % of need).
-1. Recommend specific hiring, cross-training, or contractor actions to close gaps.
-1. Return:
-   - A summary table (month × function × region) with projected demand, supply, and variance.  
-   - A bulleted risk list highlighting any functions over 120 % or under 80 % utilization.  
-   - Plain-language rationale (≤ 200 words) for the recommended actions.
+1. Ingest the data and project monthly FTE needs using an appropriate time-series model.
+2. Identify capacity gaps or surpluses greater than ±10 %.
+3. Recommend hiring, cross-training or contractor actions to close gaps.
+4. Provide a summary table with projected demand, supply and variance, a risk list for functions over 120 % or under 80 % utilization, and a rationale under 200 words.
 
-**Style** Concise, business-formal. Use headings and bullet points.  
-Ask clarifying questions if any input is missing or ambiguous. Think step-by-step before answering.
+## Inputs
+
+- `{{project_list}}` – project schedules and scope.
+- `{{time_tracking_csv}}` – historical hours.
+- `{{headcount}}` – approved FTEs and open requisitions.
+
+## Output Format
+
+Markdown table followed by bullets and the rationale paragraph.
+
+## Additional Notes
+
+Keep the tone concise and business formal. Ask clarifying questions if inputs are missing.

--- a/operations_prompts/04_study_startup_checklist.md
+++ b/operations_prompts/04_study_startup_checklist.md
@@ -1,19 +1,42 @@
+---
+id: operations-study-startup-checklist
+title: Study Start-Up Checklist & Timeline
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, startup]
+---
+
 # Study Start-Up Checklist & Timeline
 
-**Role**: Experienced clinical-operations specialist creating a Phase IIb start-up plan.  
-**Context**  
-• Therapeutic area: Oncology  
-• Regions: US & EU  
-• First-Patient-In target: 2025-10-15  
-• Regulations: FDA 21 CFR §312, EMA CTR  
-**Task**  
-Produce a detailed, actionable checklist and Gantt-style timeline covering:  
-  – Regulatory & ethics submissions  
-  – Site selection & contracts  
-  – Vendor onboarding & sample-handling logistics  
-  – IMP / IP supply & labeling  
-  – Staff training & readiness  
-Include at least three common start-up risks with mitigations.  
-**Output format**: Markdown table—Columns = Workstream | Key Activities | Owner | Start | Finish | Dependencies | Notes/Risks.  
-**Quality bar**: All critical-path tasks ≤ 15 business days; timeline aligns with FPI.  
-Ask clarifying questions before answering if anything is missing.
+## Purpose
+
+Provide an actionable checklist and timeline for Phase IIb study start-up.
+
+## Context
+
+You are an experienced clinical-operations specialist. The therapeutic area, regions, target first-patient-in date and regulations are provided.
+
+## Instructions
+
+1. Detail workstreams for regulatory submissions, site contracts, vendor onboarding, IMP supply and staff training.
+2. Include a Gantt-style timeline.
+3. List at least three common start-up risks with mitigations.
+
+## Inputs
+
+- `{{therapeutic_area}}` – indication for the study.
+- `{{regions}}` – participating regions.
+- `{{fpi_date}}` – first-patient-in target date.
+- `{{regulations}}` – key regulatory references.
+
+## Output Format
+
+Markdown table with columns `Workstream | Key Activities | Owner | Start | Finish | Dependencies | Notes/Risks`.
+
+## Additional Notes
+
+All critical-path tasks should take no longer than 15 business days and align with the FPI date. Ask clarifying questions if information is missing.

--- a/operations_prompts/05_multistudy_resource_capacity_forecast_plan.md
+++ b/operations_prompts/05_multistudy_resource_capacity_forecast_plan.md
@@ -1,27 +1,41 @@
+---
+id: operations-multistudy-capacity-plan
+title: Multistudy Resource & Capacity Forecast Plan
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, capacity]
+---
+
 # Multistudy Resource & Capacity Forecast Plan
 
-Act as a senior CRO resource-planning consultant.
+## Purpose
+
+Outline a data-driven approach for forecasting resources across multiple upcoming trials.
 
 ## Context
 
-Over the next 9 months we expect 12 new Phase II/III trials. Each requires different FTE mixes (project management, data management, site monitoring) and technology costs.
+You are a senior CRO resource-planning consultant. Twelve new Phase II/III trials are expected over the next nine months with varying FTE mixes and technology costs.
 
-## Task
+## Instructions
 
-1. Show a step-by-step approach (with formulas) for forecasting head-count and spend using historical utilization data.
-1. Provide a sample RACI matrix for cross-functional collaboration (Ops, Finance, HR, IT).
-1. Suggest three automation opportunities to streamline capacity planning.
+1. Show a step-by-step methodology with formulas for forecasting headcount and spend using historical utilization data.
+2. Provide a sample RACI matrix for collaboration between Operations, Finance, HR and IT.
+3. Suggest three automation opportunities to streamline capacity planning.
 
-### Constraints
+## Inputs
 
-Use best-practice workflow-optimization principles and emphasize data-driven decision-making.
+- `{{historical_utilization}}` – past FTE and spend data.
 
-### Output Format
+## Output Format
 
-- Section A: numbered methodology steps (max 7).
-- Section B: Markdown RACI table.
-- Section C: bullet list of automation ideas (≤25 words each).
+Section A: numbered steps (max seven).
+Section B: markdown RACI table.
+Section C: bullet list of automation ideas (≤25 words each).
 
-## Why It Matters
+## Additional Notes
 
-Workflow optimization, resource allocation and cross-department collaboration are core duties for Business Operations Specialists.
+Use workflow-optimization principles and emphasise data-driven decision making.

--- a/operations_prompts/05_proactive_risk_heat_map.md
+++ b/operations_prompts/05_proactive_risk_heat_map.md
@@ -1,15 +1,40 @@
+---
+id: operations-proactive-risk-heat-map
+title: Proactive Risk Heat-Map for Decentralized & Virtual Trials
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, risk]
+---
+
 # Proactive Risk Heat-Map for Decentralized & Virtual Trials
 
-You are a risk-management strategist specializing in decentralized clinical trials.
+## Purpose
 
-INSTRUCTIONS
+Visualize portfolio risks and propose mitigation actions.
 
-1. Synthesise the project portfolio data below with 2025 CRO risk trends (patient-recruitment, data integrity, regulatory, supply-chain).
-1. Score each active study on Likelihood (1-5) and Impact (1-5); calculate Risk = Likelihood × Impact.
-1. Produce a color-coded heat-map (use simple ASCII boxes) and a bulleted mitigation plan for the top five risks.
-1. Flag any AI/ML tools that could automate the mitigation step, citing recent examples.
+## Context
 
-PORTFOLIO DATA
-"""
-<<portfolio snapshot>>
-"""
+You are a risk-management strategist specializing in decentralized clinical trials. Portfolio data will be provided along with current CRO risk trends.
+
+## Instructions
+
+1. Combine the provided portfolio data with 2025 CRO risk trends.
+2. Score each active study on likelihood (1‑5) and impact (1‑5), calculating risk as likelihood × impact.
+3. Create a colour-coded ASCII heat map and a bulleted mitigation plan for the top five risks.
+4. Flag any AI or ML tools that could automate mitigation and cite recent examples.
+
+## Inputs
+
+- `{{portfolio_snapshot}}` – summary of active studies.
+
+## Output Format
+
+ASCII heat map followed by a mitigation bullet list.
+
+## Additional Notes
+
+Use concise language and highlight high-risk studies clearly.

--- a/operations_prompts/05_quarterly_kpi_executive_brief.md
+++ b/operations_prompts/05_quarterly_kpi_executive_brief.md
@@ -1,22 +1,42 @@
+---
+id: operations-quarterly-kpi-brief
+title: Quarterly CRO KPI Executive Brief
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, kpi]
+---
+
 # Quarterly CRO KPI Executive Brief
 
-Act as the Business Operations lead preparing the Q3 Executive Brief for our CRO.
+## Purpose
 
-**Goal**  
-Transform raw operational data into a C-suite-ready dashboard narrative that instantly signals performance, risks, and required decisions.
+Present key operational KPIs and recommended actions for the quarterly review.
 
-**Inputs available**  
-• Operational dataset (Redshift): study start-up cycle time, enrollment rate, CRF completion lag, protocol deviations, revenue vs. forecast, EBITDA, employee turnover.  
-• Internal KPI definitions & thresholds (Excel).  
-• Commentary from functional heads (Word docs).
+## Context
 
-**Deliverables**  
-A. One-page written narrative that:  
-   ▸ Highlights 3 KPIs above target, 3 below target, root-cause hypotheses, and one actionable decision for each lagging KPI.  
-   ▸ Summarizes overall financial health in ≤ 75 words.  
-B. PowerPoint outline (slide titles + bullet points) for a 6-slide deck.  
-C. Suggested data-viz styles (e.g., bullet chart, sparkline) for each KPI.
+You are the Business Operations lead preparing the Q3 executive brief. Operational data, KPI thresholds and functional commentary are available.
 
-**Constraints** Avoid jargon; assume audience is time-pressed. Place any numbers in parentheses after the KPI name.  
-Invite follow-up questions if data anomalies appear. Use first-person plural (“we”, “our”).  
-Reason out loud internally before producing the final answer (but do not show that chain of thought).
+## Instructions
+
+1. Produce a one-page narrative highlighting three KPIs above target and three below, include root-cause hypotheses and an actionable decision for each lagging KPI.
+2. Summarize overall financial health in 75 words or fewer.
+3. Outline a six-slide PowerPoint deck with slide titles and bullets.
+4. Suggest appropriate data visualizations for each KPI.
+
+## Inputs
+
+- `{{operational_dataset}}` – metrics from Redshift.
+- `{{kpi_definitions}}` – thresholds and descriptions.
+- `{{functional_comments}}` – notes from department heads.
+
+## Output Format
+
+Narrative summary, slide outline and recommended visualization styles.
+
+## Additional Notes
+
+Keep language jargon-free and assume the audience is time pressed. Use first-person plural and offer to answer questions if data anomalies appear.

--- a/operations_prompts/05_weekly_ops_kpi_snapshot.md
+++ b/operations_prompts/05_weekly_ops_kpi_snapshot.md
@@ -1,15 +1,39 @@
+---
+id: operations-weekly-kpi-snapshot
+title: Weekly Operations KPI Snapshot
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, kpi]
+---
+
 # Weekly Operations KPI Snapshot
 
-**Role**: Data analyst supporting CRO operations leadership.  
-**Input**: Paste CSV with columns: StudyID, Milestone, PlannedDate, ActualDate, Status, Issues.  
-**Objectives**
+## Purpose
 
-1. Calculate portfolio on-time performance (% milestones delivered on/ before PlannedDate).
-1. Compute median slip days for late milestones.
-1. Identify the three highest-risk studies (Status="Behind" OR slip > 10 days) and give one-sentence cause.
+Summarize weekly milestone performance and highlight at-risk studies.
 
-**Output**
-• ≤ 150-word executive summary.  
-• Markdown table titled “Portfolio KPI Snapshot”.  
-• ISO-8601 dates (YYYY-MM-DD).  
-**Tone**: Concise and professional.
+## Context
+
+You are a data analyst supporting CRO operations leadership. A CSV with StudyID, Milestone, PlannedDate, ActualDate, Status and Issues will be provided.
+
+## Instructions
+
+1. Calculate portfolio on-time performance (percentage of milestones delivered on or before the planned date).
+2. Compute median slip days for late milestones.
+3. Identify the three highest-risk studies (Status="Behind" or slip > 10 days) and give a one-sentence cause for each.
+
+## Inputs
+
+- `{{milestone_csv}}` – milestone data.
+
+## Output Format
+
+A ≤150-word executive summary and a Markdown table titled **Portfolio KPI Snapshot**. Dates should be ISO-8601.
+
+## Additional Notes
+
+Use a concise and professional tone.

--- a/operations_prompts/06_action_oriented_meeting_minutes.md
+++ b/operations_prompts/06_action_oriented_meeting_minutes.md
@@ -1,12 +1,41 @@
+---
+id: operations-action-oriented-minutes
+title: Action-Oriented Meeting Minutes & Tracker
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, meetings]
+---
+
 # Action-Oriented Meeting Minutes & Tracker
 
-**Role**: Senior project administrator capturing decisions & actions.  
-**Input**: Full transcript of weekly cross-functional study-team meeting.  
-**Deliverables**  
-A. Meeting minutes with: Attendees, Key Decisions, Discussion Highlights.  
-B. Action-item register as Markdown table—Columns = Item # | Description | Owner | Due Date | Priority (High / Med / Low).  
-C. Automatically assign IDs “OPS-2025-MM-NN” to each action.  
-D. Finish with a single-sentence “Next Steps” section.  
-**Rules**  
-– Flag any action missing a due date with “TBD” and suggest one.  
-– Keep language clear, neutral and implementation-ready.
+## Purpose
+
+Capture decisions and action items from cross-functional meetings.
+
+## Context
+
+You are a senior project administrator. A full transcript of the weekly cross-functional study-team meeting will be provided.
+
+## Instructions
+
+1. Summarize attendees, key decisions and discussion highlights.
+2. Create an action-item register as a Markdown table with columns `Item # | Description | Owner | Due Date | Priority`.
+3. Assign IDs in the format `OPS-2025-MM-NN`.
+4. End with a one-sentence **Next Steps** section.
+5. Flag any action missing a due date with `TBD` and suggest one.
+
+## Inputs
+
+- `{{meeting_transcript}}` – full text of the meeting.
+
+## Output Format
+
+Meeting minutes followed by the action-item table and the **Next Steps** sentence.
+
+## Additional Notes
+
+Use clear, neutral language and ensure items are implementation ready.

--- a/operations_prompts/06_fair_market_value_budget_negotiation_brief.md
+++ b/operations_prompts/06_fair_market_value_budget_negotiation_brief.md
@@ -1,27 +1,39 @@
+---
+id: operations-fmv-budget-brief
+title: Fair-Market-Value Budget Negotiation Brief
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, budget]
+---
+
 # Fair-Market-Value Budget Negotiation Brief
 
-You are an experienced CRO contract-budget negotiator.
+## Purpose
+
+Prepare a concise briefing to support FMV negotiations with a pharma sponsor.
 
 ## Context
 
-We’re entering FMV talks with a top-10 pharma sponsor across diverse global sites (urban U.S., EU, APAC). The sponsor wants a one-size-fits-all rate card; our sites need locality adjustments to stay sustainable.
+You are an experienced CRO contract-budget negotiator. The sponsor wants a single rate card across diverse sites, while our sites require locality adjustments.
 
-## Task
+## Instructions
 
-1. Draft a two-page briefing that:
-   - summarizes common FMV pain points for sponsors vs. sites,
-   - proposes a tiered, region-sensitive compensation model, and
-   - outlines a transparent calculation template we can share.
-1. Include three evidence-based talking points on how flexible FMV improves study start-up speed and overall cost control.
+1. Summarize typical FMV pain points for sponsors versus sites.
+2. Propose a tiered, region-sensitive compensation model and a transparent calculation template.
+3. Provide three evidence-based talking points on how flexible FMV improves start-up speed and overall cost control.
 
-### Constraints
+## Inputs
 
-Professional tone, bullet style, cite peer-reviewed or industry sources where possible.
+- `{{site_cost_data}}` – regional cost benchmarks.
 
-### Output Format
+## Output Format
 
 Structured Markdown with H2 headings and nested bullets.
 
-## Why It Matters
+## Additional Notes
 
-Balancing transparent FMV with cost-efficiency is a growing priority highlighted in industry analyses.
+Maintain a professional tone and cite peer-reviewed or industry sources where possible. FMV transparency helps balance sustainability and cost efficiency.

--- a/operations_prompts/06_forward_capacity_forecast.md
+++ b/operations_prompts/06_forward_capacity_forecast.md
@@ -1,17 +1,41 @@
+---
+id: operations-forward-capacity-forecast
+title: Forward-Looking Resource & Capacity Forecast
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, forecasting]
+---
+
 # Forward-Looking Resource & Capacity Forecast (90-Day Horizon)
 
-Act as an operations-capacity planner for a mid-size CRO.
+## Purpose
 
-INSTRUCTIONS
+Project FTE demand and recommend actions to balance capacity for the next 90 days.
 
-1. From the study-pipeline and staffing data below, project FTE demand by functional group for the next 90 days.
-1. Identify any over-/under-capacity (>10 % variance) per week.
-1. Suggest actionable levers (hiring, outsourcing, cross-training) to balance capacity while meeting margin targets.
-1. Output:
-   • Section A – Table: Week | Function | Req. FTE | Avail. FTE | Δ%
-   • Section B – Three-point action plan (bullet list, ≤120 words).
+## Context
 
-INPUTS
-"""
-<<pipeline forecast + current staffing>>
-"""
+You are an operations-capacity planner at a mid-size CRO. Study pipeline and staffing data will be provided.
+
+## Instructions
+
+1. Project FTE demand by functional group for the next 90 days.
+2. Identify any over- or under-capacity greater than 10 % per week.
+3. Suggest hiring, outsourcing or cross-training actions to meet margin targets.
+4. Present Section A: table `Week | Function | Req. FTE | Avail. FTE | Δ%` and Section B: three-point action plan in 120 words or fewer.
+
+## Inputs
+
+- `{{pipeline_forecast}}` – upcoming work.
+- `{{current_staffing}}` – available resources.
+
+## Output Format
+
+Markdown table plus bullet list action plan.
+
+## Additional Notes
+
+Use concise business language and verify any missing inputs before beginning.

--- a/operations_prompts/06_vendor_performance_improvement_plan.md
+++ b/operations_prompts/06_vendor_performance_improvement_plan.md
@@ -1,27 +1,43 @@
+---
+id: operations-vendor-performance-plan
+title: Risk-Based Vendor Performance Improvement Plan
+category: operations_prompts
+author: Frederick de Ruiter
+created: 2025-07-18
+last_modified: 2025-07-18
+tested_model: gpt-4o
+temperature: 0.2
+tags: [operations, vendors]
+---
+
 # Risk-Based Vendor Performance Improvement Plan
 
-Role: Director, Business Operations (CRO)  
-Context: We rely on 14 preferred vendors (labs, imaging, central IRB, eCOA) that support > 80 % of active studies.
+## Purpose
 
-**Task**  
-Draft a 90-day action plan to raise overall vendor performance and lower risk.
+Raise overall vendor performance and reduce operational risk.
 
-**Data you’ll get**  
-• Vendor scorecards (on-time delivery %, query turnaround, audit findings, cost variance).  
-• Contract terms & SLAs.  
-• Last two QA audit reports.
+## Context
 
-## Steps
+You are the Director of Business Operations for a CRO relying on fourteen preferred vendors covering labs, imaging, central IRB and eCOA.
+Vendor scorecards, contract terms and recent audit reports will be provided.
 
-1. Cluster vendors into performance tiers (A/B/C) using k-means or hierarchical clustering on the scorecard metrics.
-1. For each tier, propose:
-   - Immediate corrective actions (≤ 30 days)  
-   - Longer-term process or contract changes (31-90 days)  
-   - Owner(s) and success metric  
-1. Identify systemic causes (e.g., unclear change-order workflow) and recommend enterprise-level fixes.
-1. Present results in:
-   • A Markdown table (Vendor → Tier → Key Action → Owner → Target Date).  
-   • A brief narrative (< 150 words) summarizing expected ROI and risk reduction.
+## Instructions
 
-**Style** Direct and prescriptive. Use active voice.  
-Ask for missing data rather than assuming. Think step-by-step internally.
+1. Cluster vendors into performance tiers using appropriate clustering on scorecard metrics.
+2. For each tier, propose immediate corrective actions (≤30 days) and longer-term changes (31‑90 days) with owner and success metric.
+3. Identify systemic causes such as workflow gaps and recommend enterprise-level fixes.
+4. Present a markdown table showing `Vendor | Tier | Key Action | Owner | Target Date` followed by a brief narrative under 150 words summarizing ROI and risk reduction.
+
+## Inputs
+
+- `{{vendor_scorecards}}` – performance metrics.
+- `{{contract_terms}}` – key obligations and SLAs.
+- `{{audit_reports}}` – recent QA findings.
+
+## Output Format
+
+Markdown table plus narrative paragraph.
+
+## Additional Notes
+
+Use a direct, prescriptive style. Request missing data before proceeding and think step by step.


### PR DESCRIPTION
## Summary
- reformat every operations prompt with YAML front matter
- add purpose, context, instructions, inputs, and output format sections
- ensure blank lines around headings per markdownlint

## Testing
- `python3 scripts/update_docs_index.py`
- `./scripts/validate_markdown.sh` *(fails: MD002, MD022, MD029 in unrelated folders)*

------
https://chatgpt.com/codex/tasks/task_e_687abefb2f08832cb83661acf324f433