### PR TITLE
Add test data and evaluators for RTSM prompts

### DIFF
--- a/rtsm_prompts/01_patient_centered_randomization_scheme.prompt.yaml
+++ b/rtsm_prompts/01_patient_centered_randomization_scheme.prompt.yaml
@@ -50,5 +50,12 @@ messages:
 
       Additional notes:
       Ensure the scheme is ready for RTSM vendor implementation.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      study_parameters: example_study_parameters
+    expected: |-
+      4-bullet executive summary and specification table.
+evaluators:
+  - name: Output starts with bullet list
+    string:
+      startsWith: '- '

--- a/rtsm_prompts/02_site_level_supply_resupply_strategy.prompt.yaml
+++ b/rtsm_prompts/02_site_level_supply_resupply_strategy.prompt.yaml
@@ -47,5 +47,12 @@ messages:
 
       Additional notes:
       Omit internal reasoning; provide only the final deliverable.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      trial_enrollment: example_enrollment
+    expected: |-
+      Markdown table, ASCII timeline, and rationale paragraph.
+evaluators:
+  - name: Output contains markdown table
+    string:
+      contains: '|'

--- a/rtsm_prompts/03_risk_based_monitoring_sop.prompt.yaml
+++ b/rtsm_prompts/03_risk_based_monitoring_sop.prompt.yaml
@@ -36,5 +36,12 @@ messages:
 
       Additional notes:
       Avoid internal reasoning in the output.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      existing_sop: example_sop
+    expected: |-
+      Markdown table, mitigation procedures, and flowchart description.
+evaluators:
+  - name: Output starts with markdown table
+    string:
+      startsWith: '|'


### PR DESCRIPTION
## Summary
- add sample test cases to RTSM randomization, supply strategy, and monitoring prompts
- include simple evaluators ensuring expected output structure

## Testing
- `yamllint rtsm_prompts/01_patient_centered_randomization_scheme.prompt.yaml rtsm_prompts/02_site_level_supply_resupply_strategy.prompt.yaml rtsm_prompts/03_risk_based_monitoring_sop.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e26fe2d60832cafe1b271227fb287