### PR TITLE
Add JSON template and cross-reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,36 @@
 # Repository Guidance for AI Agent Prompts
 
-This repository stores a collection of AI agent prompts. Each prompt is stored as JSON and placed in one of the categories under the repository root (e.g. `agentic_coding`, `meta_prompts`). Use this file for guidelines on adding or modifying prompts.
+This repository stores a collection of AI agent prompts. Each prompt is written in Markdown and placed in one of the categories under the repository root (e.g. `agentic_coding`, `meta_prompts`). Use this file for guidelines on adding or modifying prompts.
 
 ## File Format and Layout
 
-- **JSON only**: Every file in this repository should have the `.json` extension and contain valid JSON content.
-- **Naming**: Follow the existing naming style in each directory. For example, prompts in `agentic_coding` use numeric prefixes (`01_product_brief.json`, `02_project_brief_epic.json`, etc.), while prompts in `meta_prompts` start with `L#_` (`L0_master-ultrameta.json`).
+- **Markdown only**: Every file in this repository should have the `.md` extension and contain valid Markdown content.
+- **Naming**: Follow the existing naming style in each directory. For example, prompts in `agentic_coding` use numeric prefixes (`01_product_brief.md`, `02_project_brief_epic.md`, etc.), while prompts in `meta_prompts` start with `L#_` (`L0_master-ultrameta.md`).
 - **Directory placement**: Add new prompts to the most relevant directory. Create new directories when necessary, using short, lowercase names separated by underscores.
+
+## Prompt Metadata Schema
+
+Each prompt begins with YAML front matter that follows this schema (shown here in JSON form for clarity):
+
+- `id` *(string, required)* — unique kebab‑case identifier.
+- `title` *(string, required)* — short descriptive title.
+- `category` *(string, required)* — directory or topical grouping.
+- `author` *(string, optional)* — original author or maintainer.
+- `created` *(string, required)* — date added in `YYYY-MM-DD` format.
+- `last_modified` *(string, required)* — last modification date in the same format.
+- `tested_model` *(string, optional)* — model name or version used for testing.
+- `temperature` *(number, optional)* — sampling temperature (0–2).
+- `tags` *(array of strings, optional)* — helpful keywords.
+
+The body of the prompt then uses standard **H2** sections—`Purpose`, `Context`, `Instructions`, `Inputs`, `Output Format`, `Additional Notes`, `Example Usage`, and `References`—as described in `prompt_tools/L5_standardize-prompt-files.md`.
+
+For a complete JSON example that includes these sections, see `docs/template_prompt.json`.
 
 ## Contributing New Prompts
 
 Follow these steps when adding a new prompt:
 
-1. Create a JSON file that contains the prompt data.
+1. Create a Markdown file that contains the prompt text and front matter.
 1. Place the file in the appropriate directory (`agentic_coding`, `meta_prompts`, etc.). Create new directories if needed using short, lowercase names separated by underscores.
 1. When you make a new directory, also add an `overview.md` file inside it that briefly explains the prompts in that folder.
 1. Run the draft through `prompt_tools/L5_prompt_sanitiser.md`.
@@ -20,19 +38,19 @@ Follow these steps when adding a new prompt:
 1. For large reorganizations, follow `prompt_tools/L5_refactor-reindex-prompts.md`.
 1. Optionally, run `prompt_tools/01_architecture_review_pipeline.md` for repository audits.
 1. Run `scripts/update_docs_index.py` to regenerate the docs index (or rely on `.github/workflows/update-docs.yml`).
-1. Verify the JSON formatting using your preferred validator.
+1. Verify the Markdown formatting by running `./scripts/validate_markdown.sh`.
 1. Commit the new file with a concise message, e.g. `Add data ingestion prompt`.
 1. Open a pull request for review.
 
 ## Validation Script
 
-The workflow in `.github/workflows/json-validation.yml` runs `scripts/validate_json.sh` to check JSON formatting. You can run this script locally before committing:
+The workflow in `.github/workflows/markdown-validation.yml` runs `scripts/validate_markdown.sh` to check Markdown formatting. You can run this script locally before committing:
 
 ```bash
-./scripts/validate_json.sh
+./scripts/validate_markdown.sh
 ```
 
-Make sure the `jsonlint` tool (`jq` command) is available. If it's missing, install it with `npm install -g jsonlint` or your package manager.
+Make sure the `markdownlint` tool (`mdl` command) is available. If it's missing, install it with `gem install mdl` or your package manager.
 The `.github/workflows/update-docs.yml` workflow will automatically commit the docs index if it becomes out of date.
 
 ## Automation
@@ -40,8 +58,8 @@ The `.github/workflows/update-docs.yml` workflow will automatically commit the d
 Several GitHub Actions take care of routine maintenance tasks:
 
 - **`generate-overviews.yml`** automatically creates an `overview.md` file in any new prompt directory and updates the docs index.
-- **`repo-checks.yml`** verifies file naming conventions, ensures all files use the `.json` extension, and checks that each directory contains `overview.md`.
-- **`json-validation.yml`** runs `scripts/validate_json.sh`.
+- **`repo-checks.yml`** verifies file naming conventions, ensures all files use the `.md` extension, and checks that each directory contains `overview.md`.
+- **`markdown-validation.yml`** runs `scripts/validate_markdown.sh`.
 - **`update-docs.yml`** commits the documentation index if it changes.
 
 These workflows run on every push or pull request. When contributing, you can rely on them to handle the overview generation and docs update steps for you.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ A curated set of Markdown prompts for AI-assisted product development, regulator
 
 - **`docs/`** – additional docs and a full [table of contents](docs/index.md)
 
+## Prompt Schema
+
+Each prompt begins with YAML front matter that includes these fields:
+
+- `id` – unique kebab-case identifier.
+- `title` – short descriptive title.
+- `category` – directory or topical grouping.
+- `author` – optional author attribution.
+- `created` – date added (`YYYY-MM-DD`).
+- `last_modified` – most recent modification date.
+- `tested_model` – optional model/version used when testing.
+- `temperature` – optional sampling temperature.
+- `tags` – optional array of keywords.
+
+The body of the prompt follows the template in `prompt_tools/L5_standardize-prompt-files.md` with **H2** sections for `Purpose`, `Context`, `Instructions`, `Inputs`, `Output Format`, `Additional Notes`, `Example Usage`, and `References`.
+
+You can also see the same structure in JSON form in `docs/template_prompt.json`.
+
 ## Validation
 
 Check Markdown formatting and the docs index before committing:
@@ -28,8 +46,7 @@ Check Markdown formatting and the docs index before committing:
 The script first runs `python3 scripts/update_docs_index.py --check` to ensure
 `docs/index.md` and `docs/table-of-contents.md` are up to date, then runs `mdl`.
 It requires both Python 3 and the `mdl` tool. Install the linter with
-`gem install mdl` if it isn't already available. The same check runs in GitHub
-Actions.
+`gem install mdl` if it isn't already available. The same check runs in GitHub Actions.
 This repository also runs workflows to generate missing `overview.md` files, verify file naming, and commit the docs index when it changes.
 
 ## Contributing

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,5 @@
 # Table of Contents
 
-## .git
-
-- [Fix-All-Files-In-Todo Fix](../.git/logs/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
-- [Fix-All-Files-In-Todo Fix](../.git/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
-
 ## Adjudication Prompts
 
 - [Real-Time Adjudication Visibility Dashboard](../adjudication_prompts/01_real_time_adjudication_dashboard.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -1,5 +1,3 @@
-[Fix-All-Files-In-Todo Fix](../.git/logs/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
-[Fix-All-Files-In-Todo Fix](../.git/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
 [Real-Time Adjudication Visibility Dashboard](../adjudication_prompts/01_real_time_adjudication_dashboard.md)
 [Source Document and Endpoint Checklist](../adjudication_prompts/02_source_document_endpoint_checklist.md)
 [Analyze Adjudication KPIs](../adjudication_prompts/03_analyze_adjudication_kpis.md)

--- a/docs/template_prompt.json
+++ b/docs/template_prompt.json
@@ -1,0 +1,21 @@
+{
+  "id": "example-prompt",
+  "title": "Example Prompt",
+  "category": "sample_category",
+  "author": "Jane Doe",
+  "created": "2025-01-01",
+  "last_modified": "2025-01-01",
+  "tested_model": "gpt-4",
+  "temperature": 0.7,
+  "tags": ["example", "template"],
+  "prompt": {
+    "purpose": "One-sentence statement of the prompt's goal.",
+    "context": "Essential background and assumptions the model needs.",
+    "instructions": "Step-by-step directives phrased imperatively.",
+    "inputs": "List of {{placeholders}} with descriptions.",
+    "output_format": "Description or example of the expected result.",
+    "additional_notes": "Tips, constraints, or token budget remarks.",
+    "example_usage": "Caller input → expected model output.",
+    "references": "Links to supporting docs or resources."
+  }
+}


### PR DESCRIPTION
## Summary
- include example JSON prompt schema `docs/template_prompt.json`
- reference JSON template from AGENTS and README
- document that prompts use standard H2 sections

## Testing
- `./scripts/validate_markdown.sh`


------
https://chatgpt.com/codex/tasks/task_e_687ef2fc9acc832c8c74f5587e592635