### PR TITLE
Add test data and evaluators for data management prompts

### DIFF
--- a/data_management_prompts/01_unified_data_cleansing.prompt.yaml
+++ b/data_management_prompts/01_unified_data_cleansing.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Unified Data Cleansing
-description: Outline a unified data cleansing approach for clinical trial 
+description: Outline a unified data cleansing approach for clinical trial
   datasets.
 model: gpt-4o
 modelParameters:
@@ -13,5 +13,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Provide a brief plan for cleansing datasets collected from multiple sites.
+    expected: Includes steps for removing duplicates and aligning formats.
+evaluators:
+  - name: Output mentions cleansing
+    string:
+      contains: "cleansing"

--- a/data_management_prompts/02_regulatory_gap_analysis.prompt.yaml
+++ b/data_management_prompts/02_regulatory_gap_analysis.prompt.yaml
@@ -12,5 +12,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Review data workflow for GDPR compliance.
+    expected: Highlights missing consent records.
+evaluators:
+  - name: Output mentions compliance
+    string:
+      contains: "compliance"

--- a/data_management_prompts/03_data_architecture_blueprint.prompt.yaml
+++ b/data_management_prompts/03_data_architecture_blueprint.prompt.yaml
@@ -11,5 +11,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Design a high-level architecture for storing clinical trial data.
+    expected: Mentions staging, warehouse, and analytics layers.
+evaluators:
+  - name: Output mentions architecture
+    string:
+      contains: "architecture"

--- a/data_management_prompts/04_clinical_etl_mapping_spec.prompt.yaml
+++ b/data_management_prompts/04_clinical_etl_mapping_spec.prompt.yaml
@@ -12,5 +12,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Map source patient records to target schema fields.
+    expected: Includes field-to-field mappings.
+evaluators:
+  - name: Output mentions mapping
+    string:
+      contains: "mapping"

--- a/data_management_prompts/05_clinical_etl_transformation_qc.prompt.yaml
+++ b/data_management_prompts/05_clinical_etl_transformation_qc.prompt.yaml
@@ -12,5 +12,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      List QC checks for transforming lab results data.
+    expected: Mentions range validations and format consistency.
+evaluators:
+  - name: Output mentions validation
+    string:
+      contains: "validation"

--- a/data_management_prompts/06_clinical_etl_pipeline_review.prompt.yaml
+++ b/data_management_prompts/06_clinical_etl_pipeline_review.prompt.yaml
@@ -12,5 +12,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Assess pipeline stages for bottlenecks.
+    expected: Identifies slow transformations and load issues.
+evaluators:
+  - name: Output mentions pipeline
+    string:
+      contains: "pipeline"

--- a/data_management_prompts/07_phase_ii_oncology_dmp.prompt.yaml
+++ b/data_management_prompts/07_phase_ii_oncology_dmp.prompt.yaml
@@ -11,5 +11,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Draft key sections of the DMP for a Phase II trial.
+    expected: Includes data collection, cleaning, and storage plans.
+evaluators:
+  - name: Output mentions plan
+    string:
+      contains: "plan"

--- a/data_management_prompts/08_decentralized_trial_risk_matrix.prompt.yaml
+++ b/data_management_prompts/08_decentralized_trial_risk_matrix.prompt.yaml
@@ -12,5 +12,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      List potential risks for remote patient monitoring.
+    expected: Includes mitigation strategies and risk levels.
+evaluators:
+  - name: Output mentions risk
+    string:
+      contains: "risk"

--- a/data_management_prompts/09_sop_gap_analysis.prompt.yaml
+++ b/data_management_prompts/09_sop_gap_analysis.prompt.yaml
@@ -11,5 +11,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Review SOPs for data entry processes.
+    expected: Identifies missing version controls.
+evaluators:
+  - name: Output mentions SOP
+    string:
+      contains: "SOP"


### PR DESCRIPTION
## Summary
- add sample test inputs and evaluation checks to data management prompts for completeness

## Testing
- `yamllint data_management_prompts/*.prompt.yaml`
- `python scripts/update_docs_index.py`

------
https://chatgpt.com/codex/tasks/task_e_689e26f5ca7c832c9deacf68ef3a21e7