### PR TITLE
Modify AGENTS rules to switch to JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,16 @@
 # Repository Guidance for AI Agent Prompts
 
-This repository stores a collection of AI agent prompts. Each prompt is written in Markdown and placed in one of the categories under the repository root (e.g. `agentic_coding`, `meta_prompts`). Use this file for guidelines on adding or modifying prompts.
+This repository stores a collection of AI agent prompts. Each prompt is stored as JSON and placed in one of the categories under the repository root (e.g. `agentic_coding`, `meta_prompts`). Use this file for guidelines on adding or modifying prompts.
 
 ## File Format and Layout
 
-- **Markdown only**: Every file in this repository should have the `.md` extension and contain valid Markdown content.
-- **Naming**: Follow the existing naming style in each directory. For example, prompts in `agentic_coding` use numeric prefixes (`01_product_brief.md`, `02_project_brief_epic.md`, etc.), while prompts in `meta_prompts` start with `L#_` (`L0_master-ultrameta.md`).
+- **JSON only**: Every file in this repository should have the `.json` extension and contain valid JSON content.
+- **Naming**: Follow the existing naming style in each directory. For example, prompts in `agentic_coding` use numeric prefixes (`01_product_brief.json`, `02_project_brief_epic.json`, etc.), while prompts in `meta_prompts` start with `L#_` (`L0_master-ultrameta.json`).
 - **Directory placement**: Add new prompts to the most relevant directory. Create new directories when necessary, using short, lowercase names separated by underscores.
 
 ## Prompt Metadata Schema
 
-Each prompt begins with YAML front matter that follows this schema (shown here in JSON form for clarity):
+Each prompt file is a JSON document that follows this schema:
 
 - `id` *(string, required)* — unique kebab‑case identifier.
 - `title` *(string, required)* — short descriptive title.
@@ -30,7 +30,7 @@ For a complete JSON example that includes these sections, see `docs/template_pro
 
 Follow these steps when adding a new prompt:
 
-1. Create a Markdown file that contains the prompt text and front matter.
+1. Create a JSON file that contains the prompt text and metadata.
 1. Place the file in the appropriate directory (`agentic_coding`, `meta_prompts`, etc.). Create new directories if needed using short, lowercase names separated by underscores.
 1. When you make a new directory, also add an `overview.md` file inside it that briefly explains the prompts in that folder.
 1. Run the draft through `prompt_tools/L5_prompt_sanitiser.md`.
@@ -38,19 +38,18 @@ Follow these steps when adding a new prompt:
 1. For large reorganizations, follow `prompt_tools/L5_refactor-reindex-prompts.md`.
 1. Optionally, run `prompt_tools/01_architecture_review_pipeline.md` for repository audits.
 1. Run `scripts/update_docs_index.py` to regenerate the docs index (or rely on `.github/workflows/update-docs.yml`).
-1. Verify the Markdown formatting by running `./scripts/validate_markdown.sh`.
+1. Verify the JSON formatting using a tool like `jq` or `python -m json.tool`.
 1. Commit the new file with a concise message, e.g. `Add data ingestion prompt`.
 1. Open a pull request for review.
 
 ## Validation Script
 
-The workflow in `.github/workflows/markdown-validation.yml` runs `scripts/validate_markdown.sh` to check Markdown formatting. You can run this script locally before committing:
+The `.github/workflows/markdown-validation.yml` workflow still checks Markdown documentation files. For JSON prompts, ensure each file is valid JSON before committing, for example using `jq`:
 
 ```bash
-./scripts/validate_markdown.sh
+jq . your_prompt.json >/dev/null
 ```
 
-Make sure the `markdownlint` tool (`mdl` command) is available. If it's missing, install it with `gem install mdl` or your package manager.
 The `.github/workflows/update-docs.yml` workflow will automatically commit the docs index if it becomes out of date.
 
 ## Automation
@@ -58,8 +57,8 @@ The `.github/workflows/update-docs.yml` workflow will automatically commit the d
 Several GitHub Actions take care of routine maintenance tasks:
 
 - **`generate-overviews.yml`** automatically creates an `overview.md` file in any new prompt directory and updates the docs index.
-- **`repo-checks.yml`** verifies file naming conventions, ensures all files use the `.md` extension, and checks that each directory contains `overview.md`.
-- **`markdown-validation.yml`** runs `scripts/validate_markdown.sh`.
+- **`repo-checks.yml`** verifies file naming conventions, ensures all prompt files use the `.json` extension, and checks that each directory contains `overview.md`.
+- **`markdown-validation.yml`** runs `scripts/validate_markdown.sh` for Markdown documentation files.
 - **`update-docs.yml`** commits the documentation index if it changes.
 
 These workflows run on every push or pull request. When contributing, you can rely on them to handle the overview generation and docs update steps for you.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,5 @@
 # Table of Contents
 
-## .git
-
-- [Fix-All-Files-In-Todo Fix](../.git/logs/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
-- [Fix-All-Files-In-Todo Fix](../.git/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
-
 ## Adjudication Prompts
 
 - [Real-Time Adjudication Visibility Dashboard](../adjudication_prompts/01_real_time_adjudication_dashboard.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -1,5 +1,3 @@
-[Fix-All-Files-In-Todo Fix](../.git/logs/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
-[Fix-All-Files-In-Todo Fix](../.git/refs/remotes/origin/slop/fix-all-files-in-todo_fix.md)
 [Real-Time Adjudication Visibility Dashboard](../adjudication_prompts/01_real_time_adjudication_dashboard.md)
 [Source Document and Endpoint Checklist](../adjudication_prompts/02_source_document_endpoint_checklist.md)
 [Analyze Adjudication KPIs](../adjudication_prompts/03_analyze_adjudication_kpis.md)


### PR DESCRIPTION
## Summary
- update root AGENTS instructions to store prompts in JSON
- regenerate documentation index

## Testing
- `scripts/validate_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fb1e13ec4832ca8925d206a8e487b