### PR TITLE
Add test data and evaluators to communication prompts

### DIFF
--- a/communication_prompts/01_explain_like_im_5.prompt.yaml
+++ b/communication_prompts/01_explain_like_im_5.prompt.yaml
@@ -14,5 +14,13 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Gravity
+    expected: |-
+      Imagine a magnet pulling toys to the floor.
+      Apples drop, rain falls, and we stay on the ground.
+      Grown-up summary: Gravity is Earth's pull on objects.
+evaluators:
+  - name: Output includes grown-up summary
+    string:
+      contains: 'Grown-up summary'

--- a/communication_prompts/02_tldr_summarizer.prompt.yaml
+++ b/communication_prompts/02_tldr_summarizer.prompt.yaml
@@ -12,5 +12,15 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Eating vegetables boosts health and energy.
+    expected: |-
+      - Veggies give vitamins.
+      - Energy rises with greens.
+      - Health improves daily.
+      Next step: Add a salad to meals.
+evaluators:
+  - name: Output lists next step
+    string:
+      contains: 'Next step'

--- a/communication_prompts/03_80_20_crash_course.prompt.yaml
+++ b/communication_prompts/03_80_20_crash_course.prompt.yaml
@@ -13,5 +13,13 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Time management
+    expected: |-
+      - Focus on high-value tasks — finish reports first.
+      - Batch small chores to save time.
+      Practice exercise: Plan tomorrow using these steps.
+evaluators:
+  - name: Output mentions practice exercise
+    string:
+      contains: 'Practice exercise'

--- a/communication_prompts/04_smart_task_prioritizer.prompt.yaml
+++ b/communication_prompts/04_smart_task_prioritizer.prompt.yaml
@@ -13,5 +13,18 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Write report
+      Clean desk
+      Pay bills
+    expected: |-
+      Task | Urgency | Impact | Effort | Priority Score
+      Write report | 5 | 5 | 3 | 8.3
+      Pay bills | 4 | 4 | 2 | 8
+      Clean desk | 1 | 2 | 1 | 2
+      First tasks: Write report, Pay bills, Clean desk.
+evaluators:
+  - name: Output shows priority score
+    string:
+      contains: 'Priority Score'

--- a/communication_prompts/05_devils_advocate_stress_test.prompt.yaml
+++ b/communication_prompts/05_devils_advocate_stress_test.prompt.yaml
@@ -13,5 +13,16 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Launch a new social app
+    expected: |-
+      Objection 1: crowded market; Example: many apps fail.
+      Mitigation: offer unique community.
+      Objection 2: privacy risk; Example: data leaks.
+      Mitigation: strong encryption.
+      Objection 3: low retention; Example: early churn.
+      Mitigation: gamified rewards.
+evaluators:
+  - name: Output lists mitigations
+    string:
+      contains: 'Mitigation'

--- a/communication_prompts/06_storyboard_my_idea.prompt.yaml
+++ b/communication_prompts/06_storyboard_my_idea.prompt.yaml
@@ -13,5 +13,17 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Eco-friendly water bottle
+    expected: |-
+      Frame 1: Plastic waste piles up.
+      Frame 2: Reusable bottle introduced.
+      Frame 3: People refill happily.
+      Frame 4: Bottle features shown.
+      Frame 5: Community cleanup.
+      Frame 6: Clean beach celebration.
+      Takeaway: Every refill protects the ocean.
+evaluators:
+  - name: Output includes frame 6
+    string:
+      contains: 'Frame 6'

--- a/communication_prompts/07_rapid_risk_matrix.prompt.yaml
+++ b/communication_prompts/07_rapid_risk_matrix.prompt.yaml
@@ -14,5 +14,15 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Backyard treehouse project
+    expected: |-
+      Risk | Likelihood | Impact | Raw-Score | Mitigation
+      Fall injuries | 3 | 4 | 12 | safety rails
+      Rotting wood | 2 | 5 | 10 | sealant
+      Storm damage | 4 | 3 | 12 | anchors
+      Monitor top risks: inspect rails weekly; check weather alerts.
+evaluators:
+  - name: Output shows raw-score
+    string:
+      contains: 'Raw-Score'

--- a/communication_prompts/08_data_to_insight_analyst.prompt.yaml
+++ b/communication_prompts/08_data_to_insight_analyst.prompt.yaml
@@ -16,5 +16,21 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      date,sales
+      Jan,10
+      Feb,20
+      Mar,30
+    expected: |-
+      Question 1: Are there promotions?
+      Question 2: Which region?
+      Question 3: Any returns?
+      Insight 1: Sales rise each month – line chart date vs sales.
+      Insight 2: Highest jump from Feb to Mar – bar chart month vs growth.
+      Insight 3: No declines detected – table month vs sales.
+      Follow-up experiment: test weekend promotion.
+evaluators:
+  - name: Output proposes follow-up experiment
+    string:
+      contains: 'Follow-up experiment'

--- a/communication_prompts/09_socratic_coach.prompt.yaml
+++ b/communication_prompts/09_socratic_coach.prompt.yaml
@@ -14,5 +14,16 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Improving public speaking
+    expected: |-
+      What situations make you most nervous?
+      Summary: Speaker fears forgetting words.
+      Next actions:
+      1. Practice key points.
+      2. Record rehearsals.
+      3. Join a speaking club.
+evaluators:
+  - name: Output asks a question
+    string:
+      contains: '?'

--- a/communication_prompts/10_red_team_stress_test.prompt.yaml
+++ b/communication_prompts/10_red_team_stress_test.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Red-Team Stress-Test
-description: Form a red-team panel of 3 experts (Technical Hacker, Ruthless 
+description: Form a red-team panel of 3 experts (Technical Hacker, Ruthless
   Competitor CEO, Regulatory Officer).
 model: gpt-4
 modelParameters:
@@ -17,5 +17,16 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: New online payment platform
+    expected: |-
+      Technical Hacker: breach data; inject malware.
+      Competitor CEO: undercut fees; poach merchants.
+      Regulatory Officer: non-compliance fines; audit failures.
+      Ranked attacks: data breach, fee war, compliance gaps.
+      Mitigations: encryption, reserve fund, audit trail.
+      Metric: weekly fraud rate.
+evaluators:
+  - name: Output specifies metric
+    string:
+      contains: 'Metric'

--- a/communication_prompts/11_analogy_architect.prompt.yaml
+++ b/communication_prompts/11_analogy_architect.prompt.yaml
@@ -16,5 +16,14 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Blockchain
+    expected: |-
+      1. **Ledger** like a shared notebook; each entry is a block.
+      2. **Chain** like linked train cars; break one and records stop.
+      3. **Vault** like a bank safe with codes.
+      Accuracy check: Analogies omit technical complexity.
+evaluators:
+  - name: Output uses bold analogies
+    string:
+      contains: '**'

--- a/communication_prompts/12_density_refiner.prompt.yaml
+++ b/communication_prompts/12_density_refiner.prompt.yaml
@@ -21,5 +21,18 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Elephants migrate long distances for food and water.
+    expected: |-
+      **Gist**
+      Elephants travel for food and water.
+      **Missing Entities**
+      Savannah, herds.
+      **Dense Summary**
+      Elephant herds cross savannahs seeking water holes as seasons shift.
+      **Reflection**
+      Adding locations clarified context.
+evaluators:
+  - name: Output includes dense summary
+    string:
+      contains: 'Dense Summary'

--- a/communication_prompts/13_negotiation_coach.prompt.yaml
+++ b/communication_prompts/13_negotiation_coach.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Negotiation Coach
-description: Prepare the user for salary negotiations by roleplaying as a 
+description: Prepare the user for salary negotiations by roleplaying as a
   manager and offering feedback.
 model: gpt-4
 modelParameters:
@@ -36,5 +36,18 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: I'd like a 20% raise for my performance.
+    expected: |-
+      Manager: Let's discuss your contributions first.
+      ---
+      Best move | Worst move
+      Data use | Weak timing
+      Tips:
+      - Present market data.
+      - Pick quieter moment.
+      - Rehearse responses.
+evaluators:
+  - name: Output contains markdown divider
+    string:
+      contains: '---'

--- a/communication_prompts/14_panel_debate.prompt.yaml
+++ b/communication_prompts/14_panel_debate.prompt.yaml
@@ -22,5 +22,19 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Remote work
+    expected: |-
+      Proponent: boosts flexibility.
+      Opponent: lowers team cohesion.
+      Moderator: notes key points.
+      Rebuttal round 1...
+      Rebuttal round 2...
+      Moderator Table:
+      Point | Agreement?
+      Flex time | Yes
+      Takeaway: balance office days with remote options.
+evaluators:
+  - name: Output references moderator
+    string:
+      contains: 'Moderator'

--- a/communication_prompts/15_scamper_ideation_coach.prompt.yaml
+++ b/communication_prompts/15_scamper_ideation_coach.prompt.yaml
@@ -19,5 +19,21 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Coffee mug
+    expected: |-
+      Substitute: use bamboo; Idea: eco mug.
+      Combine: mug + warmer; Idea: self-heating cup.
+      Adapt: travel lid; Idea: spill-proof mug.
+      Modify: enlarge handle; Idea: two-finger grip.
+      Put to other use: plant pot idea.
+      Eliminate: remove handle for stackable design.
+      Reverse: cools drinks instead.
+      Idea | Feasibility | Impact
+      self-heating cup | Med | High
+      eco mug | High | Med
+      spill-proof mug | High | Med
+evaluators:
+  - name: Output ranks ideas with feasibility
+    string:
+      contains: 'Feasibility'

--- a/communication_prompts/16_empathy_map_facilitator.prompt.yaml
+++ b/communication_prompts/16_empathy_map_facilitator.prompt.yaml
@@ -20,5 +20,16 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Busy parent using meal kits
+    expected: |-
+      Says: "I need quick dinners."
+      Thinks: "Am I a good cook?"
+      Does: orders kits weekly.
+      Feels: relieved but guilty.
+      Insight: Parents seek time-saving confidence.
+      Next-step research question: What recipes feel intimidating?
+evaluators:
+  - name: Output includes next-step question
+    string:
+      contains: 'Next-step'

--- a/communication_prompts/17_rubber_duck_debugger.prompt.yaml
+++ b/communication_prompts/17_rubber_duck_debugger.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Rubber Duck Debugger
-description: Guide developers through self-explanation to uncover bugs before 
+description: Guide developers through self-explanation to uncover bugs before
   providing fixes.
 model: gpt-4
 modelParameters:
@@ -21,5 +21,21 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      for i in range(5):
+          print(i)
+      # nothing prints
+    expected: |-
+      Why do you expect output?
+      Did you run the file?
+      Diagnosis: loop unused.
+      ```python
+      for i in range(5):
+          print(i)
+      ```
+      Tip: run script after saving.
+evaluators:
+  - name: Output gives diagnosis
+    string:
+      contains: 'Diagnosis'

--- a/communication_prompts/18_pitch_deck_outliner.prompt.yaml
+++ b/communication_prompts/18_pitch_deck_outliner.prompt.yaml
@@ -20,5 +20,20 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Time-tracking app for freelancers
+    expected: |-
+      Slide 1: Problem – freelancers lose billable hours.
+      Slide 2: Solution – simple timer.
+      Slide 3: Market size.
+      Slide 4: Business model.
+      Slide 5: Traction.
+      Slide 6: Competition.
+      Slide 7: Team.
+      Slide 8: Ask.
+      Visual cues: clock icon on slides 1 and 2.
+      Success metric: daily active users.
+evaluators:
+  - name: Output notes success metric
+    string:
+      contains: 'Success metric'


### PR DESCRIPTION
## Summary
- add sample `testData` and `evaluators` sections to each communication prompt

## Testing
- `yamllint communication_prompts/*.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e26f33850832c85a9edd66b25a579