### PR TITLE
Fix YAML description for go/no-go vote prompt

### DIFF
--- a/design_prompts/02_email_assistant_go_no_go_vote.prompt.yaml
+++ b/design_prompts/02_email_assistant_go_no_go_vote.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: AI Email Assistant Go/No-Go Vote
-description: Personas: UX designer, data scientist, CFO. Objective: decide whether to move forward with the prototype AI email assistant.
+description: |
+  Personas: UX designer, data scientist, CFO. Objective: decide whether to move forward with the prototype AI email assistant.
 model: gpt-4o
 modelParameters:
   temperature: 0.2


### PR DESCRIPTION
## Summary
- quote description in `design_prompts/02_email_assistant_go_no_go_vote.prompt.yaml` to ensure valid YAML parsing
- ran repo-wide JSON↔️YAML comparison noting structural differences from legacy JSON format
- ran `yamllint` across prompt files (fails: trailing spaces in unrelated prompts)

## Testing
- `python - <<'PY' ... PY` (JSON/YAML comparison; mismatches due to schema differences)
- `yamllint **/*.prompt.yaml` *(fails: trailing spaces in various files)*
- `yamllint design_prompts/02_email_assistant_go_no_go_vote.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689d004fdd8c832ca9683f132ca88108