### PR TITLE
Add testData and evaluators to protocol prompts

### DIFF
--- a/protocol_prompts/01_clinical_trial_protocol_creator.prompt.yaml
+++ b/protocol_prompts/01_clinical_trial_protocol_creator.prompt.yaml
@@ -40,5 +40,11 @@ messages:
 
       Additional notes:
       Ensure regulatory compliance throughout the draft.
-testData: []
-evaluators: []
+testData:
+  - input: |
+      summary_sheet: Phase I study of investigational hypertension drug
+    expected: Title Page
+evaluators:
+  - name: Includes Title Page heading
+    string:
+      contains: Title Page

--- a/protocol_prompts/02_ultimate_sop_architect.prompt.yaml
+++ b/protocol_prompts/02_ultimate_sop_architect.prompt.yaml
@@ -41,5 +41,11 @@ messages:
 
       Additional notes:
       Ensure terminology is consistent throughout.
-testData: []
-evaluators: []
+testData:
+  - input: |
+      process_information: basic lab procedure
+    expected: Purpose / Objective
+evaluators:
+  - name: Contains Purpose heading
+    string:
+      contains: Purpose / Objective

--- a/protocol_prompts/03_protocol_reviewer_gap_analysis_coach.prompt.yaml
+++ b/protocol_prompts/03_protocol_reviewer_gap_analysis_coach.prompt.yaml
@@ -37,5 +37,11 @@ messages:
 
       Additional notes:
       Keep feedback constructive and reference best practice guidelines.
-testData: []
-evaluators: []
+testData:
+  - input: |
+      protocol_text_or_nct: NCT00000000
+    expected: Table of scores
+evaluators:
+  - name: Provides score table
+    string:
+      contains: Table of scores

--- a/protocol_prompts/04_protocol_section_refinement.prompt.yaml
+++ b/protocol_prompts/04_protocol_section_refinement.prompt.yaml
@@ -29,5 +29,12 @@ messages:
 
       Additional notes:
       Keep language concise and align with regulatory expectations.
-testData: []
-evaluators: []
+testData:
+  - input: |
+      condition: diabetes
+      draft_section: placeholder text
+    expected: Inclusion
+evaluators:
+  - name: Contains inclusion subsection
+    string:
+      contains: Inclusion


### PR DESCRIPTION
## Summary
- add example `testData` and `evaluators` sections to clinical protocol creator, SOP architect, gap-analysis coach, and section refinement prompts

## Testing
- `scripts/validate_prompts.sh` *(fails: trailing spaces in clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml)*
- `yamllint protocol_prompts/01_clinical_trial_protocol_creator.prompt.yaml && echo '01 ok'`
- `yamllint protocol_prompts/02_ultimate_sop_architect.prompt.yaml && echo '02 ok'`
- `yamllint protocol_prompts/03_protocol_reviewer_gap_analysis_coach.prompt.yaml && echo '03 ok'`
- `yamllint protocol_prompts/04_protocol_section_refinement.prompt.yaml && echo '04 ok'`


------
https://chatgpt.com/codex/tasks/task_e_689e26fc4568832ca31611ebe0c59398