### PR TITLE
Document Markdown docs policy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,4 +1,5 @@
 name: Deploy Jekyll site
+# Build site from Markdown documentation and prompts
 
 on:
   push:

--- a/.github/workflows/fix-markdown-issues.yml
+++ b/.github/workflows/fix-markdown-issues.yml
@@ -1,4 +1,5 @@
 name: Fix Markdown Issues
+# Auto-format documentation in Markdown
 
 on:
   push:

--- a/.github/workflows/generate-overviews.yml
+++ b/.github/workflows/generate-overviews.yml
@@ -1,4 +1,5 @@
 name: Generate Overviews
+# Keep overview files as Markdown
 
 on:
   push:

--- a/.github/workflows/json-validation.yml
+++ b/.github/workflows/json-validation.yml
@@ -1,4 +1,5 @@
 name: JSON Validation
+# Ensure prompt JSON and Markdown docs remain valid
 
 on:
   push:

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -1,4 +1,5 @@
 name: Repository Checks
+# Validate JSON prompts and overview.md presence
 
 on:
   push:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,4 +1,5 @@
 name: Update Docs Index
+# Regenerate Markdown docs index files
 
 on:
   push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This repository stores a collection of AI agent prompts. Each prompt is stored a
 ## File Format and Layout
 
 - **JSON only**: All prompts must be stored as `.json` files containing valid JSON. Use Markdown strictly for documentation such as `README.md` or `overview.md`.
+- **Markdown docs**: All documentation files—including `overview.md`, `docs/*.md`, and any additional guides—remain in Markdown format. Do not convert these files to JSON or other formats.
 - **Naming**: Follow the existing naming style in each directory. For example, prompts in `agentic_coding` use numeric prefixes (`01_product_brief.json`, `02_project_brief_epic.json`, etc.), while prompts in `meta_prompts` start with `L#_` (`L0_master-ultrameta.json`).
 - **Directory placement**: Add new prompts to the most relevant directory. Create new directories when necessary, using short, lowercase names separated by underscores.
 

--- a/scripts/check_prompts.py
+++ b/scripts/check_prompts.py
@@ -4,6 +4,8 @@
 import re
 from pathlib import Path
 
+OVERVIEW_NAME = "overview.md"  # documentation stays Markdown
+
 ROOT = Path(__file__).resolve().parents[1]
 EXCLUDE_DIRS = {"docs", "scripts", ".github", "prompt_tools"}
 
@@ -13,8 +15,8 @@ LEVEL_RE = re.compile(r"^L\d+_.*\.json$")
 
 
 def check_overview(directory: Path) -> bool:
-    if not (directory / "overview.md").exists():
-        print(f"Missing overview.md in {directory}")
+    if not (directory / OVERVIEW_NAME).exists():
+        print(f"Missing {OVERVIEW_NAME} in {directory}")
         return False
     return True
 
@@ -25,7 +27,7 @@ def check_files(directory: Path) -> bool:
         if not file.is_file() or file.name.startswith('.'):
             continue
         name = file.name
-        if name.lower() in {"overview.md", "readme.md"}:
+        if name.lower() in {OVERVIEW_NAME, "readme.md"}:
             continue
         if file.suffix.lower() != ".json":
             print(f"{file} is not a JSON file")

--- a/scripts/generate_overviews.py
+++ b/scripts/generate_overviews.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""Create overview.md files for prompt directories if missing."""
+"""Create ``overview.md`` files for prompt directories if missing."""
 
 from pathlib import Path
 import sys
+
+OVERVIEW_NAME = "overview.md"  # documentation remains in Markdown
 
 ROOT = Path(__file__).resolve().parents[1]
 EXCLUDE_DIRS = {"docs", "scripts", ".github"}
@@ -28,7 +30,7 @@ def generate_overview(directory: Path) -> str:
     title = directory.name.replace("_", " ").title()
     lines = [f"# {title} Overview", ""]
     for file in sorted(directory.glob("*.md")):
-        if file.name.lower() in {"overview.md", "readme.md"}:
+        if file.name.lower() in {OVERVIEW_NAME, "readme.md"}:
             continue
         heading = heading_from_file(file)
         lines.append(f"- [{heading}]({file.name})")
@@ -36,7 +38,7 @@ def generate_overview(directory: Path) -> str:
 
 
 def ensure_overview(directory: Path) -> bool:
-    path = directory / "overview.md"
+    path = directory / OVERVIEW_NAME
     if path.exists():
         return False
     content = generate_overview(directory)

--- a/scripts/update_docs_index.py
+++ b/scripts/update_docs_index.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Update docs index and table of contents for prompt files."""
+"""Update `docs/index.md` and `docs/table-of-contents.md` in Markdown."""
 
 import argparse
 import json


### PR DESCRIPTION
## Summary
- state clearly in AGENTS.md that docs remain in Markdown
- tweak scripts to use a constant `overview.md`
- note Markdown policy in CI workflows

## Testing
- `./scripts/validate_json.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fd87f5f84832ca97e259f2375761a