### PR TITLE
Update scripts for JSON prompts

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,6 +2,7 @@
 
 This directory stores general reference material for the repository. Use
 `index.md` or `table-of-contents.md` for a complete table of contents that links to every prompt.
+All prompts are saved as `.json` files that conform to `prompt_schema.json`.
 
 ## Quick Links
 

--- a/prompt_tools/L5_refactor-reindex-prompts.md
+++ b/prompt_tools/L5_refactor-reindex-prompts.md
@@ -40,7 +40,7 @@ You are an autonomous coding agent tasked with making every prompt in the GitHub
    ```
 
 1. **Enumerate prompt files**
-   ▸ Recursively collect all `*.md` files **excluding**:
+   ▸ Recursively collect all `*.json` files **excluding**:
 
    * any `overview.md`
    * any file inside `docs/`
@@ -61,7 +61,7 @@ You are an autonomous coding agent tasked with making every prompt in the GitHub
    For each oversize file:
 
    * Split at the highest-level Markdown heading that keeps every part ≤ `MAX_TOKENS_PER_PROMPT / 2`.
-   * Name parts `<originalStem>_part-01.md`, `…_part-NN.md`.
+   * Name parts `<originalStem>_part-01.json`, `…_part-NN.json`.
    * In each new part add a front-matter banner:
 
      ```md

--- a/prompt_tools/L5_standardize-prompt-files.md
+++ b/prompt_tools/L5_standardize-prompt-files.md
@@ -70,10 +70,10 @@ Links or relative paths to supporting docs/resources.
 ## Migration Workflow
 
 1. **Clone** the repo and create a new branch (default: `feat/standardize-prompt-format`).
-1. **Iterate** through every `*.md` file inside prompt directories:
+1. **Iterate** through every `*.json` file inside prompt directories:
 
-   * Detect existing headings; map their content to the new schema.
-   * Add or update YAML front‑matter (preserve original dates unless instructed otherwise).
+   * Verify all required fields match `docs/prompt_schema.json`.
+   * Add missing metadata values (preserve original dates unless instructed otherwise).
    * Move any unmapped text under **Additional Notes**.
 1. **Run** `./scripts/validate_json.sh` to ensure JSON linting passes.
 1. **Commit** changes in logical chunks and push the branch.

--- a/scripts/generate_overviews.py
+++ b/scripts/generate_overviews.py
@@ -3,20 +3,20 @@
 
 from pathlib import Path
 import sys
+import json
 
 ROOT = Path(__file__).resolve().parents[1]
 EXCLUDE_DIRS = {"docs", "scripts", ".github"}
 
 
-def heading_from_file(path: Path) -> str:
-    """Return first Markdown heading or fallback to filename."""
+def title_from_json(path: Path) -> str:
+    """Return prompt title from a JSON file or fallback to filename."""
     try:
-        with path.open("r", encoding="utf-8") as f:
-            for line in f:
-                stripped = line.strip()
-                if stripped.startswith("#"):
-                    return stripped.lstrip("#").strip()
-    except FileNotFoundError:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        title = data.get("title")
+        if title:
+            return str(title).strip()
+    except Exception:
         pass
     name = path.stem
     if name.split("_", 1)[0].isdigit():
@@ -27,10 +27,8 @@ def heading_from_file(path: Path) -> str:
 def generate_overview(directory: Path) -> str:
     title = directory.name.replace("_", " ").title()
     lines = [f"# {title} Overview", ""]
-    for file in sorted(directory.glob("*.md")):
-        if file.name.lower() in {"overview.md", "readme.md"}:
-            continue
-        heading = heading_from_file(file)
+    for file in sorted(directory.glob("*.json")):
+        heading = title_from_json(file)
         lines.append(f"- [{heading}]({file.name})")
     return "\n".join(lines).rstrip() + "\n"
 

--- a/scripts/standardize_c_prompts.py
+++ b/scripts/standardize_c_prompts.py
@@ -1,112 +1,45 @@
-import re
+import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 TODAY = "2025-07-18"
 AUTHOR = "fderuiter"
 
-# Map headings to standardized versions
-HEADING_MAP = {
-    'goal': 'Purpose',
-    'objective': 'Purpose',
-    'context / background': 'Context',
-    'context': 'Context',
-    'background': 'Context',
-    'instructions': 'Instructions',
-    'additional notes': 'Additional Notes',
-    'example usage': 'Example Usage',
-    'references': 'References',
-}
+REQUIRED_SECTIONS = [
+    "purpose",
+    "context",
+    "instructions",
+    "inputs",
+    "output_format",
+]
+OPTIONAL_SECTIONS = ["additional_notes", "example_usage", "references"]
 
-for d in sorted([p for p in ROOT.iterdir() if p.is_dir() and p.name.startswith('c')]):
-    for path in sorted(d.glob('*.md')):
-        if path.name.lower() == 'overview.md':
-            continue
-        text = path.read_text(encoding='utf-8')
-        lines = text.splitlines()
-        if lines and lines[0].strip() == '---':
-            # strip existing front matter
-            end = 1
-            while end < len(lines) and lines[end].strip() != '---':
-                end += 1
-            lines = lines[end+1:]
-        # remove leading comments
-        while lines and lines[0].strip().startswith('<!--'):
-            # keep comment after
-            lines.pop(0)
-        # extract title
-        title = None
-        body_lines = []
-        for line in lines:
-            if title is None and line.startswith('#'):
-                title = line.lstrip('#').strip()
-                continue
-            body_lines.append(line)
-        if title is None:
-            title = path.stem.replace('_', ' ').title()
-            body_lines = lines
-        # categorize lines by headings
-        sections = {}
-        current = 'Instructions'
-        sections[current] = []
-        for line in body_lines:
-            m = re.match(r'^##+\s*(.+)', line)
-            if m:
-                heading = m.group(1).strip().lower()
-                heading = HEADING_MAP.get(heading, heading.title())
-                current = heading
-                sections.setdefault(current, [])
-            else:
-                sections[current].append(line)
-        # ensure all required sections exist
-        for h in ['Purpose', 'Context', 'Instructions', 'Inputs', 'Output Format', 'Additional Notes']:
-            sections.setdefault(h, [])
-        # trim leading/trailing blank lines in each section
-        for key, lines_list in sections.items():
-            while lines_list and not lines_list[0].strip():
-                lines_list.pop(0)
-            while lines_list and not lines_list[-1].strip():
-                lines_list.pop()
-        # try to derive Purpose from first line of Instructions if empty
-        if not sections['Purpose'] and sections['Instructions']:
-            first_line = ''
-            idx = 0
-            for i, line in enumerate(sections['Instructions']):
-                stripped = line.strip().strip('*').strip('"')
-                if stripped:
-                    first_line = stripped
-                    idx = i
-                    break
-            if first_line:
-                sections['Purpose'] = [first_line]
-                sections['Instructions'] = sections['Instructions'][idx+1:]
-        # build markdown
-        id_ = path.stem.replace('_', '-').lower()
-        front_matter = [
-            '---',
-            f'id: {id_}',
-            f'title: {title}',
-            f'category: {d.name}',
-            f'author: {AUTHOR}',
-            f'created: {TODAY}',
-            f'last_modified: {TODAY}',
-            'tested_model: gpt-4',
-            'temperature: 0.2',
-            'tags: []',
-            '---',
-            '',
-            f'# {title}',
-            ''
-        ]
-        content_lines = []
-        order = ['Purpose', 'Context', 'Instructions', 'Inputs', 'Output Format', 'Additional Notes', 'Example Usage', 'References']
-        for h in order:
-            if h in sections:
-                content_lines.append(f'## {h}')
-                if sections[h] and sections[h][0].strip():
-                    content_lines.append('')
-                content_lines.extend(sections[h])
-                content_lines.append('')
-        new_text = '\n'.join(front_matter + content_lines).rstrip() + '\n'
-        path.write_text(new_text, encoding='utf-8')
-        print('Standardized', path)
+for d in sorted([p for p in ROOT.iterdir() if p.is_dir() and p.name.startswith("c")]):
+    for path in sorted(d.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        prompt = data.get("prompt", {})
+        changed = False
+
+        for key in REQUIRED_SECTIONS:
+            if key not in prompt:
+                prompt[key] = ""
+                changed = True
+        for key in OPTIONAL_SECTIONS:
+            prompt.setdefault(key, "")
+
+        if data.get("author") is None:
+            data["author"] = AUTHOR
+            changed = True
+        if data.get("category") != d.name:
+            data["category"] = d.name
+            changed = True
+        if data.get("last_modified") != TODAY:
+            data["last_modified"] = TODAY
+            changed = True
+
+        data["prompt"] = prompt
+
+        if changed:
+            path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+            print("Standardized", path)
+


### PR DESCRIPTION
## Summary
- update generate_overviews.py to read JSON metadata
- rewrite standardize_c_prompts.py to operate on JSON files
- note JSON file format in docs/overview.md
- clarify JSON workflow in L5_standardize-prompt-files.md
- adjust L5_refactor-reindex-prompts.md for JSON filenames

## Testing
- `./scripts/validate_json.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fd89379d8832cb42044338f39a792