### PR TITLE
Add test cases and evaluators for design prompts

### DIFF
--- a/design_prompts/01_design_md_template.prompt.yaml
+++ b/design_prompts/01_design_md_template.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Design.md Template
-description: Generate a design.md template capturing problem, constraints, and 
+description: Generate a design.md template capturing problem, constraints, and
   decisions.
 model: gpt-4o
 modelParameters:
@@ -13,5 +13,15 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |
+      Design a microservice for processing image uploads.
+    expected: |
+      Template includes sections: Problem, Constraints, and Key Decisions.
+evaluators:
+  - name: Contains Problem section
+    string:
+      contains: "## Problem"
+  - name: Contains Key Decisions section
+    string:
+      contains: "## Key Decisions"

--- a/design_prompts/02_email_assistant_go_no_go_vote.prompt.yaml
+++ b/design_prompts/02_email_assistant_go_no_go_vote.prompt.yaml
@@ -13,5 +13,16 @@ messages:
   - role: user
     content: |
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |
+      Prototype feedback:
+        - UX designer impressed with usability.
+        - Data scientist concerned about privacy.
+        - CFO notes high projected costs.
+      Should we proceed with development?
+    expected: |
+      Summary of each persona's vote and final Go or No-Go recommendation.
+evaluators:
+  - name: Mentions a Go or No-Go decision
+    string:
+      contains: "Go"


### PR DESCRIPTION
## Summary
- add sample input and evaluators to Design.md template prompt
- extend AI Email Assistant Go/No-Go vote prompt with test data and validation

## Testing
- `yamllint design_prompts/01_design_md_template.prompt.yaml design_prompts/02_email_assistant_go_no_go_vote.prompt.yaml`
- `python3 scripts/validate_prompt_schema.py`
- `scripts/validate_prompts.sh` *(fails: trailing spaces in communication_prompts/10_red_team_stress_test.prompt.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_689e26f682f8832cacedfdce5f386d77