### PR TITLE
Add test cases and evaluators for clinical safety prompts

### DIFF
--- a/clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml
+++ b/clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Clinical Safety Synopsis for EU MDR CER
-description: Provide a concise clinical safety synopsis for the EU MDR Clinical 
+description: Provide a concise clinical safety synopsis for the EU MDR Clinical
   Evaluation Report.
 model: gpt-4
 modelParameters:
@@ -13,5 +13,12 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: >
+      55-year-old male experienced screw loosening requiring revision surgery.
+    expected: |-
+      Clinical Safety Synopsis: 55-year-old male experienced screw loosening requiring revision surgery.
+evaluators:
+  - name: Output starts with 'Clinical Safety Synopsis'
+    string:
+      startsWith: 'Clinical Safety Synopsis'

--- a/clinical_safety_prompts/02_fda_mdr_adverse_event_narrative.prompt.yaml
+++ b/clinical_safety_prompts/02_fda_mdr_adverse_event_narrative.prompt.yaml
@@ -17,5 +17,16 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |
+      Event date: 2024-05-01
+      Patient: 34-year-old female
+      Device ID: 12345
+      Reporter: Physician
+      Device returned: No
+    expected: |-
+      Adverse Event Narrative: 34-year-old female experienced skin irritation; device not returned.
+evaluators:
+  - name: Output ends with boilerplate sentence
+    string:
+      endsWith: 'This information is submitted to comply with 21 CFR 803.52.'

--- a/clinical_safety_prompts/03_post_market_safety_signal_trending.prompt.yaml
+++ b/clinical_safety_prompts/03_post_market_safety_signal_trending.prompt.yaml
@@ -12,5 +12,12 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: >
+      Complaints of rash increased from 2 to 8 between Q1 and Q2 2024.
+    expected: |-
+      Post-Market Safety Signal Trending: Rash complaints increased fourfold from Q1 to Q2 2024.
+evaluators:
+  - name: Output starts with 'Post-Market Safety Signal Trending'
+    string:
+      startsWith: 'Post-Market Safety Signal Trending'


### PR DESCRIPTION
## Summary
- add sample testData entries and evaluators for EU CER synopsis, FDA adverse-event narrative, and post-market safety signal prompts

## Testing
- `yamllint clinical_safety_prompts/01_eu_cer_clinical_safety_synopsis.prompt.yaml clinical_safety_prompts/02_fda_mdr_adverse_event_narrative.prompt.yaml clinical_safety_prompts/03_post_market_safety_signal_trending.prompt.yaml`
- `python scripts/validate_prompt_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_689e26f1d0a4832c8012b255dd95d694