### PR TITLE
Add test data and evaluators for clinical data prompts

### DIFF
--- a/clinical_data_prompts/01_discrepancy_detection_query_log.prompt.yaml
+++ b/clinical_data_prompts/01_discrepancy_detection_query_log.prompt.yaml
@@ -24,5 +24,13 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Subject_ID,Visit,Field,Value
+      001,Baseline,Age,34
+      002,Baseline,Age,28
+    expected: No data discrepancies detected.
+evaluators:
+  - name: Should report no discrepancies
+    string:
+      equals: "No data discrepancies detected."

--- a/clinical_data_prompts/02_data_management_plan_section.prompt.yaml
+++ b/clinical_data_prompts/02_data_management_plan_section.prompt.yaml
@@ -11,5 +11,14 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: Include handling of out-of-range lab values.
+    expected: |-
+      Data Validation & Cleaning includes automated edit checks in Medidata Rave to flag out-of-range lab values.
+evaluators:
+  - name: Mentions Data Validation & Cleaning
+    string:
+      contains: "Data Validation & Cleaning"
+  - name: References Medidata Rave
+    string:
+      contains: "Medidata Rave"

--- a/clinical_data_prompts/03_edit_check_specification_builder.prompt.yaml
+++ b/clinical_data_prompts/03_edit_check_specification_builder.prompt.yaml
@@ -13,5 +13,13 @@ messages:
   - role: user
     content: |-
       {{input}}
-testData: []
-evaluators: []
+testData:
+  - input: |-
+      Field: CMSTDTC, CMENDTC
+      Rule: End Date must be on or after Start Date.
+    expected: |-
+      IF CMENDTC < CMSTDTC THEN raise query "End Date precedes Start Date."
+evaluators:
+  - name: Validates date order
+    string:
+      contains: "CMENDTC < CMSTDTC"


### PR DESCRIPTION
## Summary
- add sample test data and evaluation rules to discrepancy detection query log prompt
- include test case and evaluators for data management plan section drafting
- supply example input/output and evaluator for edit-check specification builder

## Testing
- `./scripts/validate_prompts.sh` *(fails: communication_prompts/17_rubber_duck_debugger.prompt.yaml trailing spaces)*

------
https://chatgpt.com/codex/tasks/task_e_689e26eefac8832c89f6708acd665b2f