### PR TITLE
Clarify evaluator naming in CFO prompts

### DIFF
--- a/cfo_prompts/01_scenario_cash_flow_forecast.prompt.yaml
+++ b/cfo_prompts/01_scenario_cash_flow_forecast.prompt.yaml
@@ -28,6 +28,6 @@ testData:
       notes: none
     expected: Scenario Forecast -
 evaluators:
-  - name: Output starts with 'Scenario Forecast -'
+  - name: Output should start with 'Scenario Forecast -'
     string:
       startsWith: 'Scenario Forecast -'

--- a/cfo_prompts/02_competitive_bid_pricing.prompt.yaml
+++ b/cfo_prompts/02_competitive_bid_pricing.prompt.yaml
@@ -28,6 +28,6 @@ testData:
       volume_adjustments: none
     expected: Bid Analysis -
 evaluators:
-  - name: Output starts with 'Bid Analysis -'
+  - name: Output should start with 'Bid Analysis -'
     string:
       startsWith: 'Bid Analysis -'

--- a/cfo_prompts/03_regulatory_risk_dashboard.prompt.yaml
+++ b/cfo_prompts/03_regulatory_risk_dashboard.prompt.yaml
@@ -29,6 +29,6 @@ testData:
       risk_tolerance: moderate
     expected: Risk Dashboard -
 evaluators:
-  - name: Output starts with 'Risk Dashboard -'
+  - name: Output should start with 'Risk Dashboard -'
     string:
       startsWith: 'Risk Dashboard -'


### PR DESCRIPTION
## Summary
- Clarify evaluator descriptions for CFO prompt templates to align with repository style

## Testing
- `yamllint cfo_prompts/01_scenario_cash_flow_forecast.prompt.yaml cfo_prompts/02_competitive_bid_pricing.prompt.yaml cfo_prompts/03_regulatory_risk_dashboard.prompt.yaml`
- `python scripts/validate_prompt_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_689e26ee169c832c9b4c1b74efd36750