### PR TITLE
Add testData and evaluators for testing prompts

### DIFF
--- a/testing_prompts/01_e2e_test_discovery.prompt.yaml
+++ b/testing_prompts/01_e2e_test_discovery.prompt.yaml
@@ -40,3 +40,15 @@ messages:
       7. Environment & Tooling
       8. Proposed E2E Test Suite
       9. Coverage Gaps & Risk Register
+
+testData:
+  - input: |
+      project_name: Cartify
+      languages_frameworks: Django, React
+      business_goal: Enable online shopping for users
+    expected: |
+      Repository Overview
+evaluators:
+  - name: Output starts with 'Repository Overview'
+    string:
+      startsWith: 'Repository Overview'

--- a/testing_prompts/02_design_verification_test_plan.prompt.yaml
+++ b/testing_prompts/02_design_verification_test_plan.prompt.yaml
@@ -27,3 +27,13 @@ messages:
       3. Detailed test procedures with numbered steps
       4. Rationale for each verification method
       5. Reference list formatted per ISO 13485 §7.3.6
+
+testData:
+  - input: |
+      device_name: Wearable Glucose Monitor
+    expected: |
+      Introduction
+evaluators:
+  - name: Output starts with 'Introduction'
+    string:
+      startsWith: 'Introduction'

--- a/testing_prompts/03_human_factors_validation_study_protocol.prompt.yaml
+++ b/testing_prompts/03_human_factors_validation_study_protocol.prompt.yaml
@@ -34,3 +34,14 @@ messages:
       6. Risk-mitigation triggers and stop rules
       7. Data analysis plan
       8. Deliverables and acceptance criteria
+
+testData:
+  - input: |
+      device_name: Smart Inhaler
+      class: II
+    expected: |
+      Purpose and regulatory basis
+evaluators:
+  - name: Output starts with 'Purpose and regulatory basis'
+    string:
+      startsWith: 'Purpose and regulatory basis'

--- a/testing_prompts/04_risk_based_test_case_suite.prompt.yaml
+++ b/testing_prompts/04_risk_based_test_case_suite.prompt.yaml
@@ -24,3 +24,16 @@ messages:
       1. Markdown traceability matrix linking hazards, controls and test cases
       2. Detailed test-case catalog with objectives, setups, steps, expected results and sample size justification
       3. Summary of uncovered high-risk areas requiring additional controls
+
+testData:
+  - input: |
+      device_name: Cardiac Monitor
+      hazard_analysis_table: |
+        Hazard_ID | Hazard | Control
+        H1        | Battery failure | Backup battery
+    expected: |
+      Risk-Control Traceability Matrix
+evaluators:
+  - name: Output starts with 'Risk-Control Traceability Matrix'
+    string:
+      startsWith: 'Risk-Control Traceability Matrix'


### PR DESCRIPTION
## Summary
- add sample testData inputs and expected outputs for testing prompts
- include simple string-based evaluators to verify generated section headers

## Testing
- `yamllint testing_prompts/*.prompt.yaml`

------
https://chatgpt.com/codex/tasks/task_e_689e1b16bf60832cb35a7292c56f1a90