### PR TITLE
Add test data and evaluators to clinical monitoring prompts

### DIFF
--- a/clinical_monitoring_prompts/01_risk_based_site_performance_dashboard.prompt.yaml
+++ b/clinical_monitoring_prompts/01_risk_based_site_performance_dashboard.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Risk-Based Site Performance Dashboard
-description: You are an experienced **Clinical Monitoring Manager** at a global 
+description: You are an experienced **Clinical Monitoring Manager** at a global
   CRO overseeing several Phase II oncology trials.
 model: gpt-4
 modelParameters:
@@ -21,5 +21,23 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      sites:
+        - id: S101
+          protocol_deviations: 4
+          query_aging_days: 12
+          ip_accountability_issues: 2
+          enrollment_lapse_days: 5
+          training_compliance: 95
+        - id: S102
+          protocol_deviations: 1
+          query_aging_days: 8
+          ip_accountability_issues: 0
+          enrollment_lapse_days: 0
+          training_compliance: 98
+    expected: Rank | Site ID | Composite Score | Key Drivers | Mitigation Plan | Target Date
+evaluators:
+  - name: Contains dashboard table
+    string:
+      contains: "Rank | Site ID | Composite Score"

--- a/clinical_monitoring_prompts/02_capa_plan_builder_for_monitoring_findings.prompt.yaml
+++ b/clinical_monitoring_prompts/02_capa_plan_builder_for_monitoring_findings.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: CAPA Plan Builder for Monitoring Findings
-description: You are a **Regulatory Quality Advisor** specializing in ICH-GCP 
+description: You are a **Regulatory Quality Advisor** specializing in ICH-GCP
   compliance.
 model: gpt-4
 modelParameters:
@@ -18,5 +18,13 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      issues:
+        - Missing signatures on consent forms
+        - Late adverse event reporting
+    expected: Issue | Root Cause | Corrective Action | Preventive Action | Owner | Due Date | Effectiveness Check
+evaluators:
+  - name: Returns CAPA table
+    string:
+      contains: "Issue | Root Cause | Corrective Action | Preventive Action | Owner | Due Date | Effectiveness Check"

--- a/clinical_monitoring_prompts/03_monitoring_visit_report_quality_critique.prompt.yaml
+++ b/clinical_monitoring_prompts/03_monitoring_visit_report_quality_critique.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Monitoring Visit Report (MVR) Quality Critique
-description: You are a **Senior Monitoring Oversight Lead** conducting quality 
+description: You are a **Senior Monitoring Oversight Lead** conducting quality
   review of a draft **Monitoring Visit Report (MVR)**.
 model: gpt-4
 modelParameters:
@@ -19,5 +19,15 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      section: AE/SAE reporting
+      text: Adverse events were summarized but severity grading was omitted.
+    expected: Summary of Critical Gaps
+evaluators:
+  - name: Contains summary block
+    string:
+      contains: "Summary of Critical Gaps"
+  - name: Contains redlines table
+    string:
+      contains: "Section | Current Text | Recommended Edit"


### PR DESCRIPTION
## Summary
- enrich clinical monitoring prompts with sample `testData` and `evaluators`
- clean up trailing spaces and ensure YAML structure

## Testing
- `yamllint clinical_monitoring_prompts/01_risk_based_site_performance_dashboard.prompt.yaml clinical_monitoring_prompts/02_capa_plan_builder_for_monitoring_findings.prompt.yaml clinical_monitoring_prompts/03_monitoring_visit_report_quality_critique.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e26f11274832c8f2a976ab3c2a01c