### PR TITLE
Add role guidance to prompts with empty system messages

### DIFF
--- a/chemical_characterization_prompts/01_design_the_study.prompt.yaml
+++ b/chemical_characterization_prompts/01_design_the_study.prompt.yaml
@@ -12,6 +12,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are an analytical chemist planning extractables and leachables studies in
+      line with ISO 10993-18 and current FDA guidance.
   - role: user
     content: |-
       1. Summarize device configuration and materials (include additives, coatings, sterilization).

--- a/chemical_characterization_prompts/02_interpret_the_chemistry_assess_risk.prompt.yaml
+++ b/chemical_characterization_prompts/02_interpret_the_chemistry_assess_risk.prompt.yaml
@@ -8,6 +8,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a board-certified toxicologist interpreting extractables and leachables
+      data to evaluate patient risk.
   - role: user
     content: |-
       I will supply the extractables/leachables results table that was generated per ISO 10993-18. Using those data:

--- a/chemical_characterization_prompts/03_write_the_regulatory_summary.prompt.yaml
+++ b/chemical_characterization_prompts/03_write_the_regulatory_summary.prompt.yaml
@@ -9,6 +9,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a regulatory affairs specialist summarizing chemical characterization
+      findings for 510(k) submissions.
   - role: user
     content: |-
       Produce a 2-3-page executive summary that:

--- a/clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml
+++ b/clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml
@@ -8,6 +8,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a clinical safety specialist preparing concise summaries for EU MDR
+      clinical evaluation reports.
   - role: user
     content: |-
       {{input}}

--- a/clinical_safety_prompts/03_post_market_safety_signal_trending.prompt.yaml
+++ b/clinical_safety_prompts/03_post_market_safety_signal_trending.prompt.yaml
@@ -7,6 +7,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a safety analyst trending post-market data to surface emerging
+      signals.
   - role: user
     content: |-
       {{input}}

--- a/data_management_prompts/01_unified_data_cleansing.prompt.yaml
+++ b/data_management_prompts/01_unified_data_cleansing.prompt.yaml
@@ -8,6 +8,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a clinical data manager outlining unified data cleansing strategies
+      for trial datasets.
   - role: user
     content: |-
       {{input}}

--- a/data_management_prompts/02_regulatory_gap_analysis.prompt.yaml
+++ b/data_management_prompts/02_regulatory_gap_analysis.prompt.yaml
@@ -7,6 +7,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a compliance analyst identifying regulatory gaps in clinical data
+      management processes.
   - role: user
     content: |-
       {{input}}

--- a/data_management_prompts/03_data_architecture_blueprint.prompt.yaml
+++ b/data_management_prompts/03_data_architecture_blueprint.prompt.yaml
@@ -7,6 +7,7 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a data architect drafting blueprints for clinical data architectures.
   - role: user
     content: |-
       {{input}}

--- a/data_management_prompts/04_clinical_etl_mapping_spec.prompt.yaml
+++ b/data_management_prompts/04_clinical_etl_mapping_spec.prompt.yaml
@@ -7,6 +7,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are an ETL specialist defining mapping specifications for clinical data
+      pipelines.
   - role: user
     content: |-
       {{input}}

--- a/data_management_prompts/05_clinical_etl_transformation_qc.prompt.yaml
+++ b/data_management_prompts/05_clinical_etl_transformation_qc.prompt.yaml
@@ -7,6 +7,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a quality engineer specifying validation checks for clinical ETL
+      transformations.
   - role: user
     content: |-
       {{input}}

--- a/data_management_prompts/06_clinical_etl_pipeline_review.prompt.yaml
+++ b/data_management_prompts/06_clinical_etl_pipeline_review.prompt.yaml
@@ -7,6 +7,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a reviewer evaluating clinical ETL pipelines for accuracy and
+      efficiency.
   - role: user
     content: |-
       {{input}}

--- a/data_management_prompts/07_phase_ii_oncology_dmp.prompt.yaml
+++ b/data_management_prompts/07_phase_ii_oncology_dmp.prompt.yaml
@@ -7,6 +7,7 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a data manager developing a Phase II oncology data management plan.
   - role: user
     content: |-
       {{input}}

--- a/data_management_prompts/08_decentralized_trial_risk_matrix.prompt.yaml
+++ b/data_management_prompts/08_decentralized_trial_risk_matrix.prompt.yaml
@@ -7,6 +7,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a risk analyst constructing risk matrices for decentralized
+      clinical trials.
   - role: user
     content: |-
       {{input}}

--- a/data_management_prompts/09_sop_gap_analysis.prompt.yaml
+++ b/data_management_prompts/09_sop_gap_analysis.prompt.yaml
@@ -7,6 +7,7 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a process auditor evaluating gaps in data management SOPs.
   - role: user
     content: |-
       {{input}}

--- a/design_prompts/01_design_md_template.prompt.yaml
+++ b/design_prompts/01_design_md_template.prompt.yaml
@@ -8,6 +8,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a software design assistant drafting Design.md templates that capture
+      problems, constraints, and key decisions.
   - role: user
     content: |-
       {{input}}

--- a/executive_prompts/15_hosting_cost_reduction_tot.prompt.yaml
+++ b/executive_prompts/15_hosting_cost_reduction_tot.prompt.yaml
@@ -7,6 +7,8 @@ modelParameters:
 messages:
   - role: system
     content: |
+      You are a cost-optimization strategist using tree-of-thought reasoning to
+      reduce hosting expenses.
   - role: user
     content: |-
       {{input}}


### PR DESCRIPTION
## Summary
- Add concise domain-specific system role guidance to 16 prompts across design, chemical characterization, executive, data management, and clinical safety directories
- Ensure all updated prompts pass yamllint syntax checks

## Testing
- `yamllint design_prompts/01_design_md_template.prompt.yaml`
- `yamllint chemical_characterization_prompts/01_design_the_study.prompt.yaml`
- `yamllint chemical_characterization_prompts/02_interpret_the_chemistry_assess_risk.prompt.yaml`
- `yamllint chemical_characterization_prompts/03_write_the_regulatory_summary.prompt.yaml`
- `yamllint executive_prompts/15_hosting_cost_reduction_tot.prompt.yaml`
- `yamllint data_management_prompts/01_unified_data_cleansing.prompt.yaml`
- `yamllint data_management_prompts/02_regulatory_gap_analysis.prompt.yaml`
- `yamllint data_management_prompts/03_data_architecture_blueprint.prompt.yaml`
- `yamllint data_management_prompts/04_clinical_etl_mapping_spec.prompt.yaml`
- `yamllint data_management_prompts/05_clinical_etl_transformation_qc.prompt.yaml`
- `yamllint data_management_prompts/06_clinical_etl_pipeline_review.prompt.yaml`
- `yamllint data_management_prompts/07_phase_ii_oncology_dmp.prompt.yaml`
- `yamllint data_management_prompts/08_decentralized_trial_risk_matrix.prompt.yaml`
- `yamllint data_management_prompts/09_sop_gap_analysis.prompt.yaml`
- `yamllint clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml`
- `yamllint clinical_safety_prompts/03_post_market_safety_signal_trending.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e1be3f998832c924536bb53109ad4