### PR TITLE
Add placeholder test data and evaluators to prompts

### DIFF
--- a/clinical_data_prompts/01_discrepancy_detection_query_log.prompt.yaml
+++ b/clinical_data_prompts/01_discrepancy_detection_query_log.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Discrepancy Detection & Query Log Generator
-description: Examine a CSV dataset to detect discrepancies and generate a query
+description: Examine a CSV dataset to detect discrepancies and generate a query 
   log.
 model: gpt-4
 modelParameters:
@@ -24,3 +24,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_data_prompts/02_data_management_plan_section.prompt.yaml
+++ b/clinical_data_prompts/02_data_management_plan_section.prompt.yaml
@@ -11,3 +11,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_data_prompts/03_edit_check_specification_builder.prompt.yaml
+++ b/clinical_data_prompts/03_edit_check_specification_builder.prompt.yaml
@@ -13,3 +13,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_monitoring_prompts/01_risk_based_site_performance_dashboard.prompt.yaml
+++ b/clinical_monitoring_prompts/01_risk_based_site_performance_dashboard.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Risk-Based Site Performance Dashboard
-description: You are an experienced **Clinical Monitoring Manager** at a global
+description: You are an experienced **Clinical Monitoring Manager** at a global 
   CRO overseeing several Phase II oncology trials.
 model: gpt-4
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_monitoring_prompts/02_capa_plan_builder_for_monitoring_findings.prompt.yaml
+++ b/clinical_monitoring_prompts/02_capa_plan_builder_for_monitoring_findings.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: CAPA Plan Builder for Monitoring Findings
-description: You are a **Regulatory Quality Advisor** specializing in ICH-GCP
+description: You are a **Regulatory Quality Advisor** specializing in ICH-GCP 
   compliance.
 model: gpt-4
 modelParameters:
@@ -18,3 +18,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_monitoring_prompts/03_monitoring_visit_report_quality_critique.prompt.yaml
+++ b/clinical_monitoring_prompts/03_monitoring_visit_report_quality_critique.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Monitoring Visit Report (MVR) Quality Critique
-description: You are a **Senior Monitoring Oversight Lead** conducting quality
+description: You are a **Senior Monitoring Oversight Lead** conducting quality 
   review of a draft **Monitoring Visit Report (MVR)**.
 model: gpt-4
 modelParameters:
@@ -19,3 +19,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_prompts/01_crf_shell_generator.prompt.yaml
+++ b/clinical_prompts/01_crf_shell_generator.prompt.yaml
@@ -15,3 +15,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_prompts/02_crf_quality_auditor.prompt.yaml
+++ b/clinical_prompts/02_crf_quality_auditor.prompt.yaml
@@ -15,3 +15,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_prompts/03_cdash_mapping_completion_guide.prompt.yaml
+++ b/clinical_prompts/03_cdash_mapping_completion_guide.prompt.yaml
@@ -15,3 +15,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_research_manager_prompts/01_accelerate_patient_recruitment_retention.prompt.yaml
+++ b/clinical_research_manager_prompts/01_accelerate_patient_recruitment_retention.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Accelerate Patient Recruitment & Retention
-description: Design a 3-step recruitment and retention plan for a Phase II
+description: Design a 3-step recruitment and retention plan for a Phase II 
   oncology study within budget and timeline constraints.
 model: gpt-4
 modelParameters:
@@ -20,3 +20,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_research_manager_prompts/02_digest_regulatory_updates.prompt.yaml
+++ b/clinical_research_manager_prompts/02_digest_regulatory_updates.prompt.yaml
@@ -1,7 +1,7 @@
 ---
 name: Digest the Latest Regulatory Updates Affecting My Protocol
-description: Summarize June 2025 FDA e-source guidance changes affecting
-  protocol ABC-123, flagging mandatory versus recommended items and mapping to
+description: Summarize June 2025 FDA e-source guidance changes affecting 
+  protocol ABC-123, flagging mandatory versus recommended items and mapping to 
   protocol sections.
 model: gpt-4
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_research_manager_prompts/03_portfolio_kpi_dashboard_brief.prompt.yaml
+++ b/clinical_research_manager_prompts/03_portfolio_kpi_dashboard_brief.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Portfolio KPI Dashboard Brief
-description: Produce a one-page executive dashboard of enrollment, deviation,
+description: Produce a one-page executive dashboard of enrollment, deviation, 
   SDV, and budget KPIs for live studies.
 model: gpt-4
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml
+++ b/clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Clinical Safety Synopsis for EU MDR CER
-description: Provide a concise clinical safety synopsis for the EU MDR Clinical
+description: Provide a concise clinical safety synopsis for the EU MDR Clinical 
   Evaluation Report.
 model: gpt-4
 modelParameters:
@@ -13,3 +13,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_safety_prompts/02_fda_mdr_adverse_event_narrative.prompt.yaml
+++ b/clinical_safety_prompts/02_fda_mdr_adverse_event_narrative.prompt.yaml
@@ -17,3 +17,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/clinical_safety_prompts/03_post_market_safety_signal_trending.prompt.yaml
+++ b/clinical_safety_prompts/03_post_market_safety_signal_trending.prompt.yaml
@@ -12,3 +12,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/01_project_init_codex.prompt.yaml
+++ b/codex_prompts/01_project_init_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Project Init & Skeleton (OpenAI Codex)
-description: Spin up a brand-new repository with a minimal but runnable
+description: Spin up a brand-new repository with a minimal but runnable 
   skeleton, plus a one-command local dev experience.
 model: gpt-4
 modelParameters:
@@ -24,3 +24,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/02_codebase_testing_plan.prompt.yaml
+++ b/codex_prompts/02_codebase_testing_plan.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Codebase Testing Plan
-description: Generate a detailed analysis of an existing codebase **and**
+description: Generate a detailed analysis of an existing codebase **and** 
   produce a step-by-step plan to introduce or improve automated testing, aligned
   with project priorities, team skills, and CI/CD constraints.
 model: gpt-4
@@ -77,3 +77,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/03_tooling_and_quality_codex.prompt.yaml
+++ b/codex_prompts/03_tooling_and_quality_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Tooling, Linting & Quality Gates (OpenAI Codex)
-description: Add opinionated linters, formatters, type-checkers, commit hooks,
+description: Add opinionated linters, formatters, type-checkers, commit hooks, 
   and test frameworks so the repo “fails fast” on bad code.
 model: gpt-4
 modelParameters:
@@ -29,3 +29,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/04_ci_cd_codex.prompt.yaml
+++ b/codex_prompts/04_ci_cd_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Continuous Integration & Delivery (OpenAI Codex)
-description: Generate GitHub Actions workflows that build, test, version, and
+description: Generate GitHub Actions workflows that build, test, version, and 
   deploy the app (often a containerised service that calls the OpenAI API).
 model: gpt-4
 modelParameters:
@@ -33,3 +33,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/05_docs_and_onboarding_codex.prompt.yaml
+++ b/codex_prompts/05_docs_and_onboarding_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Documentation & Developer Onboarding (OpenAI Codex)
-description: Create living docs that cut time-to-first-PR and capture
+description: Create living docs that cut time-to-first-PR and capture 
   architectural decisions.
 model: gpt-4
 modelParameters:
@@ -30,3 +30,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/06_refactoring_suggestions_codex.prompt.yaml
+++ b/codex_prompts/06_refactoring_suggestions_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Refactoring Suggestions (OpenAI Codex)
-description: Suggest structural improvements for a complex file to increase
+description: Suggest structural improvements for a complex file to increase 
   readability and testability.
 model: gpt-4
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/07_architecture_flow_codex.prompt.yaml
+++ b/codex_prompts/07_architecture_flow_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Architecture Flow Q&A (OpenAI Codex)
-description: Trace a request from client endpoint to database and document the
+description: Trace a request from client endpoint to database and document the 
   flow with a Mermaid diagram.
 model: gpt-4
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/08_security_vulnerability_codex.prompt.yaml
+++ b/codex_prompts/08_security_vulnerability_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Security Vulnerability Hunt (OpenAI Codex)
-description: Locate and fix a memory-safety vulnerability in the specified
+description: Locate and fix a memory-safety vulnerability in the specified 
   package.
 model: gpt-4
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/09_code_review_codex.prompt.yaml
+++ b/codex_prompts/09_code_review_codex.prompt.yaml
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/10_add_tests_codex.prompt.yaml
+++ b/codex_prompts/10_add_tests_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Targeted Test Generation (OpenAI Codex)
-description: Add unit or integration tests for specified files on the current
+description: Add unit or integration tests for specified files on the current 
   branch.
 model: gpt-4
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/11_bug_fix_codex.prompt.yaml
+++ b/codex_prompts/11_bug_fix_codex.prompt.yaml
@@ -20,3 +20,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/codex_prompts/12_ui_fix_codex.prompt.yaml
+++ b/codex_prompts/12_ui_fix_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: UI Tweak & Verification (OpenAI Codex)
-description: Resolve a minor UI regression and confirm the fix with build or
+description: Resolve a minor UI regression and confirm the fix with build or 
   test steps.
 model: gpt-4
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/01_explain_like_im_5.prompt.yaml
+++ b/communication_prompts/01_explain_like_im_5.prompt.yaml
@@ -14,3 +14,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/02_tldr_summarizer.prompt.yaml
+++ b/communication_prompts/02_tldr_summarizer.prompt.yaml
@@ -12,3 +12,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/03_80_20_crash_course.prompt.yaml
+++ b/communication_prompts/03_80_20_crash_course.prompt.yaml
@@ -13,3 +13,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/04_smart_task_prioritizer.prompt.yaml
+++ b/communication_prompts/04_smart_task_prioritizer.prompt.yaml
@@ -13,3 +13,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/05_devils_advocate_stress_test.prompt.yaml
+++ b/communication_prompts/05_devils_advocate_stress_test.prompt.yaml
@@ -13,3 +13,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/06_storyboard_my_idea.prompt.yaml
+++ b/communication_prompts/06_storyboard_my_idea.prompt.yaml
@@ -13,3 +13,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/07_rapid_risk_matrix.prompt.yaml
+++ b/communication_prompts/07_rapid_risk_matrix.prompt.yaml
@@ -14,3 +14,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/08_data_to_insight_analyst.prompt.yaml
+++ b/communication_prompts/08_data_to_insight_analyst.prompt.yaml
@@ -16,3 +16,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/09_socratic_coach.prompt.yaml
+++ b/communication_prompts/09_socratic_coach.prompt.yaml
@@ -14,3 +14,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/10_red_team_stress_test.prompt.yaml
+++ b/communication_prompts/10_red_team_stress_test.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Red-Team Stress-Test
-description: Form a red-team panel of 3 experts (Technical Hacker, Ruthless
+description: Form a red-team panel of 3 experts (Technical Hacker, Ruthless 
   Competitor CEO, Regulatory Officer).
 model: gpt-4
 modelParameters:
@@ -17,3 +17,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/11_analogy_architect.prompt.yaml
+++ b/communication_prompts/11_analogy_architect.prompt.yaml
@@ -16,3 +16,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/12_density_refiner.prompt.yaml
+++ b/communication_prompts/12_density_refiner.prompt.yaml
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/13_negotiation_coach.prompt.yaml
+++ b/communication_prompts/13_negotiation_coach.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Negotiation Coach
-description: Prepare the user for salary negotiations by roleplaying as a
+description: Prepare the user for salary negotiations by roleplaying as a 
   manager and offering feedback.
 model: gpt-4
 modelParameters:
@@ -36,3 +36,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/14_panel_debate.prompt.yaml
+++ b/communication_prompts/14_panel_debate.prompt.yaml
@@ -22,3 +22,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/15_scamper_ideation_coach.prompt.yaml
+++ b/communication_prompts/15_scamper_ideation_coach.prompt.yaml
@@ -19,3 +19,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/16_empathy_map_facilitator.prompt.yaml
+++ b/communication_prompts/16_empathy_map_facilitator.prompt.yaml
@@ -20,3 +20,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/17_rubber_duck_debugger.prompt.yaml
+++ b/communication_prompts/17_rubber_duck_debugger.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Rubber Duck Debugger
-description: Guide developers through self-explanation to uncover bugs before
+description: Guide developers through self-explanation to uncover bugs before 
   providing fixes.
 model: gpt-4
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/communication_prompts/18_pitch_deck_outliner.prompt.yaml
+++ b/communication_prompts/18_pitch_deck_outliner.prompt.yaml
@@ -20,3 +20,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/cra_prompts/01_monitoring_visit_report_generator.prompt.yaml
+++ b/cra_prompts/01_monitoring_visit_report_generator.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Monitoring-Visit Report Generator
-description: Draft a monitoring visit report summarizing on-site activities,
+description: Draft a monitoring visit report summarizing on-site activities, 
   findings, follow-ups, and attachments.
 model: gpt-4
 modelParameters:
@@ -29,3 +29,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/cra_prompts/02_investigator_follow_up_email_tracker.prompt.yaml
+++ b/cra_prompts/02_investigator_follow_up_email_tracker.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Investigator Follow-up Email & Action-Item Tracker
-description: Compose a follow-up email to the PI summarizing visit findings and
+description: Compose a follow-up email to the PI summarizing visit findings and 
   action items, plus a tracking table.
 model: gpt-4
 modelParameters:
@@ -30,3 +30,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/cra_prompts/03_rbm_plan_builder.prompt.yaml
+++ b/cra_prompts/03_rbm_plan_builder.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Risk-Based Monitoring (RBM) Plan Builder
-description: Develop a site-level risk-based monitoring plan with risk matrix,
+description: Develop a site-level risk-based monitoring plan with risk matrix, 
   KRIs, and adaptive strategy.
 model: gpt-4
 modelParameters:
@@ -30,3 +30,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/data_management_prompts/01_unified_data_cleansing.prompt.yaml
+++ b/data_management_prompts/01_unified_data_cleansing.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Unified Data Cleansing
-description: Outline a unified data cleansing approach for clinical trial
+description: Outline a unified data cleansing approach for clinical trial 
   datasets.
 model: gpt-4o
 modelParameters:
@@ -13,3 +13,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/data_management_prompts/02_regulatory_gap_analysis.prompt.yaml
+++ b/data_management_prompts/02_regulatory_gap_analysis.prompt.yaml
@@ -12,3 +12,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/data_management_prompts/03_data_architecture_blueprint.prompt.yaml
+++ b/data_management_prompts/03_data_architecture_blueprint.prompt.yaml
@@ -11,3 +11,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/data_management_prompts/04_clinical_etl_mapping_spec.prompt.yaml
+++ b/data_management_prompts/04_clinical_etl_mapping_spec.prompt.yaml
@@ -12,3 +12,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/data_management_prompts/05_clinical_etl_transformation_qc.prompt.yaml
+++ b/data_management_prompts/05_clinical_etl_transformation_qc.prompt.yaml
@@ -12,3 +12,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/data_management_prompts/06_clinical_etl_pipeline_review.prompt.yaml
+++ b/data_management_prompts/06_clinical_etl_pipeline_review.prompt.yaml
@@ -12,3 +12,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/data_management_prompts/07_phase_ii_oncology_dmp.prompt.yaml
+++ b/data_management_prompts/07_phase_ii_oncology_dmp.prompt.yaml
@@ -11,3 +11,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/data_management_prompts/08_decentralized_trial_risk_matrix.prompt.yaml
+++ b/data_management_prompts/08_decentralized_trial_risk_matrix.prompt.yaml
@@ -12,3 +12,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/data_management_prompts/09_sop_gap_analysis.prompt.yaml
+++ b/data_management_prompts/09_sop_gap_analysis.prompt.yaml
@@ -11,3 +11,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/design_prompts/01_design_md_template.prompt.yaml
+++ b/design_prompts/01_design_md_template.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Design.md Template
-description: Generate a design.md template capturing problem, constraints, and
+description: Generate a design.md template capturing problem, constraints, and 
   decisions.
 model: gpt-4o
 modelParameters:
@@ -13,3 +13,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/design_prompts/02_email_assistant_go_no_go_vote.prompt.yaml
+++ b/design_prompts/02_email_assistant_go_no_go_vote.prompt.yaml
@@ -13,3 +13,5 @@ messages:
   - role: user
     content: |
       {{input}}
+testData: []
+evaluators: []

--- a/eclinical_integration_prompts/01_architect_integration_blueprint.prompt.yaml
+++ b/eclinical_integration_prompts/01_architect_integration_blueprint.prompt.yaml
@@ -19,3 +19,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/eclinical_integration_prompts/02_data_mapping_transformation_playbook.prompt.yaml
+++ b/eclinical_integration_prompts/02_data_mapping_transformation_playbook.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Data Mapping and Transformation Playbook
-description: Provide a repeatable workflow for mapping JSON FHIR bundles to
+description: Provide a repeatable workflow for mapping JSON FHIR bundles to 
   SDTM-compliant tables.
 model: gpt-4o
 modelParameters:
@@ -19,3 +19,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/eclinical_integration_prompts/03_regulatory_validation_checklist.prompt.yaml
+++ b/eclinical_integration_prompts/03_regulatory_validation_checklist.prompt.yaml
@@ -17,3 +17,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/epro_prompts/01_patient-centric_byod_workflow.prompt.yaml
+++ b/epro_prompts/01_patient-centric_byod_workflow.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Patient-Centric BYOD ePRO Workflow
-description: Design a streamlined ePRO workflow that supports a BYOD model and
+description: Design a streamlined ePRO workflow that supports a BYOD model and 
   maximizes patient compliance.
 model: gpt-4o
 modelParameters:
@@ -19,3 +19,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/epro_prompts/02_optimize_epro_form_design.prompt.yaml
+++ b/epro_prompts/02_optimize_epro_form_design.prompt.yaml
@@ -19,3 +19,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/epro_prompts/03_epro_adoption_plan_for_sponsors.prompt.yaml
+++ b/epro_prompts/03_epro_adoption_plan_for_sponsors.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: ePRO Adoption Plan for Sponsors
-description: Outline a six-month plan for rolling out ePRO across multiple
+description: Outline a six-month plan for rolling out ePRO across multiple 
   sites.
 model: gpt-4o
 modelParameters:
@@ -20,3 +20,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/01_strategic_market_foresight.prompt.yaml
+++ b/executive_prompts/01_strategic_market_foresight.prompt.yaml
@@ -17,3 +17,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/02_crisis_management_playbook.prompt.yaml
+++ b/executive_prompts/02_crisis_management_playbook.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Crisis-Management Playbook Generator
-description: Provide a concise playbook for handling critical incidents
+description: Provide a concise playbook for handling critical incidents 
   affecting customer data.
 model: gpt-4o
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/03_executive_brief_synthesizer.prompt.yaml
+++ b/executive_prompts/03_executive_brief_synthesizer.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Executive-Ready Brief and Talking Points
-description: Turn disparate reports into a concise executive brief and talking
+description: Turn disparate reports into a concise executive brief and talking 
   points.
 model: gpt-4o
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/04_digital_transformation_roadmap.prompt.yaml
+++ b/executive_prompts/04_digital_transformation_roadmap.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Digital Transformation Roadmap for Clinical Operations
-description: Build a technology roadmap that shortens cycle times and enhances
+description: Build a technology roadmap that shortens cycle times and enhances 
   patient engagement.
 model: gpt-4o
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/05_market_competitor_radar.prompt.yaml
+++ b/executive_prompts/05_market_competitor_radar.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Strategic Market and Competitor Radar
-description: Provide an executive briefing on growth areas, competitor moves,
+description: Provide an executive briefing on growth areas, competitor moves, 
   and regulatory shifts.
 model: gpt-4o
 modelParameters:
@@ -20,3 +20,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/06_strategic_growth_roadmap.prompt.yaml
+++ b/executive_prompts/06_strategic_growth_roadmap.prompt.yaml
@@ -23,3 +23,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/07_strategic_portfolio_prioritizer.prompt.yaml
+++ b/executive_prompts/07_strategic_portfolio_prioritizer.prompt.yaml
@@ -27,3 +27,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/08_ai_governance_framework.prompt.yaml
+++ b/executive_prompts/08_ai_governance_framework.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: FDA-Aligned AI Governance Framework
-description: Draft an AI governance framework that satisfies regulators and
+description: Draft an AI governance framework that satisfies regulators and 
   sponsors.
 model: gpt-4o
 modelParameters:
@@ -21,3 +21,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/09_emerging_science_horizon_scan.prompt.yaml
+++ b/executive_prompts/09_emerging_science_horizon_scan.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Emerging-Science Horizon Scan
-description: Highlight emerging therapeutic areas or technologies likely to
+description: Highlight emerging therapeutic areas or technologies likely to 
   disrupt CRO services in the next three years.
 model: gpt-4o
 modelParameters:
@@ -24,3 +24,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/10_executive_trial_health_dashboard.prompt.yaml
+++ b/executive_prompts/10_executive_trial_health_dashboard.prompt.yaml
@@ -25,3 +25,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/11_investor_board_narrative_builder.prompt.yaml
+++ b/executive_prompts/11_investor_board_narrative_builder.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Investor and Board Narrative Builder
-description: Craft a concise two-slide narrative for investors and board
+description: Craft a concise two-slide narrative for investors and board 
   members.
 model: gpt-4o
 modelParameters:
@@ -19,3 +19,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/12_innovation_radar.prompt.yaml
+++ b/executive_prompts/12_innovation_radar.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Quarterly Innovation Radar for Decentralized and Hybrid Trials
-description: Identify and prioritize technologies for decentralized or hybrid
+description: Identify and prioritize technologies for decentralized or hybrid 
   trials.
 model: gpt-4o
 modelParameters:
@@ -22,3 +22,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/13_regulatory_competitive_intel_briefing.prompt.yaml
+++ b/executive_prompts/13_regulatory_competitive_intel_briefing.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Regulatory and Competitive Intelligence Briefing
-description: Provide a Monday-morning briefing on regulatory changes and
+description: Provide a Monday-morning briefing on regulatory changes and 
   competitor moves that may affect decentralized and hybrid trials.
 model: gpt-4o
 modelParameters:
@@ -23,3 +23,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/14_trial_design_optimisation_memo.prompt.yaml
+++ b/executive_prompts/14_trial_design_optimisation_memo.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Trial-Design Optimisation Memo
-description: Rewrite a study synopsis to accelerate startup while maintaining
+description: Rewrite a study synopsis to accelerate startup while maintaining 
   statistical power and budget.
 model: gpt-4o
 modelParameters:
@@ -25,3 +25,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/15_hosting_cost_reduction_tot.prompt.yaml
+++ b/executive_prompts/15_hosting_cost_reduction_tot.prompt.yaml
@@ -12,3 +12,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/executive_prompts/16_strategic_consultant_swot.prompt.yaml
+++ b/executive_prompts/16_strategic_consultant_swot.prompt.yaml
@@ -16,3 +16,5 @@ messages:
   - role: user
     content: |-
       {{input}}
+testData: []
+evaluators: []

--- a/pathology_prompts/01_study_protocol_outline.prompt.yaml
+++ b/pathology_prompts/01_study_protocol_outline.prompt.yaml
@@ -37,3 +37,5 @@ messages:
 
       Additional notes:
       Keep language concise and suitable for protocol drafting.
+testData: []
+evaluators: []

--- a/pathology_prompts/02_device_tissue_interface_evaluation.prompt.yaml
+++ b/pathology_prompts/02_device_tissue_interface_evaluation.prompt.yaml
@@ -35,3 +35,5 @@ messages:
 
       Additional notes:
       Keep explanations concise and evidence-based.
+testData: []
+evaluators: []

--- a/pathology_prompts/03_slides_and_reporting_workflow.prompt.yaml
+++ b/pathology_prompts/03_slides_and_reporting_workflow.prompt.yaml
@@ -31,3 +31,5 @@ messages:
 
       Additional notes:
       Keep the schedule concise and GLP compliant.
+testData: []
+evaluators: []

--- a/payment_prompts/01_audit_ready_site_payment_schedule.prompt.yaml
+++ b/payment_prompts/01_audit_ready_site_payment_schedule.prompt.yaml
@@ -36,3 +36,5 @@ messages:
 
       Additional notes:
       Ensure calculations and triggers are fully traceable for auditors.
+testData: []
+evaluators: []

--- a/payment_prompts/02_sunshine_act_fmv_compliance_check.prompt.yaml
+++ b/payment_prompts/02_sunshine_act_fmv_compliance_check.prompt.yaml
@@ -36,3 +36,5 @@ messages:
 
       Additional notes:
       Use clear column headers so the tables can be imported without modification.
+testData: []
+evaluators: []

--- a/payment_prompts/03_payment_process_risk_assessment.prompt.yaml
+++ b/payment_prompts/03_payment_process_risk_assessment.prompt.yaml
@@ -33,3 +33,5 @@ messages:
 
       Additional notes:
       Cite external benchmarks or stats where relevant.
+testData: []
+evaluators: []

--- a/payment_prompts/04_investigator_site_payment_forecast.prompt.yaml
+++ b/payment_prompts/04_investigator_site_payment_forecast.prompt.yaml
@@ -33,3 +33,5 @@ messages:
 
       Additional notes:
       Keep the table easy to import into spreadsheets.
+testData: []
+evaluators: []

--- a/payment_prompts/05_payment_reconciliation_discrepancy_report.prompt.yaml
+++ b/payment_prompts/05_payment_reconciliation_discrepancy_report.prompt.yaml
@@ -33,3 +33,5 @@ messages:
 
       Additional notes:
       Keep recommendations actionable and concise.
+testData: []
+evaluators: []

--- a/payment_prompts/06_global_regulatory_tax_matrix.prompt.yaml
+++ b/payment_prompts/06_global_regulatory_tax_matrix.prompt.yaml
@@ -27,3 +27,5 @@ messages:
 
       Additional notes:
       Keep language concise and reference official guidance where possible.
+testData: []
+evaluators: []

--- a/productivity_prompts/01_eisenhower_matrix_coach.prompt.yaml
+++ b/productivity_prompts/01_eisenhower_matrix_coach.prompt.yaml
@@ -27,3 +27,5 @@ messages:
 
       Additional notes:
       Keep the entire reply under 150 words.
+testData: []
+evaluators: []

--- a/productivity_prompts/02_second_order_thinking_oracle.prompt.yaml
+++ b/productivity_prompts/02_second_order_thinking_oracle.prompt.yaml
@@ -27,3 +27,5 @@ messages:
 
       Additional notes:
       Keep the entire response under 140 words and use plain language.
+testData: []
+evaluators: []

--- a/productivity_prompts/03_fishbone_facilitator.prompt.yaml
+++ b/productivity_prompts/03_fishbone_facilitator.prompt.yaml
@@ -26,3 +26,5 @@ messages:
 
       Additional notes:
       Limit the entire reply to 120 words.
+testData: []
+evaluators: []

--- a/productivity_prompts/04_heros_journey_storyboarder.prompt.yaml
+++ b/productivity_prompts/04_heros_journey_storyboarder.prompt.yaml
@@ -27,3 +27,5 @@ messages:
 
       Additional notes:
       Kid-friendly tone is optional.
+testData: []
+evaluators: []

--- a/productivity_prompts/05_raci_mapper.prompt.yaml
+++ b/productivity_prompts/05_raci_mapper.prompt.yaml
@@ -27,3 +27,5 @@ messages:
 
       Additional notes:
       Keep the response under 130 words and avoid jargon.
+testData: []
+evaluators: []

--- a/project_management/01_project_charter_scope.prompt.yaml
+++ b/project_management/01_project_charter_scope.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Project Charter and Scope Definition
-description: Create a complete project charter summarizing background, objectives, scope, deliverables, and key risks.
+description: Create a complete project charter summarizing background, 
+  objectives, scope, deliverables, and key risks.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -27,3 +28,5 @@ messages:
 
       Output Format:
       Markdown document with the sections listed above.
+testData: []
+evaluators: []

--- a/project_management/02_risk_register_mitigation.prompt.yaml
+++ b/project_management/02_risk_register_mitigation.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Comprehensive Risk Register and Mitigation Plan
-description: Produce a risk register with mitigation actions and overall strategies.
+description: Produce a risk register with mitigation actions and overall 
+  strategies.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -23,3 +24,5 @@ messages:
 
       Output Format:
       Markdown table followed by a short list of overarching strategies.
+testData: []
+evaluators: []

--- a/project_management/03_weekly_exec_status_report.prompt.yaml
+++ b/project_management/03_weekly_exec_status_report.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Weekly Executive Status Report
-description: Summarize project progress for executive stakeholders in a concise weekly report.
+description: Summarize project progress for executive stakeholders in a concise 
+  weekly report.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -26,3 +27,5 @@ messages:
 
       Output Format:
       Markdown table followed by bullet lists for the remaining sections.
+testData: []
+evaluators: []

--- a/project_management/04_detailed_project_blueprint_timeline.prompt.yaml
+++ b/project_management/04_detailed_project_blueprint_timeline.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Detailed Project Blueprint and Timeline
-description: Provide a comprehensive roadmap with phases, milestones, success metrics, and stakeholders.
+description: Provide a comprehensive roadmap with phases, milestones, success 
+  metrics, and stakeholders.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -24,3 +25,5 @@ messages:
 
       Output Format:
       Markdown table outlining the project roadmap.
+testData: []
+evaluators: []

--- a/project_management/05_risk_pre_mortem_analysis.prompt.yaml
+++ b/project_management/05_risk_pre_mortem_analysis.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Risk and Pre-Mortem Analysis
-description: Identify early failure points and mitigation strategies for a project or study.
+description: Identify early failure points and mitigation strategies for a 
+  project or study.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -23,3 +24,5 @@ messages:
 
       Output Format:
       Markdown table summarizing each risk and mitigation.
+testData: []
+evaluators: []

--- a/project_management/06_status_update_task_prioritization.prompt.yaml
+++ b/project_management/06_status_update_task_prioritization.prompt.yaml
@@ -28,3 +28,5 @@ messages:
 
       Output Format:
       Structured bullet lists using the format above.
+testData: []
+evaluators: []

--- a/project_management/07_clinical_trial_timeline_risk_radar.prompt.yaml
+++ b/project_management/07_clinical_trial_timeline_risk_radar.prompt.yaml
@@ -23,3 +23,5 @@ messages:
 
       Output Format:
       Markdown table followed by a bullet list of next actions.
+testData: []
+evaluators: []

--- a/project_management/07_portfolio_resource_budget_forecast.prompt.yaml
+++ b/project_management/07_portfolio_resource_budget_forecast.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Portfolio Resource and Budget Forecast
-description: Generate a rolling 12‑month FTE and budget forecast for active trials.
+description: Generate a rolling 12‑month FTE and budget forecast for active 
+  trials.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -27,3 +28,5 @@ messages:
 
       Output Format:
       Markdown table followed by bullet list and calculation notes.
+testData: []
+evaluators: []

--- a/project_management/08_cross_study_risk_heat_map_mitigation_plan.prompt.yaml
+++ b/project_management/08_cross_study_risk_heat_map_mitigation_plan.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Cross-Study Operational Risk Heat Map and Mitigation Plan
-description: Identify and prioritize the top portfolio-level operational risks and propose mitigations.
+description: Identify and prioritize the top portfolio-level operational risks 
+  and propose mitigations.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -24,3 +25,5 @@ messages:
       - Table "Risk-Heat-Map".
       - Table "Mitigation-Plan".
       - Executive summary paragraph.
+testData: []
+evaluators: []

--- a/project_management/08_sponsor_ready_monthly_status_brief.prompt.yaml
+++ b/project_management/08_sponsor_ready_monthly_status_brief.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Sponsor-Ready Monthly Status Brief
-description: Draft a concise, escalation-ready monthly status report for study sponsors.
+description: Draft a concise, escalation-ready monthly status report for study 
+  sponsors.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -22,3 +23,5 @@ messages:
 
       Output Format:
       Markdown document with H2 section headers as listed above.
+testData: []
+evaluators: []

--- a/project_management/09_executive_sponsor_briefing_deck_outline.prompt.yaml
+++ b/project_management/09_executive_sponsor_briefing_deck_outline.prompt.yaml
@@ -24,3 +24,5 @@ messages:
 
       Output Format:
       Ordered list of slides in Markdown.
+testData: []
+evaluators: []

--- a/project_management/09_tmf_gap_analysis_audit_readiness_check.prompt.yaml
+++ b/project_management/09_tmf_gap_analysis_audit_readiness_check.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: TMF Gap-Analysis and Audit Readiness Check
-description: Identify missing or outdated Trial Master File documents and propose corrective actions.
+description: Identify missing or outdated Trial Master File documents and 
+  propose corrective actions.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -22,3 +23,5 @@ messages:
 
       Output Format:
       Markdown table followed by a numbered action plan.
+testData: []
+evaluators: []

--- a/project_management/10_neutral_scrum_retro.prompt.yaml
+++ b/project_management/10_neutral_scrum_retro.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Neutral Scrum Retrospective Facilitator
-description: Design a balanced 60-minute remote sprint retrospective for seven participants.
+description: Design a balanced 60-minute remote sprint retrospective for seven 
+  participants.
 model: gpt-4o
 modelParameters:
   temperature: 0.7
@@ -21,3 +22,5 @@ messages:
 
       Output Format:
       Markdown with headers for each section.
+testData: []
+evaluators: []

--- a/project_management/10_rollout_risk_matrix.prompt.yaml
+++ b/project_management/10_rollout_risk_matrix.prompt.yaml
@@ -22,3 +22,5 @@ messages:
 
       Output Format:
       Markdown table followed by short mitigation actions.
+testData: []
+evaluators: []

--- a/protocol_prompts/01_clinical_trial_protocol_creator.prompt.yaml
+++ b/protocol_prompts/01_clinical_trial_protocol_creator.prompt.yaml
@@ -40,3 +40,5 @@ messages:
 
       Additional notes:
       Ensure regulatory compliance throughout the draft.
+testData: []
+evaluators: []

--- a/protocol_prompts/02_ultimate_sop_architect.prompt.yaml
+++ b/protocol_prompts/02_ultimate_sop_architect.prompt.yaml
@@ -41,3 +41,5 @@ messages:
 
       Additional notes:
       Ensure terminology is consistent throughout.
+testData: []
+evaluators: []

--- a/protocol_prompts/03_protocol_reviewer_gap_analysis_coach.prompt.yaml
+++ b/protocol_prompts/03_protocol_reviewer_gap_analysis_coach.prompt.yaml
@@ -37,3 +37,5 @@ messages:
 
       Additional notes:
       Keep feedback constructive and reference best practice guidelines.
+testData: []
+evaluators: []

--- a/protocol_prompts/04_protocol_section_refinement.prompt.yaml
+++ b/protocol_prompts/04_protocol_section_refinement.prompt.yaml
@@ -29,3 +29,5 @@ messages:
 
       Additional notes:
       Keep language concise and align with regulatory expectations.
+testData: []
+evaluators: []

--- a/regulatory_prompts/01_510k_pre-sub_strategy.prompt.yaml
+++ b/regulatory_prompts/01_510k_pre-sub_strategy.prompt.yaml
@@ -40,3 +40,5 @@ messages:
 
       Additional notes:
       Keep recommendations concise and evidence‑based. Wait for user confirmation before drafting the final plan.
+testData: []
+evaluators: []

--- a/regulatory_prompts/02_eu_mdr_gap_assessment.prompt.yaml
+++ b/regulatory_prompts/02_eu_mdr_gap_assessment.prompt.yaml
@@ -36,3 +36,5 @@ messages:
 
       Additional notes:
       Think step‑by‑step and summarize your reasoning. Cite exact MDR clauses used.
+testData: []
+evaluators: []

--- a/regulatory_prompts/03_regulatory_change_impact_analysis.prompt.yaml
+++ b/regulatory_prompts/03_regulatory_change_impact_analysis.prompt.yaml
@@ -39,3 +39,5 @@ messages:
 
       Additional notes:
       Write in plain English for time‑pressed executives. Cite article or section numbers. Ask up to three clarifying questions if essential details are missing.
+testData: []
+evaluators: []

--- a/regulatory_prompts/04_strategic_regulatory_pathway_plan.prompt.yaml
+++ b/regulatory_prompts/04_strategic_regulatory_pathway_plan.prompt.yaml
@@ -32,3 +32,5 @@ messages:
 
       Additional notes:
       Keep advice concise and action‑oriented for a global audience.
+testData: []
+evaluators: []

--- a/regulatory_prompts/05_compliance_gap_assessment.prompt.yaml
+++ b/regulatory_prompts/05_compliance_gap_assessment.prompt.yaml
@@ -49,3 +49,5 @@ messages:
 
       Additional notes:
       Base severity on likelihood × impact. If evidence is older than 12 months, mark status as Partially implemented. Request missing artifacts before final scoring.
+testData: []
+evaluators: []

--- a/regulatory_prompts/06_ind_readiness_gap_analysis.prompt.yaml
+++ b/regulatory_prompts/06_ind_readiness_gap_analysis.prompt.yaml
@@ -37,3 +37,5 @@ messages:
 
       Additional notes:
       Provide concise, actionable recommendations once clarifications are complete.
+testData: []
+evaluators: []

--- a/regulatory_prompts/07_ivdr_pep_blueprint.prompt.yaml
+++ b/regulatory_prompts/07_ivdr_pep_blueprint.prompt.yaml
@@ -43,3 +43,5 @@ messages:
 
       Additional notes:
       Present reasoning step‑by‑step and keep the language concise.
+testData: []
+evaluators: []

--- a/regulatory_prompts/08_raqa_integrated_quality_system_audit.prompt.yaml
+++ b/regulatory_prompts/08_raqa_integrated_quality_system_audit.prompt.yaml
@@ -29,3 +29,5 @@ messages:
 
       Additional notes:
       Keep advice concise and actionable for audit readiness.
+testData: []
+evaluators: []

--- a/regulatory_prompts/09_dual_mdr_ivdr_roadmap.prompt.yaml
+++ b/regulatory_prompts/09_dual_mdr_ivdr_roadmap.prompt.yaml
@@ -39,3 +39,5 @@ messages:
 
       Additional notes:
       Focus on clear milestones and risk mitigation.
+testData: []
+evaluators: []

--- a/regulatory_prompts/10_ivd_performance_study_compliance_review.prompt.yaml
+++ b/regulatory_prompts/10_ivd_performance_study_compliance_review.prompt.yaml
@@ -31,3 +31,5 @@ messages:
 
       Additional notes:
       Use clear references to MDCG 2024‑4 and related authorities.
+testData: []
+evaluators: []

--- a/regulatory_prompts/11_qmsr_gap_analysis.prompt.yaml
+++ b/regulatory_prompts/11_qmsr_gap_analysis.prompt.yaml
@@ -37,3 +37,5 @@ messages:
 
       Additional notes:
       Ensure recommendations align with ISO 13485:2016 and proposed QMSR requirements.
+testData: []
+evaluators: []

--- a/regulatory_prompts/12_regulatory_filing_draft_builder.prompt.yaml
+++ b/regulatory_prompts/12_regulatory_filing_draft_builder.prompt.yaml
@@ -46,3 +46,5 @@ messages:
 
       Additional notes:
       Maintain a regulator‑friendly tone and highlight missing information.
+testData: []
+evaluators: []

--- a/regulatory_prompts/13_prompt_best_practices.prompt.yaml
+++ b/regulatory_prompts/13_prompt_best_practices.prompt.yaml
@@ -30,3 +30,5 @@ messages:
 
       Additional notes:
       Adapt these points to fit the specific regulatory context.
+testData: []
+evaluators: []

--- a/regulatory_prompts/14_literature_regulatory_gap_analysis.prompt.yaml
+++ b/regulatory_prompts/14_literature_regulatory_gap_analysis.prompt.yaml
@@ -29,3 +29,5 @@ messages:
 
       Additional notes:
       Keep the analysis concise and reference authoritative guidance documents.
+testData: []
+evaluators: []

--- a/regulatory_quality_prompts/01_regulatory_radar.prompt.yaml
+++ b/regulatory_quality_prompts/01_regulatory_radar.prompt.yaml
@@ -39,3 +39,5 @@ messages:
       Use clear, concise language. Prioritize the most impactful changes.
 
       <!-- markdownlint-enable MD029 MD036 -->
+testData: []
+evaluators: []

--- a/regulatory_quality_prompts/02_compliance_gap_risk_matrix.prompt.yaml
+++ b/regulatory_quality_prompts/02_compliance_gap_risk_matrix.prompt.yaml
@@ -34,3 +34,5 @@ messages:
       This approach aligns with auditor workflows and supports import into GRC tools.
 
       <!-- markdownlint-enable MD029 MD036 -->
+testData: []
+evaluators: []

--- a/regulatory_quality_prompts/03_quality_improvement_rca_action_plan.prompt.yaml
+++ b/regulatory_quality_prompts/03_quality_improvement_rca_action_plan.prompt.yaml
@@ -37,3 +37,5 @@ messages:
       Keep total length ≤600 words and use plain language.
 
       <!-- markdownlint-enable MD029 MD036 -->
+testData: []
+evaluators: []

--- a/regulatory_quality_prompts/04_etmf_compliance_gap_analysis.prompt.yaml
+++ b/regulatory_quality_prompts/04_etmf_compliance_gap_analysis.prompt.yaml
@@ -33,3 +33,5 @@ messages:
       Think step‑by‑step internally but show only the final answer.
 
       <!-- markdownlint-enable MD029 MD036 -->
+testData: []
+evaluators: []

--- a/regulatory_quality_prompts/05_regulatory_landscape_radar.prompt.yaml
+++ b/regulatory_quality_prompts/05_regulatory_landscape_radar.prompt.yaml
@@ -41,3 +41,5 @@ messages:
       Keep language concise and actionable.
 
       <!-- markdownlint-enable MD022 MD029 MD036 -->
+testData: []
+evaluators: []

--- a/regulatory_quality_prompts/06_capa_plan_generator.prompt.yaml
+++ b/regulatory_quality_prompts/06_capa_plan_generator.prompt.yaml
@@ -33,3 +33,5 @@ messages:
       Ensure alignment with FDA 21 CFR 820.100 and ISO 13485:2016.
 
       <!-- markdownlint-enable MD029 MD036 -->
+testData: []
+evaluators: []

--- a/regulatory_quality_prompts/07_inspection_readiness_drill_capa_builder.prompt.yaml
+++ b/regulatory_quality_prompts/07_inspection_readiness_drill_capa_builder.prompt.yaml
@@ -40,3 +40,5 @@ messages:
       Use concise language and focus on actionable preparation steps.
 
       <!-- markdownlint-enable MD022 MD029 MD036 -->
+testData: []
+evaluators: []

--- a/regulatory_quality_prompts/08_integrated_submission_strategy_coach.prompt.yaml
+++ b/regulatory_quality_prompts/08_integrated_submission_strategy_coach.prompt.yaml
@@ -33,3 +33,5 @@ messages:
       Keep language concise and actionable.
 
       <!-- markdownlint-enable MD022 MD029 MD036 -->
+testData: []
+evaluators: []

--- a/regulatory_quality_prompts/09_risk_based_quality_management_plan.prompt.yaml
+++ b/regulatory_quality_prompts/09_risk_based_quality_management_plan.prompt.yaml
@@ -33,3 +33,5 @@ messages:
       Ensure guidance references are explicit where relevant.
 
       <!-- markdownlint-enable MD029 MD036 -->
+testData: []
+evaluators: []

--- a/rtsm_prompts/01_patient_centered_randomization_scheme.prompt.yaml
+++ b/rtsm_prompts/01_patient_centered_randomization_scheme.prompt.yaml
@@ -50,3 +50,5 @@ messages:
 
       Additional notes:
       Ensure the scheme is ready for RTSM vendor implementation.
+testData: []
+evaluators: []

--- a/rtsm_prompts/02_site_level_supply_resupply_strategy.prompt.yaml
+++ b/rtsm_prompts/02_site_level_supply_resupply_strategy.prompt.yaml
@@ -47,3 +47,5 @@ messages:
 
       Additional notes:
       Omit internal reasoning; provide only the final deliverable.
+testData: []
+evaluators: []

--- a/rtsm_prompts/03_risk_based_monitoring_sop.prompt.yaml
+++ b/rtsm_prompts/03_risk_based_monitoring_sop.prompt.yaml
@@ -36,3 +36,5 @@ messages:
 
       Additional notes:
       Avoid internal reasoning in the output.
+testData: []
+evaluators: []

--- a/self_improvement_prompts/01_career_compass_advisor.prompt.yaml
+++ b/self_improvement_prompts/01_career_compass_advisor.prompt.yaml
@@ -27,3 +27,5 @@ messages:
 
       Additional notes:
       Keep the entire response within 150 words.
+testData: []
+evaluators: []

--- a/self_improvement_prompts/02_financial_navigator.prompt.yaml
+++ b/self_improvement_prompts/02_financial_navigator.prompt.yaml
@@ -27,3 +27,5 @@ messages:
 
       Additional notes:
       Keep the entire reply under 170 words.
+testData: []
+evaluators: []

--- a/self_improvement_prompts/03_micro_habit_health_coach.prompt.yaml
+++ b/self_improvement_prompts/03_micro_habit_health_coach.prompt.yaml
@@ -27,3 +27,5 @@ messages:
 
       Additional notes:
       Keep the total response under 150 words.
+testData: []
+evaluators: []

--- a/self_improvement_prompts/04_learning_path_mentor.prompt.yaml
+++ b/self_improvement_prompts/04_learning_path_mentor.prompt.yaml
@@ -28,3 +28,5 @@ messages:
 
       Additional notes:
       Keep output concise.
+testData: []
+evaluators: []

--- a/self_improvement_prompts/05_writing_clarity_mentor.prompt.yaml
+++ b/self_improvement_prompts/05_writing_clarity_mentor.prompt.yaml
@@ -27,3 +27,5 @@ messages:
 
       Additional notes:
       Keep the entire reply within 180 words.
+testData: []
+evaluators: []

--- a/site_acquisition_prompts/01_site_landscape_mapping.prompt.yaml
+++ b/site_acquisition_prompts/01_site_landscape_mapping.prompt.yaml
@@ -29,3 +29,5 @@ messages:
       - Cover at least three geographic regions.
       - Base recommendations on public registries and sponsor data.
       - Cite every data source in column 9.
+testData: []
+evaluators: []

--- a/site_acquisition_prompts/02_tailored_feasibility_questionnaire.prompt.yaml
+++ b/site_acquisition_prompts/02_tailored_feasibility_questionnaire.prompt.yaml
@@ -34,3 +34,5 @@ messages:
 
       Additional notes:
       Keep medical acronyms consistent with the protocol. If key details are missing, list them and stop.
+testData: []
+evaluators: []

--- a/site_acquisition_prompts/03_investigator_outreach_email_generator.prompt.yaml
+++ b/site_acquisition_prompts/03_investigator_outreach_email_generator.prompt.yaml
@@ -34,3 +34,5 @@ messages:
 
       Additional notes:
       Tone should be professional and collaborative. Keep the email between 180 and 220 words. If any variable is blank, ask for it rather than guessing.
+testData: []
+evaluators: []

--- a/starter_pack/01_project_starter_pack.prompt.yaml
+++ b/starter_pack/01_project_starter_pack.prompt.yaml
@@ -1,7 +1,7 @@
-# yamllint disable rule:line-length
 ---
 name: Project Starter Pack Prompts
-description: Provide ready-to-copy prompt templates for common project documentation.
+description: Provide ready-to-copy prompt templates for common project 
+  documentation.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -23,3 +23,5 @@ messages:
       Prompts marked with * may result in multi-page outputs.
 
       ---
+testData: []
+evaluators: []

--- a/sterility_prompts/01_sterility_validation_protocol_builder.prompt.yaml
+++ b/sterility_prompts/01_sterility_validation_protocol_builder.prompt.yaml
@@ -32,3 +32,5 @@ messages:
       - Include all equations explicitly.
       - Cite each standard or guidance section by clause number.
       - Think through the solution step-by-step internally and reveal only the final protocol.
+testData: []
+evaluators: []

--- a/sterility_prompts/02_regulatory_gap_analysis_comparator.prompt.yaml
+++ b/sterility_prompts/02_regulatory_gap_analysis_comparator.prompt.yaml
@@ -29,3 +29,5 @@ messages:
       Additional notes:
       - Use bold red text `**<text>**` for high‑risk gaps.
       - Do not expose your chain of thought.
+testData: []
+evaluators: []

--- a/sterility_prompts/03_eto_sterilization_process_fmea.prompt.yaml
+++ b/sterility_prompts/03_eto_sterilization_process_fmea.prompt.yaml
@@ -30,3 +30,5 @@ messages:
 
       Additional notes:
       Think step-by-step internally and share only the finished FMEA table and summary.
+testData: []
+evaluators: []

--- a/study_director_prompts/01_draft_glp_compliant_study_protocol.prompt.yaml
+++ b/study_director_prompts/01_draft_glp_compliant_study_protocol.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Draft a GLP-Compliant Study Protocol
-description: Produce a detailed study plan that satisfies OECD and FDA GLP regulations.
+description: Produce a detailed study plan that satisfies OECD and FDA GLP 
+  regulations.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -25,3 +26,5 @@ messages:
       Output Format:
       1. Numbered outline covering all requested sections
       2. CSV-ready risk-mitigation table with columns: Phase, Risk, Impact, Mitigation
+testData: []
+evaluators: []

--- a/study_director_prompts/02_audit_raw_data_capa_summary.prompt.yaml
+++ b/study_director_prompts/02_audit_raw_data_capa_summary.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Audit Raw Data and Draft a CAPA Summary
-description: Review study data for deviations and produce a corrective-action plan.
+description: Review study data for deviations and produce a corrective-action 
+  plan.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -24,3 +25,5 @@ messages:
       Output Format:
       1. Markdown table with columns: Issue ID | Impact | CAPA
       2. CAPA memo addressed to the Study Director (≤300 words)
+testData: []
+evaluators: []

--- a/study_director_prompts/03_executive_summary_final_report.prompt.yaml
+++ b/study_director_prompts/03_executive_summary_final_report.prompt.yaml
@@ -24,3 +24,5 @@ messages:
       Output Format:
       1. Two-page summary in formal language aligned with CTD headings
       2. Final four-item sign-off checklist for the Study Director
+testData: []
+evaluators: []

--- a/technical_writer_prompts/01_csr_results_safety_section.prompt.yaml
+++ b/technical_writer_prompts/01_csr_results_safety_section.prompt.yaml
@@ -26,3 +26,5 @@ messages:
       1. **Efficacy Evaluation** section including Table 11‑1
       2. **Safety Evaluation** section including Table 12‑1 and Figure 12‑1
       3. Bullet list of missing information, if any
+testData: []
+evaluators: []

--- a/technical_writer_prompts/02_ib_detailed_soc.prompt.yaml
+++ b/technical_writer_prompts/02_ib_detailed_soc.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Investigator's Brochure Summary of Changes
-description: Produce a detailed summary of changes for the annual Investigator’s Brochure update.
+description: Produce a detailed summary of changes for the annual Investigator’s
+  Brochure update.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -25,3 +26,5 @@ messages:
       Output Format:
       1. Markdown table(s) with columns: Section | Old text | New text | Rationale
       2. Concise narrative summarizing major changes
+testData: []
+evaluators: []

--- a/technical_writer_prompts/03_sae_reporting_sop.prompt.yaml
+++ b/technical_writer_prompts/03_sae_reporting_sop.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: SAE and Unanticipated Problem Reporting SOP
-description: Develop a standard operating procedure for reporting serious adverse events and unanticipated problems.
+description: Develop a standard operating procedure for reporting serious 
+  adverse events and unanticipated problems.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -26,3 +27,5 @@ messages:
       1. Markdown SOP with sections: Purpose, Scope, Definitions, Responsibilities, Procedure, Timelines, Training, Record retention, Revision history
       2. ASCII or Markdown flowchart illustrating the reporting pathway
       3. Annex with template log examples
+testData: []
+evaluators: []

--- a/trial_execution_prompts/01_protocol_optimization_risk_simulation.prompt.yaml
+++ b/trial_execution_prompts/01_protocol_optimization_risk_simulation.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Protocol Optimization and Risk Simulation
-description: Evaluate a draft clinical protocol and simulate the effects of simplifying key elements.
+description: Evaluate a draft clinical protocol and simulate the effects of 
+  simplifying key elements.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -27,3 +28,5 @@ messages:
       - **Section B:** Scenario 1 – metrics and narrative
       - **Section C:** Scenario 2 – metrics and narrative
       - **Section D:** Recommendations
+testData: []
+evaluators: []

--- a/trial_execution_prompts/02_ai_powered_site_recruitment.prompt.yaml
+++ b/trial_execution_prompts/02_ai_powered_site_recruitment.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: AI-Powered Site and Recruitment Strategy
-description: Select optimal sites and anticipate dropout risks using simulated EHR insights.
+description: Select optimal sites and anticipate dropout risks using simulated 
+  EHR insights.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -26,3 +27,5 @@ messages:
       - **Site Ranking Table** – site, enrollment projection, retention rate
       - **Dropout Risks** – list with explanations
       - **Mitigation Plan** – bullet points per risk
+testData: []
+evaluators: []

--- a/trial_execution_prompts/03_compliance_data_quality_monitoring_plan.prompt.yaml
+++ b/trial_execution_prompts/03_compliance_data_quality_monitoring_plan.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Compliance and Data Quality Monitoring Plan
-description: Design an AI-assisted monitoring plan to ensure compliance and data integrity.
+description: Design an AI-assisted monitoring plan to ensure compliance and data
+  integrity.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -25,3 +26,5 @@ messages:
       - **Part A:** Alert list (type, trigger condition)
       - **Part B:** Review schedule (who and how often)
       - **Part C:** Reporting plan (frequency, content, recipients)
+testData: []
+evaluators: []

--- a/trial_execution_prompts/04_adaptive_recruitment_retention_strategy.prompt.yaml
+++ b/trial_execution_prompts/04_adaptive_recruitment_retention_strategy.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Adaptive Recruitment and Retention Strategy
-description: Design an optimized recruitment and retention plan for a multi-site pivotal study.
+description: Design an optimized recruitment and retention plan for a multi-site
+  pivotal study.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -25,3 +26,5 @@ messages:
       1. Pre‑screening workflow
       2. Site-level engagement tactics
       3. Recruitment and retention metrics
+testData: []
+evaluators: []

--- a/trial_execution_prompts/05_portfolio_clin_ops_roadmap.prompt.yaml
+++ b/trial_execution_prompts/05_portfolio_clin_ops_roadmap.prompt.yaml
@@ -25,3 +25,5 @@ messages:
 
       - **Executive Summary** (≤ 150 words)
       - **Detailed Roadmap** (table)
+testData: []
+evaluators: []

--- a/trial_execution_prompts/06_risk_based_monitoring_plan.prompt.yaml
+++ b/trial_execution_prompts/06_risk_based_monitoring_plan.prompt.yaml
@@ -22,3 +22,5 @@ messages:
       Output Format:
       1. Executive slide outline (bulleted)
       2. Editable risk register in a Markdown table
+testData: []
+evaluators: []

--- a/trial_execution_prompts/07_recruitment_diversity_acceleration.prompt.yaml
+++ b/trial_execution_prompts/07_recruitment_diversity_acceleration.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Patient Recruitment and Diversity Acceleration Plan
-description: Boost enrollment and improve demographic diversity in a stalled Phase III study.
+description: Boost enrollment and improve demographic diversity in a stalled 
+  Phase III study.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -22,3 +23,5 @@ messages:
 
       Output Format:
       Concise report (≤ 1 000 words) plus a one‑slide KPI dashboard sketch in text form.
+testData: []
+evaluators: []

--- a/vp_statistics_prompts/01_interim_results_executive_brief.prompt.yaml
+++ b/vp_statistics_prompts/01_interim_results_executive_brief.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Interim Results Executive Brief
-description: Summarize interim analysis findings for cross-functional leadership.
+description: Summarize interim analysis findings for cross-functional 
+  leadership.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -35,3 +36,5 @@ messages:
       - **Key Findings**
       - **Risk Assessment**
       - **Recommended Actions**
+testData: []
+evaluators: []

--- a/vp_statistics_prompts/02_sap_first_draft_builder.prompt.yaml
+++ b/vp_statistics_prompts/02_sap_first_draft_builder.prompt.yaml
@@ -1,6 +1,7 @@
 ---
 name: Statistical Analysis Plan Draft Builder
-description: Create the initial draft of a Statistical Analysis Plan (SAP) for a Phase II oncology trial.
+description: Create the initial draft of a Statistical Analysis Plan (SAP) for a
+  Phase II oncology trial.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -39,3 +40,5 @@ messages:
       6. Table, Listing and Figure shells
       7. SAS-style pseudocode for primary analyses
       8. Reviewer Checklist boxes
+testData: []
+evaluators: []

--- a/vp_statistics_prompts/03_data_quality_risk_heatmap.prompt.yaml
+++ b/vp_statistics_prompts/03_data_quality_risk_heatmap.prompt.yaml
@@ -36,3 +36,5 @@ messages:
       2. ASCII heat map (rows = sites, columns = risk deciles)
       3. Mitigation bullets (three per high-risk site)
       4. Python (pandas) code block used for calculations
+testData: []
+evaluators: []


### PR DESCRIPTION
## Summary
- Add empty `testData` arrays to prompts missing test data across multiple clinical and operational directories
- Add empty `evaluators` arrays to align prompts with repository schema

## Testing
- `python scripts/validate_prompt_schema.py` *(fails: missing evaluators in unrelated prompt directories)*
- `python - <<'PY' ...` (custom validator confirming all modified prompts contain required fields)


------
https://chatgpt.com/codex/tasks/task_e_689e1ef35a68832c9106c989422cff3c