### PR TITLE
Add prompt schema validation script

### DIFF
--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -8,12 +8,14 @@ on:
       - '**/*.prompt.yml'
       - '.github/workflows/repo-checks.yml'
       - 'scripts/check_prompts.py'
+      - 'scripts/validate_prompt_schema.py'
   pull_request:
     paths:
       - '**/*.prompt.yaml'
       - '**/*.prompt.yml'
       - '.github/workflows/repo-checks.yml'
       - 'scripts/check_prompts.py'
+      - 'scripts/validate_prompt_schema.py'
 
 jobs:
   verify:
@@ -26,3 +28,5 @@ jobs:
           python-version: '3.x'
       - name: Run repository checks
         run: python3 scripts/check_prompts.py
+      - name: Validate prompt schema
+        run: python3 scripts/validate_prompt_schema.py

--- a/prompt_tools/L5_standardize-prompt-files.md
+++ b/prompt_tools/L5_standardize-prompt-files.md
@@ -77,6 +77,7 @@ Links or relative paths to supporting docs/resources.
    * Add missing metadata values (preserve original dates unless instructed otherwise).
    * Move any unmapped text under **Additional Notes**.
 1. **Run** `./scripts/validate_prompts.sh` to ensure YAML linting passes.
+1. **Validate** prompt schema with `python scripts/validate_prompt_schema.py`.
 1. **Commit** changes in logical chunks and push the branch.
 1. **Open** a PR and request review from repository maintainers.
 

--- a/scripts/validate_prompt_schema.py
+++ b/scripts/validate_prompt_schema.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Validate required fields in prompt YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Tuple, Union
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_PATHS: Tuple[Tuple[Union[str, int], ...], ...] = (
+    ("name",),
+    ("description",),
+    ("model",),
+    ("modelParameters", "temperature"),
+    ("messages", 0, "content"),
+    ("messages", 1, "content"),
+    ("testData",),
+    ("evaluators",),
+)
+
+
+def iter_prompt_files() -> Iterable[Path]:
+    """Yield all prompt files in the repository."""
+    patterns = ("*.prompt.yaml", "*.prompt.yml")
+    for pattern in patterns:
+        for path in ROOT.rglob(pattern):
+            if path.is_file():
+                yield path
+
+
+def has_path(data: object, path: Tuple[Union[str, int], ...]) -> bool:
+    """Check if ``data`` has ``path`` nested keys/indexes."""
+    try:
+        for key in path:
+            if isinstance(key, int):
+                data = data[key]
+            else:
+                data = data[key]
+    except (KeyError, IndexError, TypeError):
+        return False
+    return True
+
+
+def validate_file(file_path: Path) -> bool:
+    """Validate a single prompt file and report missing keys."""
+    try:
+        content = yaml.safe_load(file_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - simple validation
+        print(f"Failed to parse {file_path}: {exc}")
+        return False
+
+    missing = [".".join(map(str, p)) for p in REQUIRED_PATHS if not has_path(content, p)]
+    if missing:
+        print(f"{file_path}: missing {', '.join(missing)}")
+        return False
+    return True
+
+
+def main() -> int:
+    ok = True
+    for file_path in iter_prompt_files():
+        if not validate_file(file_path):
+            ok = False
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add script to verify required fields across `*.prompt.yaml`
- run schema validation in `repo-checks` workflow
- document schema validation step in standardization guide

## Testing
- `python scripts/check_prompts.py`
- `python scripts/validate_prompt_schema.py` *(fails: missing testData/evaluators in many prompts)*

------
https://chatgpt.com/codex/tasks/task_e_689e1b36d590832ca164f82364ef7880