### PR TITLE
Add test data and evaluators to payment prompts

### DIFF
--- a/payment_prompts/01_audit_ready_site_payment_schedule.prompt.yaml
+++ b/payment_prompts/01_audit_ready_site_payment_schedule.prompt.yaml
@@ -36,5 +36,20 @@ messages:
 
       Additional notes:
       Ensure calculations and triggers are fully traceable for auditors.
-testData: []
-evaluators: []
+testData:
+  - visit_grid: |-
+      Milestone,Trigger,Local Rate
+      V1,SDV complete,100
+    cta_budget: "1000 USD"
+    fx_table: |-
+      Currency,USD
+      USD,1
+    fmv_benchmarks: |-
+      Milestone,USD
+      V1,90
+    expected: |-
+      | Milestone | Trigger | Local Rate | USD Rate | Tax | Net Payable | Expected Date |
+evaluators:
+  - name: Contains payment schedule table
+    string:
+      contains: "| Milestone | Trigger |"

--- a/payment_prompts/02_sunshine_act_fmv_compliance_check.prompt.yaml
+++ b/payment_prompts/02_sunshine_act_fmv_compliance_check.prompt.yaml
@@ -36,5 +36,19 @@ messages:
 
       Additional notes:
       Use clear column headers so the tables can be imported without modification.
-testData: []
-evaluators: []
+testData:
+  - payment_ledger_csv: |-
+      NPI,Amount
+      1234567890,150
+    fx_rates: |-
+      Currency,USD
+      USD,1
+    fmv_table: |-
+      Procedure,FMV
+      Consult,100
+    expected: |-
+      Reportable Payments
+evaluators:
+  - name: Generates reportable payments table
+    string:
+      contains: "Reportable Payments"

--- a/payment_prompts/03_payment_process_risk_assessment.prompt.yaml
+++ b/payment_prompts/03_payment_process_risk_assessment.prompt.yaml
@@ -33,5 +33,16 @@ messages:
 
       Additional notes:
       Cite external benchmarks or stats where relevant.
-testData: []
-evaluators: []
+testData:
+  - workflow_description: |-
+      Manual invoice tracking in spreadsheets
+    kpi_metrics: |-
+      error_rate: 5%
+    technology_stack: |-
+      Excel; Email
+    expected: |-
+      risk
+evaluators:
+  - name: Mentions risk in output
+    string:
+      contains: "risk"

--- a/payment_prompts/04_investigator_site_payment_forecast.prompt.yaml
+++ b/payment_prompts/04_investigator_site_payment_forecast.prompt.yaml
@@ -33,5 +33,19 @@ messages:
 
       Additional notes:
       Keep the table easy to import into spreadsheets.
-testData: []
-evaluators: []
+testData:
+  - site_data: |-
+      Site_ID,Country,Currency,Enrollment,Start-up
+      S1,US,USD,10,1000
+    enrollment_curve: |-
+      Month,Percent
+      1,10
+    fx_rates: |-
+      Currency,USD
+      USD,1
+    expected: |-
+      | Site ID |
+evaluators:
+  - name: Contains site ID column
+    string:
+      contains: "| Site ID |"

--- a/payment_prompts/05_payment_reconciliation_discrepancy_report.prompt.yaml
+++ b/payment_prompts/05_payment_reconciliation_discrepancy_report.prompt.yaml
@@ -33,5 +33,18 @@ messages:
 
       Additional notes:
       Keep recommendations actionable and concise.
-testData: []
-evaluators: []
+testData:
+  - payment_ledger: |-
+      Site_ID,Milestone,Amount
+      S1,Start-up,1000
+    cta_budget: |-
+      Milestone,Amount
+      Start-up,1000
+    site_queries: |-
+      S1: none
+    expected: |-
+      Issue_Type
+evaluators:
+  - name: Contains issue type column
+    string:
+      contains: "Issue_Type"

--- a/payment_prompts/06_global_regulatory_tax_matrix.prompt.yaml
+++ b/payment_prompts/06_global_regulatory_tax_matrix.prompt.yaml
@@ -27,5 +27,12 @@ messages:
 
       Additional notes:
       Keep language concise and reference official guidance where possible.
-testData: []
-evaluators: []
+testData:
+  - regional_guidelines: |-
+      US: 1099 reporting
+    expected: |-
+      | Region |
+evaluators:
+  - name: Contains region column
+    string:
+      contains: "| Region |"


### PR DESCRIPTION
## Summary
- add sample `testData` sections to payment prompt files
- include simple `evaluators` for basic output validation

## Testing
- `pip install yamllint`
- `yamllint payment_prompts/01_audit_ready_site_payment_schedule.prompt.yaml payment_prompts/02_sunshine_act_fmv_compliance_check.prompt.yaml payment_prompts/03_payment_process_risk_assessment.prompt.yaml payment_prompts/04_investigator_site_payment_forecast.prompt.yaml payment_prompts/05_payment_reconciliation_discrepancy_report.prompt.yaml payment_prompts/06_global_regulatory_tax_matrix.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e26f9e380832c89734a2d51a356e1