### PR TITLE
Add evaluators to chemical characterization prompts

### DIFF
--- a/chemical_characterization_prompts/01_design_the_study.prompt.yaml
+++ b/chemical_characterization_prompts/01_design_the_study.prompt.yaml
@@ -28,4 +28,7 @@ testData:
   - input: ''
     expected: |-
       Completion follows instructions.
-evaluators: []
+evaluators:
+  - name: Output starts with a numbered list
+    string:
+      startsWith: '1.'

--- a/chemical_characterization_prompts/02_interpret_the_chemistry_assess_risk.prompt.yaml
+++ b/chemical_characterization_prompts/02_interpret_the_chemistry_assess_risk.prompt.yaml
@@ -31,4 +31,7 @@ testData:
   - input: ''
     expected: |-
       Completion follows instructions.
-evaluators: []
+evaluators:
+  - name: Output starts with a markdown table
+    string:
+      startsWith: '|'

--- a/chemical_characterization_prompts/03_write_the_regulatory_summary.prompt.yaml
+++ b/chemical_characterization_prompts/03_write_the_regulatory_summary.prompt.yaml
@@ -26,4 +26,7 @@ testData:
   - input: ''
     expected: |-
       Completion follows instructions.
-evaluators: []
+evaluators:
+  - name: Output starts with an H2 heading
+    string:
+      startsWith: '##'


### PR DESCRIPTION
## Summary
- add simple start-of-output evaluators for chemical characterization prompt suite

## Testing
- `yamllint chemical_characterization_prompts/01_design_the_study.prompt.yaml chemical_characterization_prompts/02_interpret_the_chemistry_assess_risk.prompt.yaml chemical_characterization_prompts/03_write_the_regulatory_summary.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e26ee8ebc832c86376e39647dcb15