### PR TITLE
Add test data and evaluators to clinical prompts

### DIFF
--- a/clinical_prompts/01_crf_shell_generator.prompt.yaml
+++ b/clinical_prompts/01_crf_shell_generator.prompt.yaml
@@ -15,5 +15,13 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |
+      Study collects age and sex.
+    expected: |
+      | CRF Page | Field | CDASH Variable | Data Type | Permitted Values | SDTM Mapping |
+      | Demographics | Age | AGE | integer | >=0 | DM.AGE |
+evaluators:
+  - name: Output should include AGE mapping
+    string:
+      contains: DM.AGE

--- a/clinical_prompts/02_crf_quality_auditor.prompt.yaml
+++ b/clinical_prompts/02_crf_quality_auditor.prompt.yaml
@@ -15,5 +15,13 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |
+      Demographics form lists Age twice.
+    expected: |
+      | Issue | Recommended Fix |
+      | Duplicate field 'Age' | Remove one instance to avoid confusion. |
+evaluators:
+  - name: Should flag duplicate field
+    string:
+      contains: Duplicate field

--- a/clinical_prompts/03_cdash_mapping_completion_guide.prompt.yaml
+++ b/clinical_prompts/03_cdash_mapping_completion_guide.prompt.yaml
@@ -15,5 +15,13 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |
+      HEIGHT
+    expected: |
+      Variable | Domain | Instruction | Terminology/Units | Edit-Check
+      HEIGHT | DM.HEIGHT | Record height in cm | cm | 30-250
+evaluators:
+  - name: Output should start with CSV header
+    string:
+      startsWith: 'Variable | Domain | Instruction'


### PR DESCRIPTION
## Summary
- provide example test data for CRF shell generator and add evaluator for AGE mapping
- add sample input/output for CRF quality auditor and ensure duplicate fields are flagged
- supply test data and evaluator for CDASH mapping completion guide

## Testing
- `yamllint clinical_prompts/01_crf_shell_generator.prompt.yaml clinical_prompts/02_crf_quality_auditor.prompt.yaml clinical_prompts/03_cdash_mapping_completion_guide.prompt.yaml`
- `python scripts/update_docs_index.py`

------
https://chatgpt.com/codex/tasks/task_e_689e26f11d2c832c9ea1c3873c628bf9