### PR TITLE
Add test data and evaluators for productivity prompts

### DIFF
--- a/productivity_prompts/01_eisenhower_matrix_coach.prompt.yaml
+++ b/productivity_prompts/01_eisenhower_matrix_coach.prompt.yaml
@@ -27,5 +27,17 @@ messages:
 
       Additional notes:
       Keep the entire reply under 150 words.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      tasks: |-
+        Prepare presentation for Monday
+        Pay utility bill
+        Research vacation destinations
+        Organize desk
+    expected: |-
+      | ✅ Do Now | 📅 Schedule | ↗ Delegate | 🗑 Delete |
+      | --- | --- | --- | --- |
+evaluators:
+  - name: Includes all four quadrants
+    string:
+      contains: '🗑 Delete'

--- a/productivity_prompts/02_second_order_thinking_oracle.prompt.yaml
+++ b/productivity_prompts/02_second_order_thinking_oracle.prompt.yaml
@@ -27,5 +27,15 @@ messages:
 
       Additional notes:
       Keep the entire response under 140 words and use plain language.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      decision: adopt remote work policy
+    expected: |-
+      | Now | First-Order Outcome | Second-Order Consequence |
+      | 6 months | First-Order Outcome | Second-Order Consequence |
+      | 2 years | First-Order Outcome | Second-Order Consequence |
+      Net strategic value: 0
+evaluators:
+  - name: Includes three time horizons
+    string:
+      contains: '2 years'

--- a/productivity_prompts/03_fishbone_facilitator.prompt.yaml
+++ b/productivity_prompts/03_fishbone_facilitator.prompt.yaml
@@ -26,5 +26,15 @@ messages:
 
       Additional notes:
       Limit the entire reply to 120 words.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      problem: production line downtime
+    expected: |-
+      - Methods:
+        - ...
+      - Machines:
+        - ...
+evaluators:
+  - name: Mentions Methods category
+    string:
+      contains: 'Methods'

--- a/productivity_prompts/04_heros_journey_storyboarder.prompt.yaml
+++ b/productivity_prompts/04_heros_journey_storyboarder.prompt.yaml
@@ -27,5 +27,13 @@ messages:
 
       Additional notes:
       Kid-friendly tone is optional.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      product: eco-friendly scooter
+    expected: |-
+      **Ordinary World** - ...
+      **Return with Elixir** - ...
+evaluators:
+  - name: Includes Return with Elixir beat
+    string:
+      contains: 'Return with Elixir'

--- a/productivity_prompts/05_raci_mapper.prompt.yaml
+++ b/productivity_prompts/05_raci_mapper.prompt.yaml
@@ -27,5 +27,16 @@ messages:
 
       Additional notes:
       Keep the response under 130 words and avoid jargon.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      project_phase: Launch
+      tasks: |-
+        Design marketing plan - AB
+        Build landing page - CD
+    expected: |-
+      | Task | R | A | C | I |
+      | --- | --- | --- | --- | --- |
+evaluators:
+  - name: Outputs RACI headers
+    string:
+      contains: '| Task | R | A | C | I |'


### PR DESCRIPTION
## Summary
- add sample testData and basic evaluators to productivity coaching prompts
- run repository docs index update script
- lint productivity prompts with yamllint

## Testing
- `python scripts/update_docs_index.py`
- `yamllint productivity_prompts/01_eisenhower_matrix_coach.prompt.yaml productivity_prompts/02_second_order_thinking_oracle.prompt.yaml productivity_prompts/03_fishbone_facilitator.prompt.yaml productivity_prompts/04_heros_journey_storyboarder.prompt.yaml productivity_prompts/05_raci_mapper.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e26fb26c8832cb368cfd1492336dc