### PR TITLE
Add test data and evaluators for clinical research manager prompts

### DIFF
--- a/clinical_research_manager_prompts/01_accelerate_patient_recruitment_retention.prompt.yaml
+++ b/clinical_research_manager_prompts/01_accelerate_patient_recruitment_retention.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Accelerate Patient Recruitment & Retention
-description: Design a 3-step recruitment and retention plan for a Phase II 
+description: Design a 3-step recruitment and retention plan for a Phase II
   oncology study within budget and timeline constraints.
 model: gpt-4
 modelParameters:
@@ -20,5 +20,10 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: All details confirmed, proceed.
+    expected: Action | Owner
+evaluators:
+  - name: Contains table headers
+    string:
+      contains: 'Action | Owner'

--- a/clinical_research_manager_prompts/02_digest_regulatory_updates.prompt.yaml
+++ b/clinical_research_manager_prompts/02_digest_regulatory_updates.prompt.yaml
@@ -1,7 +1,7 @@
 ---
 name: Digest the Latest Regulatory Updates Affecting My Protocol
-description: Summarize June 2025 FDA e-source guidance changes affecting 
-  protocol ABC-123, flagging mandatory versus recommended items and mapping to 
+description: Summarize June 2025 FDA e-source guidance changes affecting
+  protocol ABC-123, flagging mandatory versus recommended items and mapping to
   protocol sections.
 model: gpt-4
 modelParameters:
@@ -21,5 +21,13 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Please summarize key updates.
+    expected: Immediate Actions
+evaluators:
+  - name: Contains 'Immediate Actions' heading
+    string:
+      contains: 'Immediate Actions'
+  - name: Contains 'Monitor for Clarification' heading
+    string:
+      contains: 'Monitor for Clarification'

--- a/clinical_research_manager_prompts/03_portfolio_kpi_dashboard_brief.prompt.yaml
+++ b/clinical_research_manager_prompts/03_portfolio_kpi_dashboard_brief.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Portfolio KPI Dashboard Brief
-description: Produce a one-page executive dashboard of enrollment, deviation, 
+description: Produce a one-page executive dashboard of enrollment, deviation,
   SDV, and budget KPIs for live studies.
 model: gpt-4
 modelParameters:
@@ -21,5 +21,10 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Dashboard request acknowledged.
+    expected: XYZ-01
+evaluators:
+  - name: Mentions study ID
+    string:
+      contains: 'XYZ-01'


### PR DESCRIPTION
## Summary
- add example inputs and expected markers for clinical research manager prompt set
- define string-based evaluators to check for required sections and table headers

## Testing
- `yamllint clinical_research_manager_prompts/01_accelerate_patient_recruitment_retention.prompt.yaml clinical_research_manager_prompts/02_digest_regulatory_updates.prompt.yaml clinical_research_manager_prompts/03_portfolio_kpi_dashboard_brief.prompt.yaml`
- `python scripts/validate_prompt_schema.py && echo "schema validation passed"`


------
https://chatgpt.com/codex/tasks/task_e_689e26f18e38832c80bbe6883a253ac2