### PR TITLE
Stop triggering workflows on removed JSON files

### DIFF
--- a/.github/workflows/fix-markdown-issues.yml
+++ b/.github/workflows/fix-markdown-issues.yml
@@ -6,14 +6,12 @@ on:
     paths:
       - '**/*.prompt.yaml'
       - '**/*.prompt.yml'
-      - '**/*.json'
       - '.github/workflows/fix-markdown-issues.yml'
       - 'scripts/fix_markdown_issues.py'
   pull_request:
     paths:
       - '**/*.prompt.yaml'
       - '**/*.prompt.yml'
-      - '**/*.json'
       - '.github/workflows/fix-markdown-issues.yml'
       - 'scripts/fix_markdown_issues.py'
 

--- a/.github/workflows/generate-overviews.yml
+++ b/.github/workflows/generate-overviews.yml
@@ -6,14 +6,12 @@ on:
     paths:
       - '**/*.prompt.yaml'
       - '**/*.prompt.yml'
-      - '**/*.json'
       - '.github/workflows/generate-overviews.yml'
       - 'scripts/generate_overviews.py'
   pull_request:
     paths:
       - '**/*.prompt.yaml'
       - '**/*.prompt.yml'
-      - '**/*.json'
       - '.github/workflows/generate-overviews.yml'
       - 'scripts/generate_overviews.py'
 

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -6,14 +6,12 @@ on:
     paths:
       - '**/*.prompt.yaml'
       - '**/*.prompt.yml'
-      - '**/*.json'
       - '.github/workflows/repo-checks.yml'
       - 'scripts/check_prompts.py'
   pull_request:
     paths:
       - '**/*.prompt.yaml'
       - '**/*.prompt.yml'
-      - '**/*.json'
       - '.github/workflows/repo-checks.yml'
       - 'scripts/check_prompts.py'
 

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -7,12 +7,10 @@ on:
     paths:
       - '**/*.prompt.yaml'
       - '**/*.prompt.yml'
-      - '**/*.json'
   pull_request:
     paths:
       - '**/*.prompt.yaml'
       - '**/*.prompt.yml'
-      - '**/*.json'
 
 jobs:
   update-docs:


### PR DESCRIPTION
## Summary
- remove `**/*.json` watchers from repo-checks, update-docs, generate-overviews and fix-markdown-issues workflows

## Testing
- `yamllint .github/workflows/repo-checks.yml .github/workflows/update-docs.yml .github/workflows/generate-overviews.yml .github/workflows/fix-markdown-issues.yml`


------
https://chatgpt.com/codex/tasks/task_e_689e1207aa64832cbd3bb51e04ab9109