### PR TITLE
Add test data and evaluators to project management prompts

### DIFF
--- a/clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml
+++ b/clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Clinical Safety Synopsis for EU MDR CER
-description: Provide a concise clinical safety synopsis for the EU MDR Clinical 
+description: Provide a concise clinical safety synopsis for the EU MDR Clinical
   Evaluation Report.
 model: gpt-4
 modelParameters:

--- a/project_management/01_project_charter_scope.prompt.yaml
+++ b/project_management/01_project_charter_scope.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Project Charter and Scope Definition
-description: Create a complete project charter summarizing background, 
+description: Create a complete project charter summarizing background,
   objectives, scope, deliverables, and key risks.
 model: gpt-4o
 modelParameters:
@@ -28,5 +28,17 @@ messages:
 
       Output Format:
       Markdown document with the sections listed above.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      project_name: Example Project
+      project_description: Example description
+      budget: "100k USD"
+      deadline: "2024-12-31"
+      stakeholders: "CEO, CTO"
+      business_outcome: Increase efficiency
+    expected: |
+      Markdown document with sections including Background and Objectives.
+evaluators:
+  - name: Contains Background heading
+    string:
+      contains: "Background"

--- a/project_management/02_risk_register_mitigation.prompt.yaml
+++ b/project_management/02_risk_register_mitigation.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Comprehensive Risk Register and Mitigation Plan
-description: Produce a risk register with mitigation actions and overall 
+description: Produce a risk register with mitigation actions and overall
   strategies.
 model: gpt-4o
 modelParameters:
@@ -24,5 +24,12 @@ messages:
 
       Output Format:
       Markdown table followed by a short list of overarching strategies.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      project_overview: Example overview
+    expected: |
+      Markdown table sorted by highest combined risk score.
+evaluators:
+  - name: Mentions mitigation actions
+    string:
+      contains: "Mitigation"

--- a/project_management/03_weekly_exec_status_report.prompt.yaml
+++ b/project_management/03_weekly_exec_status_report.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Weekly Executive Status Report
-description: Summarize project progress for executive stakeholders in a concise 
+description: Summarize project progress for executive stakeholders in a concise
   weekly report.
 model: gpt-4o
 modelParameters:
@@ -27,5 +27,12 @@ messages:
 
       Output Format:
       Markdown table followed by bullet lists for the remaining sections.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      update_notes: Example progress and issues
+    expected: |
+      Status report with RAG summary and bullet lists.
+evaluators:
+  - name: Includes RAG summary
+    string:
+      contains: "RAG summary"

--- a/project_management/04_detailed_project_blueprint_timeline.prompt.yaml
+++ b/project_management/04_detailed_project_blueprint_timeline.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Detailed Project Blueprint and Timeline
-description: Provide a comprehensive roadmap with phases, milestones, success 
+description: Provide a comprehensive roadmap with phases, milestones, success
   metrics, and stakeholders.
 model: gpt-4o
 modelParameters:
@@ -25,5 +25,14 @@ messages:
 
       Output Format:
       Markdown table outlining the project roadmap.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      project_type: Example project
+      objectives: Example objectives
+      milestone_data: Sample milestones
+    expected: |
+      Markdown table outlining phases, tasks, and owners.
+evaluators:
+  - name: Contains Phase column
+    string:
+      contains: "Phase"

--- a/project_management/05_risk_pre_mortem_analysis.prompt.yaml
+++ b/project_management/05_risk_pre_mortem_analysis.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Risk and Pre-Mortem Analysis
-description: Identify early failure points and mitigation strategies for a 
+description: Identify early failure points and mitigation strategies for a
   project or study.
 model: gpt-4o
 modelParameters:
@@ -24,5 +24,13 @@ messages:
 
       Output Format:
       Markdown table summarizing each risk and mitigation.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      project_name: Example Initiative
+      project_summary: Example summary
+    expected: |
+      Table listing potential failures with preventive steps.
+evaluators:
+  - name: Lists risks
+    string:
+      contains: "Risk"

--- a/project_management/06_status_update_task_prioritization.prompt.yaml
+++ b/project_management/06_status_update_task_prioritization.prompt.yaml
@@ -28,5 +28,12 @@ messages:
 
       Output Format:
       Structured bullet lists using the format above.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      status_notes: Example status details
+    expected: |
+      Bullet lists for Completed, Blockers, Next Actions, and Stakeholder Alerts.
+evaluators:
+  - name: Contains Blockers section
+    string:
+      contains: "Blockers"

--- a/project_management/07_clinical_trial_timeline_risk_radar.prompt.yaml
+++ b/project_management/07_clinical_trial_timeline_risk_radar.prompt.yaml
@@ -23,5 +23,12 @@ messages:
 
       Output Format:
       Markdown table followed by a bullet list of next actions.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      csv_data: "Task,Planned,Actual,Slack\nTask1,2024-01-01,2024-01-05,2"
+    expected: |
+      Table comparing planned versus actual dates and a next actions list.
+evaluators:
+  - name: Includes Next Actions list
+    string:
+      contains: "Next Actions"

--- a/project_management/07_portfolio_resource_budget_forecast.prompt.yaml
+++ b/project_management/07_portfolio_resource_budget_forecast.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Portfolio Resource and Budget Forecast
-description: Generate a rolling 12‑month FTE and budget forecast for active 
+description: Generate a rolling 12‑month FTE and budget forecast for active
   trials.
 model: gpt-4o
 modelParameters:
@@ -28,5 +28,13 @@ messages:
 
       Output Format:
       Markdown table followed by bullet list and calculation notes.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      historic_burn_rates: Sample burn rates
+      enrollment_deltas: Sample deltas
+    expected: |
+      Forecast table with cost, FTE, and variance percentage.
+evaluators:
+  - name: Contains Forecast table
+    string:
+      contains: "Forecast"

--- a/project_management/08_cross_study_risk_heat_map_mitigation_plan.prompt.yaml
+++ b/project_management/08_cross_study_risk_heat_map_mitigation_plan.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Cross-Study Operational Risk Heat Map and Mitigation Plan
-description: Identify and prioritize the top portfolio-level operational risks 
+description: Identify and prioritize the top portfolio-level operational risks
   and propose mitigations.
 model: gpt-4o
 modelParameters:
@@ -25,5 +25,12 @@ messages:
       - Table "Risk-Heat-Map".
       - Table "Mitigation-Plan".
       - Executive summary paragraph.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      risk_register: Example register
+    expected: |
+      Tables named Risk-Heat-Map and Mitigation-Plan with an executive summary.
+evaluators:
+  - name: Contains Risk-Heat-Map table
+    string:
+      contains: "Risk-Heat-Map"

--- a/project_management/08_sponsor_ready_monthly_status_brief.prompt.yaml
+++ b/project_management/08_sponsor_ready_monthly_status_brief.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sponsor-Ready Monthly Status Brief
-description: Draft a concise, escalation-ready monthly status report for study 
+description: Draft a concise, escalation-ready monthly status report for study
   sponsors.
 model: gpt-4o
 modelParameters:
@@ -23,5 +23,12 @@ messages:
 
       Output Format:
       Markdown document with H2 section headers as listed above.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      monthly_notes: Example monthly notes
+    expected: |
+      Document with sections Enrollment, Budget, Milestones, Risks & Mitigations, and Requests/Decisions Needed.
+evaluators:
+  - name: Includes Enrollment section
+    string:
+      contains: "Enrollment"

--- a/project_management/09_executive_sponsor_briefing_deck_outline.prompt.yaml
+++ b/project_management/09_executive_sponsor_briefing_deck_outline.prompt.yaml
@@ -24,5 +24,14 @@ messages:
 
       Output Format:
       Ordered list of slides in Markdown.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      kpi_snapshot: Example KPIs
+      strategic_wins: Example wins
+      challenges: Example challenges
+    expected: |
+      Slide outline following a Situation–Complication–Resolution–Ask arc.
+evaluators:
+  - name: Contains Decision Request slide
+    string:
+      contains: "Decision Request"

--- a/project_management/09_tmf_gap_analysis_audit_readiness_check.prompt.yaml
+++ b/project_management/09_tmf_gap_analysis_audit_readiness_check.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: TMF Gap-Analysis and Audit Readiness Check
-description: Identify missing or outdated Trial Master File documents and 
+description: Identify missing or outdated Trial Master File documents and
   propose corrective actions.
 model: gpt-4o
 modelParameters:
@@ -23,5 +23,12 @@ messages:
 
       Output Format:
       Markdown table followed by a numbered action plan.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      tmf_index: Example TMF index
+    expected: |
+      Table listing Doc_ID, Gap_Type, and Corrective_Action with action plan.
+evaluators:
+  - name: Includes Gap_Type column
+    string:
+      contains: "Gap_Type"

--- a/project_management/10_neutral_scrum_retro.prompt.yaml
+++ b/project_management/10_neutral_scrum_retro.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Neutral Scrum Retrospective Facilitator
-description: Design a balanced 60-minute remote sprint retrospective for seven 
+description: Design a balanced 60-minute remote sprint retrospective for seven
   participants.
 model: gpt-4o
 modelParameters:
@@ -22,5 +22,11 @@ messages:
 
       Output Format:
       Markdown with headers for each section.
-testData: []
-evaluators: []
+testData:
+  - vars: {}
+    expected: |
+      Markdown sections for ice breakers, Start/Stop/Continue board, probing questions, and closing ritual.
+evaluators:
+  - name: Contains Start/Stop/Continue board
+    string:
+      contains: "Start / Stop / Continue"

--- a/project_management/10_rollout_risk_matrix.prompt.yaml
+++ b/project_management/10_rollout_risk_matrix.prompt.yaml
@@ -22,5 +22,12 @@ messages:
 
       Output Format:
       Markdown table followed by short mitigation actions.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      risk_list: "Risk A; Risk B"
+    expected: |
+      3×3 risk matrix with mitigation actions.
+evaluators:
+  - name: Lists mitigation actions
+    string:
+      contains: "Mitigation"


### PR DESCRIPTION
## Summary
- add sample `testData` and `evaluators` blocks to project management prompts
- trim trailing whitespace in prompts to satisfy `yamllint`

## Testing
- `yamllint project_management/*.prompt.yaml`
- `scripts/validate_prompts.sh` *(fails: trailing spaces in technical_writer_prompts/03_sae_reporting_sop.prompt.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_689e26fb4920832c9be075d4b3af2576