### PR TITLE
Add test scaffolding to Codex prompts

### DIFF
--- a/codex_prompts/01_project_init_codex.prompt.yaml
+++ b/codex_prompts/01_project_init_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Project Init & Skeleton (OpenAI Codex)
-description: Spin up a brand-new repository with a minimal but runnable 
+description: Spin up a brand-new repository with a minimal but runnable
   skeleton, plus a one-command local dev experience.
 model: gpt-4
 modelParameters:
@@ -24,5 +24,14 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      project_name: example-app
+      language: python
+      package_manager: pip
+      monorepo: no
+    expected: Project Initialized -
+evaluators:
+  - name: Output starts with 'Project Initialized -'
+    string:
+      startsWith: 'Project Initialized -'

--- a/codex_prompts/02_codebase_testing_plan.prompt.yaml
+++ b/codex_prompts/02_codebase_testing_plan.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Codebase Testing Plan
-description: Generate a detailed analysis of an existing codebase **and** 
+description: Generate a detailed analysis of an existing codebase **and**
   produce a step-by-step plan to introduce or improve automated testing, aligned
   with project priorities, team skills, and CI/CD constraints.
 model: gpt-4
@@ -77,5 +77,13 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      repo_path: /tmp/repo
+      languages: [python]
+      team_size: 5
+    expected: Testing Plan -
+evaluators:
+  - name: Output starts with 'Testing Plan -'
+    string:
+      startsWith: 'Testing Plan -'

--- a/codex_prompts/03_tooling_and_quality_codex.prompt.yaml
+++ b/codex_prompts/03_tooling_and_quality_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Tooling, Linting & Quality Gates (OpenAI Codex)
-description: Add opinionated linters, formatters, type-checkers, commit hooks, 
+description: Add opinionated linters, formatters, type-checkers, commit hooks,
   and test frameworks so the repo “fails fast” on bad code.
 model: gpt-4
 modelParameters:
@@ -29,5 +29,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      language: javascript
+    expected: Tooling Added -
+evaluators:
+  - name: Output starts with 'Tooling Added -'
+    string:
+      startsWith: 'Tooling Added -'

--- a/codex_prompts/04_ci_cd_codex.prompt.yaml
+++ b/codex_prompts/04_ci_cd_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Continuous Integration & Delivery (OpenAI Codex)
-description: Generate GitHub Actions workflows that build, test, version, and 
+description: Generate GitHub Actions workflows that build, test, version, and
   deploy the app (often a containerised service that calls the OpenAI API).
 model: gpt-4
 modelParameters:
@@ -33,5 +33,12 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      environments: [dev, prod]
+      platform: vercel
+    expected: CI/CD Workflow -
+evaluators:
+  - name: Output starts with 'CI/CD Workflow -'
+    string:
+      startsWith: 'CI/CD Workflow -'

--- a/codex_prompts/05_docs_and_onboarding_codex.prompt.yaml
+++ b/codex_prompts/05_docs_and_onboarding_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Documentation & Developer Onboarding (OpenAI Codex)
-description: Create living docs that cut time-to-first-PR and capture 
+description: Create living docs that cut time-to-first-PR and capture
   architectural decisions.
 model: gpt-4
 modelParameters:
@@ -30,5 +30,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      focus: README
+    expected: Docs Plan -
+evaluators:
+  - name: Output starts with 'Docs Plan -'
+    string:
+      startsWith: 'Docs Plan -'

--- a/codex_prompts/06_refactoring_suggestions_codex.prompt.yaml
+++ b/codex_prompts/06_refactoring_suggestions_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Refactoring Suggestions (OpenAI Codex)
-description: Suggest structural improvements for a complex file to increase 
+description: Suggest structural improvements for a complex file to increase
   readability and testability.
 model: gpt-4
 modelParameters:
@@ -21,5 +21,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      file_path: src/app.js
+    expected: Refactor Plan -
+evaluators:
+  - name: Output starts with 'Refactor Plan -'
+    string:
+      startsWith: 'Refactor Plan -'

--- a/codex_prompts/07_architecture_flow_codex.prompt.yaml
+++ b/codex_prompts/07_architecture_flow_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Architecture Flow Q&A (OpenAI Codex)
-description: Trace a request from client endpoint to database and document the 
+description: Trace a request from client endpoint to database and document the
   flow with a Mermaid diagram.
 model: gpt-4
 modelParameters:
@@ -21,5 +21,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      entry_point: /api/users
+    expected: Architecture Flow -
+evaluators:
+  - name: Output starts with 'Architecture Flow -'
+    string:
+      startsWith: 'Architecture Flow -'

--- a/codex_prompts/08_security_vulnerability_codex.prompt.yaml
+++ b/codex_prompts/08_security_vulnerability_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Security Vulnerability Hunt (OpenAI Codex)
-description: Locate and fix a memory-safety vulnerability in the specified 
+description: Locate and fix a memory-safety vulnerability in the specified
   package.
 model: gpt-4
 modelParameters:
@@ -21,5 +21,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      package_path: lib/memory.c
+    expected: Security Fix -
+evaluators:
+  - name: Output starts with 'Security Fix -'
+    string:
+      startsWith: 'Security Fix -'

--- a/codex_prompts/09_code_review_codex.prompt.yaml
+++ b/codex_prompts/09_code_review_codex.prompt.yaml
@@ -21,5 +21,12 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      diff: |
+        @@ line @@
+    expected: Code Review -
+evaluators:
+  - name: Output starts with 'Code Review -'
+    string:
+      startsWith: 'Code Review -'

--- a/codex_prompts/10_add_tests_codex.prompt.yaml
+++ b/codex_prompts/10_add_tests_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Targeted Test Generation (OpenAI Codex)
-description: Add unit or integration tests for specified files on the current 
+description: Add unit or integration tests for specified files on the current
   branch.
 model: gpt-4
 modelParameters:
@@ -21,5 +21,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      files: [src/utils.py]
+    expected: Tests Added -
+evaluators:
+  - name: Output starts with 'Tests Added -'
+    string:
+      startsWith: 'Tests Added -'

--- a/codex_prompts/11_bug_fix_codex.prompt.yaml
+++ b/codex_prompts/11_bug_fix_codex.prompt.yaml
@@ -20,5 +20,12 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      package_path: src/module.py
+      bug_description: failing edge case
+    expected: Bug Fix -
+evaluators:
+  - name: Output starts with 'Bug Fix -'
+    string:
+      startsWith: 'Bug Fix -'

--- a/codex_prompts/12_ui_fix_codex.prompt.yaml
+++ b/codex_prompts/12_ui_fix_codex.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: UI Tweak & Verification (OpenAI Codex)
-description: Resolve a minor UI regression and confirm the fix with build or 
+description: Resolve a minor UI regression and confirm the fix with build or
   test steps.
 model: gpt-4
 modelParameters:
@@ -21,5 +21,11 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      component_path: src/components/button.tsx
+    expected: UI Fix -
+evaluators:
+  - name: Output starts with 'UI Fix -'
+    string:
+      startsWith: 'UI Fix -'


### PR DESCRIPTION
## Summary
- add example `testData` and `evaluators` blocks to Codex prompt templates

## Testing
- `yamllint codex_prompts/01_project_init_codex.prompt.yaml codex_prompts/02_codebase_testing_plan.prompt.yaml codex_prompts/03_tooling_and_quality_codex.prompt.yaml codex_prompts/04_ci_cd_codex.prompt.yaml codex_prompts/05_docs_and_onboarding_codex.prompt.yaml codex_prompts/06_refactoring_suggestions_codex.prompt.yaml codex_prompts/07_architecture_flow_codex.prompt.yaml codex_prompts/08_security_vulnerability_codex.prompt.yaml codex_prompts/09_code_review_codex.prompt.yaml codex_prompts/10_add_tests_codex.prompt.yaml codex_prompts/11_bug_fix_codex.prompt.yaml codex_prompts/12_ui_fix_codex.prompt.yaml`
- `python scripts/update_docs_index.py`


------
https://chatgpt.com/codex/tasks/task_e_689e26f2c53c832cb072d41820d5c9ec