### PR TITLE
Add placeholder evaluators to prompts with test data

### DIFF
--- a/adjudication_prompts/01_real_time_adjudication_dashboard.prompt.yaml
+++ b/adjudication_prompts/01_real_time_adjudication_dashboard.prompt.yaml
@@ -37,3 +37,4 @@ testData:
       - **Section 2:** Dashboard data model (table)
       - **Section 3:** Alert rules (bullets)
       - **Section 4:** Platform recommendations (table)
+evaluators: []

--- a/adjudication_prompts/02_source_document_endpoint_checklist.prompt.yaml
+++ b/adjudication_prompts/02_source_document_endpoint_checklist.prompt.yaml
@@ -32,3 +32,4 @@ testData:
     expected: |-
       - Markdown table per endpoint with columns: *Doc Type*, *Required?*, *Acceptable Formats*, *Notes*.
       - Numbered list of **Clarification Needed** items.
+evaluators: []

--- a/adjudication_prompts/03_analyze_adjudication_kpis.prompt.yaml
+++ b/adjudication_prompts/03_analyze_adjudication_kpis.prompt.yaml
@@ -36,3 +36,4 @@ testData:
       - **Metrics Summary Table**
       - Embedded charts or download links for each PNG
       - Bullet list of recommendations
+evaluators: []

--- a/agentic_coding/01_product_brief.prompt.yaml
+++ b/agentic_coding/01_product_brief.prompt.yaml
@@ -32,3 +32,4 @@ testData:
       context_notes: example_context_notes
     expected: |-
       Markdown sections titled **Vision**, **Key Features and Roadmap**, **Overall Architecture**, and **Additional Context**.
+evaluators: []

--- a/agentic_coding/02_project_brief_epic.prompt.yaml
+++ b/agentic_coding/02_project_brief_epic.prompt.yaml
@@ -36,3 +36,4 @@ testData:
       project_description: example_project_description
     expected: |-
       Markdown sections titled **Project Description**, **Key Features**, **Technical Entities & Data Models**, **Business Rules & Logic**, **Success Metrics**, and **Additional Implementation Details**.
+evaluators: []

--- a/agentic_coding/03_technical_implementation_plan.prompt.yaml
+++ b/agentic_coding/03_technical_implementation_plan.prompt.yaml
@@ -34,3 +34,4 @@ testData:
       technology_choices: example_technology_choices
     expected: |-
       Markdown sections for Architecture Breakdown, Libraries and Tools, Data Models & Specifications, Business Logic & Rules, Dependencies & Risk Analysis, and Implementation Steps.
+evaluators: []

--- a/agentic_coding/04_coding_session_guidelines.prompt.yaml
+++ b/agentic_coding/04_coding_session_guidelines.prompt.yaml
@@ -31,3 +31,4 @@ testData:
   - vars: {}
     expected: |-
       Clear Markdown checklist of steps completed during the session.
+evaluators: []

--- a/agentic_coding/05_project_review.prompt.yaml
+++ b/agentic_coding/05_project_review.prompt.yaml
@@ -28,3 +28,4 @@ testData:
   - vars: {}
     expected: |-
       Markdown checklist confirming each step was completed.
+evaluators: []

--- a/agentic_coding/06_project_memory.prompt.yaml
+++ b/agentic_coding/06_project_memory.prompt.yaml
@@ -25,3 +25,4 @@ testData:
   - vars: {}
     expected: |-
       Markdown file with sections **Current Project State** and **Contextual Notes**.
+evaluators: []

--- a/agentic_coding/06_todo_generation.prompt.yaml
+++ b/agentic_coding/06_todo_generation.prompt.yaml
@@ -24,3 +24,4 @@ testData:
   - vars: {}
     expected: |-
       Markdown checklist under **To-Do** and **Completed Tasks** sections.
+evaluators: []

--- a/agentic_coding/07_e2e_test_discovery.prompt.yaml
+++ b/agentic_coding/07_e2e_test_discovery.prompt.yaml
@@ -54,3 +54,4 @@ testData:
       1. Environment & Tooling
       1. Proposed E2E Test Suite
       1. Coverage Gaps & Risk Register
+evaluators: []

--- a/agentic_coding/07_folder_module_organization.prompt.yaml
+++ b/agentic_coding/07_folder_module_organization.prompt.yaml
@@ -30,3 +30,4 @@ testData:
       repo_path: example_repo_path
     expected: |-
       Markdown plan detailing the checklist, migration steps, validation commands, and follow-up prompts.
+evaluators: []

--- a/agentic_coding/07_requirements_prompt.prompt.yaml
+++ b/agentic_coding/07_requirements_prompt.prompt.yaml
@@ -36,3 +36,4 @@ testData:
       repository_url: example_repository_url
     expected: |-
       Return the finished `REQUIREMENTS.md` content only.
+evaluators: []

--- a/agentic_coding/08_reflexion_agent_bug_patch.prompt.yaml
+++ b/agentic_coding/08_reflexion_agent_bug_patch.prompt.yaml
@@ -25,3 +25,4 @@ testData:
       code: example_code
     expected: |-
       Markdown with code fences for the patch and a short rationale. Entire reply ≤ 120 words.
+evaluators: []

--- a/biological_safety_prompts/01_risk_assessment_expert.prompt.yaml
+++ b/biological_safety_prompts/01_risk_assessment_expert.prompt.yaml
@@ -29,3 +29,4 @@ testData:
       medical_device_type: example_medical_device_type
     expected: |-
       Markdown table summarizing hazards, risk level, and mitigation steps.
+evaluators: []

--- a/biological_safety_prompts/02_biological_safety_plan_developer.prompt.yaml
+++ b/biological_safety_prompts/02_biological_safety_plan_developer.prompt.yaml
@@ -30,3 +30,4 @@ testData:
       device_description: example_device_description
     expected: |-
       Bullet points and headings that form a ready-to-review plan.
+evaluators: []

--- a/biological_safety_prompts/03_regulatory_submission_support.prompt.yaml
+++ b/biological_safety_prompts/03_regulatory_submission_support.prompt.yaml
@@ -29,3 +29,4 @@ testData:
       device_description: example_device_description
     expected: |-
       Bullet points and tables suitable for inclusion in a submission dossier.
+evaluators: []

--- a/biological_safety_prompts/04_bep_builder.prompt.yaml
+++ b/biological_safety_prompts/04_bep_builder.prompt.yaml
@@ -29,3 +29,4 @@ testData:
       device_details: example_device_details
     expected: |-
       Executive-summary paragraph followed by a markdown table and bulleted notes.
+evaluators: []

--- a/biological_safety_prompts/05_comprehensive_test_matrix.prompt.yaml
+++ b/biological_safety_prompts/05_comprehensive_test_matrix.prompt.yaml
@@ -30,3 +30,4 @@ testData:
       device_materials: example_device_materials
     expected: |-
       Two-level markdown table followed by concise explanatory notes.
+evaluators: []

--- a/biological_safety_prompts/06_chemical_characterization_work_plan.prompt.yaml
+++ b/biological_safety_prompts/06_chemical_characterization_work_plan.prompt.yaml
@@ -32,3 +32,4 @@ testData:
       device_information: example_device_information
     expected: |-
       Numbered work plan followed by a short summary paragraph.
+evaluators: []

--- a/biosafety_prompts/01_risk_assessment_expert.prompt.yaml
+++ b/biosafety_prompts/01_risk_assessment_expert.prompt.yaml
@@ -29,3 +29,4 @@ testData:
       medical_device_type: example_medical_device_type
     expected: |-
       Markdown table summarizing hazards and mitigations.
+evaluators: []

--- a/biosafety_prompts/02_biological_safety_plan_developer.prompt.yaml
+++ b/biosafety_prompts/02_biological_safety_plan_developer.prompt.yaml
@@ -30,3 +30,4 @@ testData:
       device_description: example_device_description
     expected: |-
       Bullet points and headings forming a clear plan.
+evaluators: []

--- a/biosafety_prompts/03_regulatory_submission_support.prompt.yaml
+++ b/biosafety_prompts/03_regulatory_submission_support.prompt.yaml
@@ -29,3 +29,4 @@ testData:
       device_description: example_device_description
     expected: |-
       Bullet points and tables suitable for submission documentation.
+evaluators: []

--- a/bioskills_prompts/01_hands_on_procedure_coaching.prompt.yaml
+++ b/bioskills_prompts/01_hands_on_procedure_coaching.prompt.yaml
@@ -29,3 +29,4 @@ testData:
       procedure_name: example_procedure_name
     expected: |-
       Bullet list of steps and checkpoints.
+evaluators: []

--- a/bioskills_prompts/02_simulated_clinical_scenario_feedback.prompt.yaml
+++ b/bioskills_prompts/02_simulated_clinical_scenario_feedback.prompt.yaml
@@ -28,3 +28,4 @@ testData:
       procedure_notes: example_procedure_notes
     expected: |-
       Bullet points followed by a short reflective question.
+evaluators: []

--- a/bioskills_prompts/03_objective_skills_assessment.prompt.yaml
+++ b/bioskills_prompts/03_objective_skills_assessment.prompt.yaml
@@ -34,3 +34,4 @@ testData:
 
       | Criterion | Description | Pass threshold |
       |-----------|-------------|----------------|
+evaluators: []

--- a/biostatistics_prompts/01_statistical_analysis_plan_generator.prompt.yaml
+++ b/biostatistics_prompts/01_statistical_analysis_plan_generator.prompt.yaml
@@ -39,3 +39,4 @@ testData:
       factors: example_factors
     expected: |-
       Markdown document using H2 headings for each section.
+evaluators: []

--- a/biostatistics_prompts/02_time_to_event_analysis_coach.prompt.yaml
+++ b/biostatistics_prompts/02_time_to_event_analysis_coach.prompt.yaml
@@ -27,3 +27,4 @@ testData:
       dataset_path: example_dataset_path
     expected: |-
       Section A: conceptual walk-through (bullets). Section B: fenced R code block. Section C: interpretation and next steps (\u2264250 words).
+evaluators: []

--- a/biostatistics_prompts/03_peer_review_methods_checklist.prompt.yaml
+++ b/biostatistics_prompts/03_peer_review_methods_checklist.prompt.yaml
@@ -30,3 +30,4 @@ testData:
       manuscript_excerpt: example_manuscript_excerpt
     expected: |-
       GitHub-flavored markdown table followed by bullet lists.
+evaluators: []

--- a/biostatistics_prompts/04_universal_template_table_prompt.prompt.yaml
+++ b/biostatistics_prompts/04_universal_template_table_prompt.prompt.yaml
@@ -34,3 +34,4 @@ testData:
       dataset_path: example_dataset_path
     expected: |-
       Code block followed by the generated table.
+evaluators: []

--- a/biostatistics_prompts/05_dual_language_figure_prompt.prompt.yaml
+++ b/biostatistics_prompts/05_dual_language_figure_prompt.prompt.yaml
@@ -33,3 +33,4 @@ testData:
       dataset_path: example_dataset_path
     expected: |-
       Two pristine code blocks: first in R, then in SAS.
+evaluators: []

--- a/biostatistics_prompts/06_qc_listing_cross_check_prompt.prompt.yaml
+++ b/biostatistics_prompts/06_qc_listing_cross_check_prompt.prompt.yaml
@@ -31,3 +31,4 @@ testData:
       dataset_paths: example_dataset_paths
     expected: |-
       Three code blocks followed by a diff table or pass message.
+evaluators: []

--- a/biostatistics_prompts/07_study_design_statistical_approach.prompt.yaml
+++ b/biostatistics_prompts/07_study_design_statistical_approach.prompt.yaml
@@ -35,3 +35,4 @@ testData:
       regulatory_target: example_regulatory_target
     expected: |-
       Bullet summary followed by short explanatory paragraphs.
+evaluators: []

--- a/biostatistics_prompts/08_inclusion_exclusion_endpoints_sample_size.prompt.yaml
+++ b/biostatistics_prompts/08_inclusion_exclusion_endpoints_sample_size.prompt.yaml
@@ -33,3 +33,4 @@ testData:
       population_details: example_population_details
     expected: |-
       Bullet lists for criteria and endpoints followed by a short sample-size paragraph.
+evaluators: []

--- a/biostatistics_prompts/09_adaptive_design_interim_monitoring.prompt.yaml
+++ b/biostatistics_prompts/09_adaptive_design_interim_monitoring.prompt.yaml
@@ -30,3 +30,4 @@ testData:
       trial_details: example_trial_details
     expected: |-
       Bulleted recommendations followed by brief explanatory notes.
+evaluators: []

--- a/biostatistics_prompts/10_phase_ii_iii_sap_skeleton.prompt.yaml
+++ b/biostatistics_prompts/10_phase_ii_iii_sap_skeleton.prompt.yaml
@@ -31,3 +31,4 @@ testData:
       trial_overview: example_trial_overview
     expected: |-
       Markdown document with H2 headings, maximum 2,500 words.
+evaluators: []

--- a/biostatistics_prompts/10_sample_size_randomization_strategy.prompt.yaml
+++ b/biostatistics_prompts/10_sample_size_randomization_strategy.prompt.yaml
@@ -35,3 +35,4 @@ testData:
       dropout_rate: example_dropout_rate
     expected: |-
       Executive summary (≤150 words) followed by two tables: sample-size scenarios and randomization parameters. Conclude with a fenced R code block.
+evaluators: []

--- a/biostatistics_prompts/11_fda_missing_data_query_response.prompt.yaml
+++ b/biostatistics_prompts/11_fda_missing_data_query_response.prompt.yaml
@@ -35,3 +35,4 @@ testData:
       sap_references: example_sap_references
     expected: |-
       Word-style Markdown outline with H1/H2 sections plus the appendix table.
+evaluators: []

--- a/biostatistics_prompts/11_submission_ready_sap.prompt.yaml
+++ b/biostatistics_prompts/11_submission_ready_sap.prompt.yaml
@@ -37,3 +37,4 @@ testData:
       study_overview: example_study_overview
     expected: |-
       Markdown document with numbered sections and mock tables.
+evaluators: []

--- a/biostatistics_prompts/12_submission_ready_tlfs.prompt.yaml
+++ b/biostatistics_prompts/12_submission_ready_tlfs.prompt.yaml
@@ -38,3 +38,4 @@ testData:
       adlb_path: example_adlb_path
     expected: |-
       SAS code block(s) with header comments, followed by a QC checklist in a markdown table and brief usage notes (≤120 words).
+evaluators: []

--- a/brainstorming_prompts/01_reverse_brainstorming.prompt.yaml
+++ b/brainstorming_prompts/01_reverse_brainstorming.prompt.yaml
@@ -25,3 +25,4 @@ testData:
       problem: example_problem
     expected: |-
       Bulleted list plus markdown table.
+evaluators: []

--- a/business_development_prompts/01_emerging_market_opportunity_scan.prompt.yaml
+++ b/business_development_prompts/01_emerging_market_opportunity_scan.prompt.yaml
@@ -29,3 +29,4 @@ testData:
       market_data_sources: example_market_data_sources
     expected: |-
       Concise executive summary with bullet points and a short table if helpful.
+evaluators: []

--- a/business_development_prompts/01_market_intelligence_radar.prompt.yaml
+++ b/business_development_prompts/01_market_intelligence_radar.prompt.yaml
@@ -33,3 +33,4 @@ testData:
       company_size: example_company_size
     expected: |-
       Markdown table followed by a short summary paragraph.
+evaluators: []

--- a/business_development_prompts/02_rapid_proposal_builder.prompt.yaml
+++ b/business_development_prompts/02_rapid_proposal_builder.prompt.yaml
@@ -32,3 +32,4 @@ testData:
       client_name: example_client_name
     expected: |-
       Markdown document with headings and a budget table.
+evaluators: []

--- a/business_development_prompts/02_rfp_executive_summary_generator.prompt.yaml
+++ b/business_development_prompts/02_rfp_executive_summary_generator.prompt.yaml
@@ -30,3 +30,4 @@ testData:
       rfp_synopsis: example_rfp_synopsis
     expected: |-
       Single markdown section with concise paragraphs and bullet points as needed.
+evaluators: []

--- a/business_development_prompts/03_90_day_pipeline_health_review.prompt.yaml
+++ b/business_development_prompts/03_90_day_pipeline_health_review.prompt.yaml
@@ -30,3 +30,4 @@ testData:
       crm_csv: example_crm_csv
     expected: |-
       Markdown summary tables followed by bullet-point recommendations.
+evaluators: []

--- a/business_development_prompts/03_competitor_positioning_brief.prompt.yaml
+++ b/business_development_prompts/03_competitor_positioning_brief.prompt.yaml
@@ -29,3 +29,4 @@ testData:
       public_sources: example_public_sources
     expected: |-
       Markdown with two sections: a comparison table and a short narrative.
+evaluators: []

--- a/chemical_characterization_prompts/01_design_the_study.prompt.yaml
+++ b/chemical_characterization_prompts/01_design_the_study.prompt.yaml
@@ -28,3 +28,4 @@ testData:
   - input: ''
     expected: |-
       Completion follows instructions.
+evaluators: []

--- a/chemical_characterization_prompts/02_interpret_the_chemistry_assess_risk.prompt.yaml
+++ b/chemical_characterization_prompts/02_interpret_the_chemistry_assess_risk.prompt.yaml
@@ -31,3 +31,4 @@ testData:
   - input: ''
     expected: |-
       Completion follows instructions.
+evaluators: []

--- a/chemical_characterization_prompts/03_write_the_regulatory_summary.prompt.yaml
+++ b/chemical_characterization_prompts/03_write_the_regulatory_summary.prompt.yaml
@@ -26,3 +26,4 @@ testData:
   - input: ''
     expected: |-
       Completion follows instructions.
+evaluators: []


### PR DESCRIPTION
## Summary
- add empty `evaluators` arrays to prompts containing `testData`
- preserve existing `testData` sections across prompt directories

## Testing
- `yamllint adjudication_prompts agentic_coding biological_safety_prompts biosafety_prompts bioskills_prompts biostatistics_prompts brainstorming_prompts business_development_prompts chemical_characterization_prompts`
- `python scripts/validate_prompt_schema.py adjudication_prompts agentic_coding biological_safety_prompts biosafety_prompts bioskills_prompts biostatistics_prompts brainstorming_prompts business_development_prompts cfo_prompts chemical_characterization_prompts && echo "schema validation passed"` *(fails: unrelated prompts missing testData/evaluators)*
- `python - <<'PY'
from scripts.validate_prompt_schema import validate_file
from pathlib import Path
dirs = ["adjudication_prompts", "agentic_coding", "biological_safety_prompts", "biosafety_prompts", "bioskills_prompts", "biostatistics_prompts", "brainstorming_prompts", "business_development_prompts", "chemical_characterization_prompts", "cfo_prompts"]
failed = []
for d in dirs:
    for f in Path(d).glob('*.prompt.yaml'):
        if not validate_file(f):
            failed.append(f)
if failed:
    print('Failed:', failed)
else:
    print('All selected files valid')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689e1ee48bd4832c851ecae8fb3a8e95