### PR TITLE
feat: add YAML support to prompt scripts

### DIFF
--- a/scripts/check_prompts.py
+++ b/scripts/check_prompts.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python3
-"""Repository checks for prompt files."""
+"""Repository checks for prompt files.
 
+This utility originally handled only legacy JSON prompts. As the
+repository transitions to YAML-based prompts (``*.prompt.yaml`` and
+``*.prompt.yml``), the script now detects both formats and performs basic
+syntax validation using ``json`` and ``yaml`` parsers.
+"""
+
+import json
 import re
 from pathlib import Path
+
+import yaml
 
 OVERVIEW_NAME = "overview.md"  # documentation stays Markdown
 
@@ -10,8 +19,8 @@ ROOT = Path(__file__).resolve().parents[1]
 EXCLUDE_DIRS = {"docs", "scripts", ".github", "prompt_tools"}
 
 
-NUMERIC_RE = re.compile(r"^\d\d_.*\.json$")
-LEVEL_RE = re.compile(r"^L\d+_.*\.json$")
+NUMERIC_RE = re.compile(r"^\d\d_.*\.(json|prompt\.ya?ml)$", re.IGNORECASE)
+LEVEL_RE = re.compile(r"^L\d+_.*\.(json|prompt\.ya?ml)$", re.IGNORECASE)
 
 
 def check_overview(directory: Path) -> bool:
@@ -29,8 +38,26 @@ def check_files(directory: Path) -> bool:
         name = file.name
         if name.lower() in {OVERVIEW_NAME, "readme.md"}:
             continue
-        if file.suffix.lower() != ".json":
-            print(f"{file} is not a JSON file")
+
+        lower_name = name.lower()
+        is_json = lower_name.endswith(".json")
+        is_yaml = lower_name.endswith(".prompt.yaml") or lower_name.endswith(
+            ".prompt.yml"
+        )
+
+        if not (is_json or is_yaml):
+            print(f"{file} is not a recognised prompt file")
+            ok = False
+            continue
+
+        try:
+            text = file.read_text(encoding="utf-8")
+            if is_json:
+                json.loads(text)
+            else:
+                yaml.safe_load(text)
+        except Exception as exc:  # pragma: no cover - simple validation
+            print(f"Failed to parse {file}: {exc}")
             ok = False
             continue
         if directory.name == "agentic_coding" and not NUMERIC_RE.match(name):

--- a/scripts/generate_overviews.py
+++ b/scripts/generate_overviews.py
@@ -5,22 +5,33 @@ from pathlib import Path
 import sys
 import json
 
+import yaml
+
 OVERVIEW_NAME = "overview.md"  # documentation remains in Markdown
 
 ROOT = Path(__file__).resolve().parents[1]
 EXCLUDE_DIRS = {"docs", "scripts", ".github"}
 
 
-def title_from_json(path: Path) -> str:
-    """Return prompt title from a JSON file or fallback to filename."""
+def title_from_prompt(path: Path) -> str:
+    """Return prompt title from a JSON or YAML file or fallback to filename."""
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        title = data.get("title")
+        text = path.read_text(encoding="utf-8")
+        if path.name.lower().endswith(".json"):
+            data = json.loads(text)
+            title = data.get("title") or data.get("name")
+        else:
+            data = yaml.safe_load(text) or {}
+            title = data.get("name") or data.get("title")
         if title:
             return str(title).strip()
     except Exception:
         pass
-    name = path.stem
+    name = path.name
+    for ext in (".prompt.yaml", ".prompt.yml", ".json"):
+        if name.lower().endswith(ext):
+            name = name[: -len(ext)]
+            break
     if name.split("_", 1)[0].isdigit():
         name = name.split("_", 1)[1]
     return name.replace("_", " ").title()
@@ -29,8 +40,11 @@ def title_from_json(path: Path) -> str:
 def generate_overview(directory: Path) -> str:
     title = directory.name.replace("_", " ").title()
     lines = [f"# {title} Overview", ""]
-    for file in sorted(directory.glob("*.json")):
-        heading = title_from_json(file)
+    prompt_files = []
+    for pattern in ("*.prompt.yaml", "*.prompt.yml", "*.json"):
+        prompt_files.extend(directory.glob(pattern))
+    for file in sorted(prompt_files):
+        heading = title_from_prompt(file)
         lines.append(f"- [{heading}]({file.name})")
     return "\n".join(lines).rstrip() + "\n"
 

--- a/scripts/overview.md
+++ b/scripts/overview.md
@@ -1,6 +1,7 @@
 # Scripts Overview
 
-Utility scripts for repository maintenance live here. The `validate_json.sh` script verifies JSON formatting across the project.
+Utility scripts for repository maintenance live here. The `validate_json.sh`
+script verifies JSON and YAML formatting across the project.
 
 The `update_docs_index.py` script regenerates `docs/index.md` and
 `docs/table-of-contents.md` by scanning all prompt folders. Use the

--- a/scripts/update_docs_index.py
+++ b/scripts/update_docs_index.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Update `docs/index.md` and `docs/table-of-contents.md` from JSON metadata."""
+"""Update `docs/index.md` and `docs/table-of-contents.md` from prompt metadata."""
 
 from __future__ import annotations
 
@@ -9,17 +9,26 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 DOCS_DIR = ROOT / "docs"
 EXCLUDE = {"docs", "scripts", ".github"}
+PROMPT_EXTENSIONS = (".prompt.yaml", ".prompt.yml", ".json")
 
 
 def read_meta(path: Path) -> tuple[str, str]:
     """Return category and title from a prompt file."""
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+        lower = path.name.lower()
+        if lower.endswith(".json"):
+            data = json.loads(text)
+            title = str(data.get("title") or data.get("name") or "").strip()
+        else:
+            data = yaml.safe_load(text) or {}
+            title = str(data.get("name") or data.get("title") or "").strip()
         category = str(data.get("category") or path.parent.name)
-        title = str(data.get("title") or "").strip()
     except Exception:
         category = path.parent.name
         title = ""
@@ -37,13 +46,14 @@ def read_meta(path: Path) -> tuple[str, str]:
 def collect_prompts() -> dict[str, list[tuple[Path, str]]]:
     """Group prompt file paths by category."""
     groups: dict[str, list[tuple[Path, str]]] = defaultdict(list)
-    for path in ROOT.rglob("*.json"):
-        if not path.is_file():
-            continue
-        if any(part in EXCLUDE for part in path.parts):
-            continue
-        category, title = read_meta(path)
-        groups[category].append((path, title))
+    for ext in PROMPT_EXTENSIONS:
+        for path in ROOT.rglob(f"*{ext}"):
+            if not path.is_file():
+                continue
+            if any(part in EXCLUDE for part in path.parts):
+                continue
+            category, title = read_meta(path)
+            groups[category].append((path, title))
     # sort files within each category
     for cat in groups:
         groups[cat].sort(key=lambda t: t[0])

--- a/scripts/validate_json.sh
+++ b/scripts/validate_json.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Validate JSON prompt files and documentation index.
-# Requires 'jq' and Python 3.
+# Validate prompt files and documentation index.
+# Requires 'jq', 'yamllint', and Python 3.
 
 command -v jq >/dev/null 2>&1 || { echo "Error: jq is not installed" >&2; exit 1; }
+command -v yamllint >/dev/null 2>&1 || { echo "Error: yamllint is not installed" >&2; exit 1; }
 
 # Ensure docs/index.md and docs/table-of-contents.md are current.
 python3 scripts/update_docs_index.py --check
@@ -14,4 +15,9 @@ while IFS= read -r -d '' file; do
     jq -e '.' "$file" >/dev/null
 done < <(find . -name '*.json' -not -path './.git/*' -print0)
 
-echo "All JSON files validated"
+# Validate YAML prompt files
+while IFS= read -r -d '' file; do
+    yamllint -s "$file"
+done < <(find . \( -name '*.prompt.yaml' -o -name '*.prompt.yml' \) -not -path './.git/*' -print0)
+
+echo "All prompt files validated"


### PR DESCRIPTION
## Summary
- allow maintenance scripts to read `.prompt.yaml` files and validate syntax
- lint prompt files with `yamllint` in validation script
- document that validation covers JSON and YAML prompts

## Testing
- `python scripts/check_prompts.py`
- `python scripts/update_docs_index.py --check`
- `yamllint **/*.prompt.yaml`
- `bash scripts/validate_json.sh`


------
https://chatgpt.com/codex/tasks/task_e_689cebefa4c8832c97a218ce745e1b37