### PR TITLE
Update README instructions for contributing prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ This repository also runs workflows to generate missing `overview.md` files, ver
 
 ## Contributing
 
-1. Add prompts as `.json` files in the appropriate folder.
+1. Create prompts as `.json` files that follow [`docs/prompt_schema.json`](docs/prompt_schema.json) and place them in the appropriate folder.
 1. Before committing, sanitize and standardize the file using `prompt_tools/L5_prompt_sanitiser.md` and `prompt_tools/L5_standardize-prompt-files.md`.
+1. Run `scripts/validate_json.sh` to verify JSON formatting and update the docs index.
 1. Optionally, run `prompt_tools/01_architecture_review_pipeline.md` to audit the repository.
 1. If you create a new directory, an `overview.md` will be generated automatically by the workflow.
-1. The docs index and JSON formatting are checked in CI, but you can run `scripts/validate_json.sh` locally.
+1. The same validation runs in CI, but running `scripts/validate_json.sh` locally helps catch issues early.
 
 ## License
 


### PR DESCRIPTION
## Summary
- clarify that new prompts must follow `docs/prompt_schema.json`
- mention sanitising prompts and running `scripts/validate_json.sh`

## Testing
- `./scripts/validate_json.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fd6e3ca8c832c81eb0dbb6e8ab4f1