### PR TITLE
Add evaluators to business development prompts

### DIFF
--- a/business_development_prompts/01_emerging_market_opportunity_scan.prompt.yaml
+++ b/business_development_prompts/01_emerging_market_opportunity_scan.prompt.yaml
@@ -29,4 +29,8 @@ testData:
       market_data_sources: example_market_data_sources
     expected: |-
       Concise executive summary with bullet points and a short table if helpful.
-evaluators: []
+
+evaluators:
+  - name: Includes bullet points
+    string:
+      contains: "- "

--- a/business_development_prompts/01_market_intelligence_radar.prompt.yaml
+++ b/business_development_prompts/01_market_intelligence_radar.prompt.yaml
@@ -33,4 +33,8 @@ testData:
       company_size: example_company_size
     expected: |-
       Markdown table followed by a short summary paragraph.
-evaluators: []
+
+evaluators:
+  - name: Includes markdown table
+    string:
+      contains: "|"

--- a/business_development_prompts/02_rapid_proposal_builder.prompt.yaml
+++ b/business_development_prompts/02_rapid_proposal_builder.prompt.yaml
@@ -32,4 +32,8 @@ testData:
       client_name: example_client_name
     expected: |-
       Markdown document with headings and a budget table.
-evaluators: []
+
+evaluators:
+  - name: Includes markdown heading
+    string:
+      contains: "#"

--- a/business_development_prompts/02_rfp_executive_summary_generator.prompt.yaml
+++ b/business_development_prompts/02_rfp_executive_summary_generator.prompt.yaml
@@ -30,4 +30,8 @@ testData:
       rfp_synopsis: example_rfp_synopsis
     expected: |-
       Single markdown section with concise paragraphs and bullet points as needed.
-evaluators: []
+
+evaluators:
+  - name: Includes bullet points
+    string:
+      contains: "- "

--- a/business_development_prompts/03_90_day_pipeline_health_review.prompt.yaml
+++ b/business_development_prompts/03_90_day_pipeline_health_review.prompt.yaml
@@ -30,4 +30,8 @@ testData:
       crm_csv: example_crm_csv
     expected: |-
       Markdown summary tables followed by bullet-point recommendations.
-evaluators: []
+
+evaluators:
+  - name: Includes markdown table
+    string:
+      contains: "|"

--- a/business_development_prompts/03_competitor_positioning_brief.prompt.yaml
+++ b/business_development_prompts/03_competitor_positioning_brief.prompt.yaml
@@ -29,4 +29,8 @@ testData:
       public_sources: example_public_sources
     expected: |-
       Markdown with two sections: a comparison table and a short narrative.
-evaluators: []
+
+evaluators:
+  - name: Includes markdown table
+    string:
+      contains: "|"


### PR DESCRIPTION
## Summary
- add simple evaluator checks to six business development prompt files
- ensure outputs include bullet lists, markdown headings, or tables

## Testing
- `yamllint business_development_prompts/01_emerging_market_opportunity_scan.prompt.yaml business_development_prompts/01_market_intelligence_radar.prompt.yaml business_development_prompts/02_rapid_proposal_builder.prompt.yaml business_development_prompts/02_rfp_executive_summary_generator.prompt.yaml business_development_prompts/03_90_day_pipeline_health_review.prompt.yaml business_development_prompts/03_competitor_positioning_brief.prompt.yaml`
- `python scripts/validate_prompt_schema.py`
- `python scripts/check_prompts.py`
- `python scripts/update_docs_index.py`

------
https://chatgpt.com/codex/tasks/task_e_689e26eeb9a0832ca1c434ac6553e1a9