### PR TITLE
Clarify JSON format rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository stores a collection of AI agent prompts. Each prompt is stored a
 
 ## File Format and Layout
 
-- **JSON only**: Every prompt file in this repository should have the `.json` extension and contain valid JSON content. Documentation files remain in Markdown.
+- **JSON only**: All prompts must be stored as `.json` files containing valid JSON. Use Markdown strictly for documentation such as `README.md` or `overview.md`.
 - **Naming**: Follow the existing naming style in each directory. For example, prompts in `agentic_coding` use numeric prefixes (`01_product_brief.json`, `02_project_brief_epic.json`, etc.), while prompts in `meta_prompts` start with `L#_` (`L0_master-ultrameta.json`).
 - **Directory placement**: Add new prompts to the most relevant directory. Create new directories when necessary, using short, lowercase names separated by underscores.
 


### PR DESCRIPTION
## Summary
- emphasize JSON-only prompts in AGENTS guidance

## Testing
- `./scripts/validate_json.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fbb9c77c0832c935cd647f184190f