### PR TITLE
Update workflows to validate JSON only

### DIFF
--- a/.github/workflows/fix-markdown-issues.yml
+++ b/.github/workflows/fix-markdown-issues.yml
@@ -4,14 +4,12 @@ name: Fix Markdown Issues
 on:
   push:
     paths:
-      - '**/*.md'
-      - 'todo_fix.md'
+      - '**/*.json'
       - '.github/workflows/fix-markdown-issues.yml'
       - 'scripts/fix_markdown_issues.py'
   pull_request:
     paths:
-      - '**/*.md'
-      - 'todo_fix.md'
+      - '**/*.json'
       - '.github/workflows/fix-markdown-issues.yml'
       - 'scripts/fix_markdown_issues.py'
 

--- a/.github/workflows/generate-overviews.yml
+++ b/.github/workflows/generate-overviews.yml
@@ -4,12 +4,12 @@ name: Generate Overviews
 on:
   push:
     paths:
-      - '**/*.md'
+      - '**/*.json'
       - '.github/workflows/generate-overviews.yml'
       - 'scripts/generate_overviews.py'
   pull_request:
     paths:
-      - '**/*.md'
+      - '**/*.json'
       - '.github/workflows/generate-overviews.yml'
       - 'scripts/generate_overviews.py'
 

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -6,7 +6,6 @@ on:
     branches: ["main"]
   pull_request:
     paths:
-      - '**/*.md'
       - '**/*.json'
 
 jobs:
@@ -22,6 +21,10 @@ jobs:
           python-version: '3.x'
       - name: Update documentation index
         run: python3 scripts/update_docs_index.py
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Validate JSON
+        run: ./scripts/validate_json.sh
       - name: Check for changes
         id: diff
         run: |


### PR DESCRIPTION
## Summary
- trigger repo workflows on JSON changes instead of Markdown
- run JSON validation in docs workflow

## Testing
- `./scripts/validate_json.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fdb6702e0832cbf681ac5dec4babd