### PR TITLE
Add test data and evaluators for site acquisition prompts

### DIFF
--- a/site_acquisition_prompts/01_site_landscape_mapping.prompt.yaml
+++ b/site_acquisition_prompts/01_site_landscape_mapping.prompt.yaml
@@ -29,5 +29,11 @@ messages:
       - Cover at least three geographic regions.
       - Base recommendations on public registries and sponsor data.
       - Cite every data source in column 9.
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      protocol_summary: Example Phase II oncology study synopsis
+    expected: Rank
+evaluators:
+  - name: Output starts with 'Rank'
+    string:
+      startsWith: 'Rank'

--- a/site_acquisition_prompts/02_tailored_feasibility_questionnaire.prompt.yaml
+++ b/site_acquisition_prompts/02_tailored_feasibility_questionnaire.prompt.yaml
@@ -34,5 +34,11 @@ messages:
 
       Additional notes:
       Keep medical acronyms consistent with the protocol. If key details are missing, list them and stop.
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      protocol_summary: Draft Phase II oncology protocol
+    expected: Section A
+evaluators:
+  - name: Output starts with 'Section A'
+    string:
+      startsWith: 'Section A'

--- a/site_acquisition_prompts/03_investigator_outreach_email_generator.prompt.yaml
+++ b/site_acquisition_prompts/03_investigator_outreach_email_generator.prompt.yaml
@@ -34,5 +34,17 @@ messages:
 
       Additional notes:
       Tone should be professional and collaborative. Keep the email between 180 and 220 words. If any variable is blank, ask for it rather than guessing.
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      investigator_name: Dr. Smith
+      site_name: City Hospital
+      city_country: Chicago, USA
+      recent_relevant_trials: Trial A
+      unique_site_strength: Dedicated oncology center
+      study_synopsis: Phase II lung cancer study
+      sponsor_name: ABC Pharma
+    expected: '{'
+evaluators:
+  - name: Output starts with '{'
+    string:
+      startsWith: '{'


### PR DESCRIPTION
## Summary
- provide sample test cases for site landscape mapping, feasibility questionnaire, and investigator outreach prompts
- add evaluator stubs for each prompt to verify basic output shape

## Testing
- `yamllint site_acquisition_prompts/01_site_landscape_mapping.prompt.yaml site_acquisition_prompts/02_tailored_feasibility_questionnaire.prompt.yaml site_acquisition_prompts/03_investigator_outreach_email_generator.prompt.yaml`
- `python scripts/update_docs_index.py`

------
https://chatgpt.com/codex/tasks/task_e_689e26ff6568832c9772ba254dcf5384