### PR TITLE
Add JSON schema reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@ Each prompt begins with YAML front matter that follows this schema (shown here i
 
 The body of the prompt then uses standard **H2** sections—`Purpose`, `Context`, `Instructions`, `Inputs`, `Output Format`, `Additional Notes`, `Example Usage`, and `References`—as described in `prompt_tools/L5_standardize-prompt-files.md`.
 
-For a complete JSON example that includes these sections, see `docs/template_prompt.json`.
+For a machine-readable definition, see `docs/prompt_schema.json`. A filled-out example
+that conforms to this schema is provided in `docs/template_prompt.json`.
 
 ## Contributing New Prompts
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Each prompt begins with YAML front matter that includes these fields:
 The body of the prompt follows the template in `prompt_tools/L5_standardize-prompt-files.md` with **H2** sections for `Purpose`, `Context`, `Instructions`, `Inputs`, `Output Format`, `Additional Notes`, `Example Usage`, and `References`.
 
 You can also see the same structure in JSON form in `docs/template_prompt.json`.
+The machine-readable JSON schema is available in `docs/prompt_schema.json`.
 
 ## Validation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,5 @@
 # Table of Contents
 
-## .git
-
-- [Fix-All-Files-In-Todo Fix](../.git/logs/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
-- [Fix-All-Files-In-Todo Fix](../.git/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
-
 ## Adjudication Prompts
 
 - [Real-Time Adjudication Visibility Dashboard](../adjudication_prompts/01_real_time_adjudication_dashboard.md)

--- a/docs/prompt_schema.json
+++ b/docs/prompt_schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Proompts Prompt Schema",
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "category",
+    "created",
+    "last_modified",
+    "prompt"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "title": {"type": "string"},
+    "category": {"type": "string"},
+    "author": {"type": "string"},
+    "created": {"type": "string", "format": "date"},
+    "last_modified": {"type": "string", "format": "date"},
+    "tested_model": {"type": "string"},
+    "temperature": {"type": "number"},
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "prompt": {
+      "type": "object",
+      "required": [
+        "purpose",
+        "context",
+        "instructions",
+        "inputs",
+        "output_format"
+      ],
+      "properties": {
+        "purpose": {"type": "string"},
+        "context": {"type": "string"},
+        "instructions": {"type": "string"},
+        "inputs": {"type": "string"},
+        "output_format": {"type": "string"},
+        "additional_notes": {"type": "string"},
+        "example_usage": {"type": "string"},
+        "references": {"type": "string"}
+      }
+    }
+  }
+}

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -1,5 +1,3 @@
-[Fix-All-Files-In-Todo Fix](../.git/logs/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
-[Fix-All-Files-In-Todo Fix](../.git/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
 [Real-Time Adjudication Visibility Dashboard](../adjudication_prompts/01_real_time_adjudication_dashboard.md)
 [Source Document and Endpoint Checklist](../adjudication_prompts/02_source_document_endpoint_checklist.md)
 [Analyze Adjudication KPIs](../adjudication_prompts/03_analyze_adjudication_kpis.md)


### PR DESCRIPTION
## Summary
- add a machine-readable prompt schema in `docs/prompt_schema.json`
- reference the schema in `AGENTS.md` and `README.md`
- update docs index

## Testing
- `./scripts/validate_markdown.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fb1977440832c8845145647122fce