### PR TITLE
Update docs index generator to use JSON metadata

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -4,6 +4,8 @@ name: Update Docs Index
 on:
   push:
     branches: ["main"]
+    paths:
+      - '**/*.json'
   pull_request:
     paths:
       - '**/*.json'


### PR DESCRIPTION
## Summary
- rewrite `scripts/update_docs_index.py` to read prompt category and title from JSON metadata
- only run the docs update workflow when JSON files change

## Testing
- `python3 scripts/update_docs_index.py --check`
- `./scripts/validate_json.sh`

------
https://chatgpt.com/codex/tasks/task_e_687feb92e6b4832ca432c4688317a649