### PR TITLE
Add test data to self improvement prompts

### DIFF
--- a/self_improvement_prompts/01_career_compass_advisor.prompt.yaml
+++ b/self_improvement_prompts/01_career_compass_advisor.prompt.yaml
@@ -27,5 +27,9 @@ messages:
 
       Additional notes:
       Keep the entire response within 150 words.
-testData: []
+testData:
+  - vars:
+      background: Sample background and goals
+    expected: |-
+      Markdown table followed by the action plan.
 evaluators: []

--- a/self_improvement_prompts/02_financial_navigator.prompt.yaml
+++ b/self_improvement_prompts/02_financial_navigator.prompt.yaml
@@ -27,5 +27,9 @@ messages:
 
       Additional notes:
       Keep the entire reply under 170 words.
-testData: []
+testData:
+  - vars:
+      user_data: Sample financial profile
+    expected: |-
+      Markdown table of projections followed by brief tactics and a caution note.
 evaluators: []

--- a/self_improvement_prompts/03_micro_habit_health_coach.prompt.yaml
+++ b/self_improvement_prompts/03_micro_habit_health_coach.prompt.yaml
@@ -27,5 +27,9 @@ messages:
 
       Additional notes:
       Keep the total response under 150 words.
-testData: []
+testData:
+  - vars:
+      user_info: Sample preferences and equipment
+    expected: |-
+      Markdown sections for Meals, Movement, and Mindset followed by the disclaimer.
 evaluators: []

--- a/self_improvement_prompts/04_learning_path_mentor.prompt.yaml
+++ b/self_improvement_prompts/04_learning_path_mentor.prompt.yaml
@@ -28,5 +28,10 @@ messages:
 
       Additional notes:
       Keep output concise.
-testData: []
+testData:
+  - vars:
+      skill_level: novice
+      weekly_hours: 5
+    expected: |-
+      Markdown roadmap table followed by self-check questions.
 evaluators: []

--- a/self_improvement_prompts/05_writing_clarity_mentor.prompt.yaml
+++ b/self_improvement_prompts/05_writing_clarity_mentor.prompt.yaml
@@ -27,5 +27,9 @@ messages:
 
       Additional notes:
       Keep the entire reply within 180 words.
-testData: []
+testData:
+  - vars:
+      passage: Sample text needing improvement
+    expected: |-
+      Markdown with a summary, issue list, revised passage, and style tip.
 evaluators: []


### PR DESCRIPTION
## Summary
- add sample test inputs to career compass, financial navigator, micro habit health coach, learning path mentor, and writing clarity mentor prompts
- include evaluators array placeholders for future checks

## Testing
- `yamllint self_improvement_prompts/01_career_compass_advisor.prompt.yaml self_improvement_prompts/02_financial_navigator.prompt.yaml self_improvement_prompts/03_micro_habit_health_coach.prompt.yaml self_improvement_prompts/04_learning_path_mentor.prompt.yaml self_improvement_prompts/05_writing_clarity_mentor.prompt.yaml`
- `python scripts/update_docs_index.py`


------
https://chatgpt.com/codex/tasks/task_e_689e26fea8b4832cab252198f670dbcb