### PR TITLE
Add evaluators for reverse brainstorming prompt

### DIFF
--- a/brainstorming_prompts/01_reverse_brainstorming.prompt.yaml
+++ b/brainstorming_prompts/01_reverse_brainstorming.prompt.yaml
@@ -25,4 +25,10 @@ testData:
       problem: example_problem
     expected: |-
       Bulleted list plus markdown table.
-evaluators: []
+evaluators:
+  - name: Output includes '➜' bullet prefix
+    string:
+      contains: '➜'
+  - name: Output includes Solution | Impact table header
+    string:
+      contains: 'Solution | Impact'


### PR DESCRIPTION
## Summary
- add basic evaluators to reverse brainstorming prompt to check for bullet prefix and table header

## Testing
- `python scripts/update_docs_index.py`
- `yamllint brainstorming_prompts/01_reverse_brainstorming.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e26ec6e64832c8367657128786298