### PR TITLE
Add JSON validation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,15 @@ The body of the prompt mirrors the template in
 
 ## Validation
 
-Check JSON formatting and the docs index before committing:
+Run the helper script to verify JSON formatting and the docs index before committing:
 
 ```bash
 ./scripts/validate_json.sh
 ```
 
-The script first runs `python3 scripts/update_docs_index.py --check` to ensure
-`docs/index.md` and `docs/table-of-contents.md` are up to date, then checks every
-`*.json` file with `jq`. Install `jq` with your package manager if it isn't already
-available. The same check runs in GitHub Actions.
+The script requires `jq` and Python 3. It checks that
+`docs/index.md` and `docs/table-of-contents.md` are current and then runs `jq`
+against every `*.json` file. The same check runs in GitHub Actions.
 This repository also runs workflows to generate missing `overview.md` files, verify file naming, and commit the docs index when it changes.
 
 ## Contributing

--- a/scripts/validate_json.sh
+++ b/scripts/validate_json.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Validate JSON prompt files and documentation index
-# Requires the 'jq' command and Python 3
+# Validate JSON prompt files and documentation index.
+# Requires 'jq' and Python 3.
+
+command -v jq >/dev/null 2>&1 || { echo "Error: jq is not installed" >&2; exit 1; }
 
 # Ensure docs/index.md and docs/table-of-contents.md are current.
 python3 scripts/update_docs_index.py --check
 
 # Verify each JSON file parses correctly
 while IFS= read -r -d '' file; do
-    jq '.' "$file" >/dev/null
+    jq -e '.' "$file" >/dev/null
 done < <(find . -name '*.json' -not -path './.git/*' -print0)
 
 echo "All JSON files validated"
-


### PR DESCRIPTION
## Summary
- improve the `validate_json.sh` helper
- clarify README instructions for validating prompts

## Testing
- `./scripts/validate_json.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fbe5f3c94832ca410048e06ffa1f3