### PR TITLE
Archive JSON to YAML migration doc

### DIFF
--- a/docs/json_to_yaml_migration.md
+++ b/docs/json_to_yaml_migration.md
@@ -1,0 +1,9 @@
+# JSON to YAML Migration (Historical)
+
+> **Status:** Archived. Prompts in this repository are now stored exclusively in YAML.
+>
+> This document remains for historical reference.
+
+Earlier versions of this repository stored prompts as `.json` files. A migration effort converted all prompts to the `.prompt.yaml` format, simplifying maintenance and enabling richer metadata.
+
+Since the migration is complete, all prompts are now YAML-only. New prompts must be authored as `.prompt.yaml` or `.prompt.yml` files.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -20,5 +20,6 @@ retired.
 - [Project Starter Pack](../starter_pack/overview.md)
 - [Codex Prompts](../codex_prompts/overview.md)
 - [GLP Prompts](../glp_prompts/overview.md)
+- [JSON to YAML Migration (historical)](json_to_yaml_migration.md)
 
 Add any new guidance here as the repository grows.


### PR DESCRIPTION
## Summary
- add historical note about the repository's JSON-to-YAML migration
- link to this historical document from the docs overview

## Testing
- `python scripts/update_docs_index.py`
- `yamllint $(git ls-files '*.prompt.yaml')`


------
https://chatgpt.com/codex/tasks/task_e_689e1326e924832ca50cc6b0ca691981