### PR TITLE
Add evaluators for biostatistics prompts

### DIFF
--- a/biostatistics_prompts/01_statistical_analysis_plan_generator.prompt.yaml
+++ b/biostatistics_prompts/01_statistical_analysis_plan_generator.prompt.yaml
@@ -39,4 +39,7 @@ testData:
       factors: example_factors
     expected: |-
       Markdown document using H2 headings for each section.
-evaluators: []
+evaluators:
+  - name: Output starts with '##'
+    string:
+      startsWith: '##'

--- a/biostatistics_prompts/02_time_to_event_analysis_coach.prompt.yaml
+++ b/biostatistics_prompts/02_time_to_event_analysis_coach.prompt.yaml
@@ -27,4 +27,7 @@ testData:
       dataset_path: example_dataset_path
     expected: |-
       Section A: conceptual walk-through (bullets). Section B: fenced R code block. Section C: interpretation and next steps (\u2264250 words).
-evaluators: []
+evaluators:
+  - name: Output starts with 'Section A:'
+    string:
+      startsWith: 'Section A:'

--- a/biostatistics_prompts/03_peer_review_methods_checklist.prompt.yaml
+++ b/biostatistics_prompts/03_peer_review_methods_checklist.prompt.yaml
@@ -30,4 +30,7 @@ testData:
       manuscript_excerpt: example_manuscript_excerpt
     expected: |-
       GitHub-flavored markdown table followed by bullet lists.
-evaluators: []
+evaluators:
+  - name: Output starts with '|'
+    string:
+      startsWith: '|'

--- a/biostatistics_prompts/04_universal_template_table_prompt.prompt.yaml
+++ b/biostatistics_prompts/04_universal_template_table_prompt.prompt.yaml
@@ -34,4 +34,7 @@ testData:
       dataset_path: example_dataset_path
     expected: |-
       Code block followed by the generated table.
-evaluators: []
+evaluators:
+  - name: Output starts with '```'
+    string:
+      startsWith: '```'

--- a/biostatistics_prompts/05_dual_language_figure_prompt.prompt.yaml
+++ b/biostatistics_prompts/05_dual_language_figure_prompt.prompt.yaml
@@ -33,4 +33,7 @@ testData:
       dataset_path: example_dataset_path
     expected: |-
       Two pristine code blocks: first in R, then in SAS.
-evaluators: []
+evaluators:
+  - name: Output starts with '```r'
+    string:
+      startsWith: '```r'

--- a/biostatistics_prompts/06_qc_listing_cross_check_prompt.prompt.yaml
+++ b/biostatistics_prompts/06_qc_listing_cross_check_prompt.prompt.yaml
@@ -31,4 +31,7 @@ testData:
       dataset_paths: example_dataset_paths
     expected: |-
       Three code blocks followed by a diff table or pass message.
-evaluators: []
+evaluators:
+  - name: Output starts with '```r'
+    string:
+      startsWith: '```r'

--- a/biostatistics_prompts/07_study_design_statistical_approach.prompt.yaml
+++ b/biostatistics_prompts/07_study_design_statistical_approach.prompt.yaml
@@ -35,4 +35,7 @@ testData:
       regulatory_target: example_regulatory_target
     expected: |-
       Bullet summary followed by short explanatory paragraphs.
-evaluators: []
+evaluators:
+  - name: Output starts with '- '
+    string:
+      startsWith: '- '

--- a/biostatistics_prompts/08_inclusion_exclusion_endpoints_sample_size.prompt.yaml
+++ b/biostatistics_prompts/08_inclusion_exclusion_endpoints_sample_size.prompt.yaml
@@ -33,4 +33,7 @@ testData:
       population_details: example_population_details
     expected: |-
       Bullet lists for criteria and endpoints followed by a short sample-size paragraph.
-evaluators: []
+evaluators:
+  - name: Output starts with '- '
+    string:
+      startsWith: '- '

--- a/biostatistics_prompts/09_adaptive_design_interim_monitoring.prompt.yaml
+++ b/biostatistics_prompts/09_adaptive_design_interim_monitoring.prompt.yaml
@@ -30,4 +30,7 @@ testData:
       trial_details: example_trial_details
     expected: |-
       Bulleted recommendations followed by brief explanatory notes.
-evaluators: []
+evaluators:
+  - name: Output starts with '- '
+    string:
+      startsWith: '- '

--- a/biostatistics_prompts/10_phase_ii_iii_sap_skeleton.prompt.yaml
+++ b/biostatistics_prompts/10_phase_ii_iii_sap_skeleton.prompt.yaml
@@ -31,4 +31,7 @@ testData:
       trial_overview: example_trial_overview
     expected: |-
       Markdown document with H2 headings, maximum 2,500 words.
-evaluators: []
+evaluators:
+  - name: Output starts with '##'
+    string:
+      startsWith: '##'

--- a/biostatistics_prompts/10_sample_size_randomization_strategy.prompt.yaml
+++ b/biostatistics_prompts/10_sample_size_randomization_strategy.prompt.yaml
@@ -35,4 +35,7 @@ testData:
       dropout_rate: example_dropout_rate
     expected: |-
       Executive summary (≤150 words) followed by two tables: sample-size scenarios and randomization parameters. Conclude with a fenced R code block.
-evaluators: []
+evaluators:
+  - name: Output starts with 'Executive summary'
+    string:
+      startsWith: 'Executive summary'

--- a/biostatistics_prompts/11_fda_missing_data_query_response.prompt.yaml
+++ b/biostatistics_prompts/11_fda_missing_data_query_response.prompt.yaml
@@ -35,4 +35,7 @@ testData:
       sap_references: example_sap_references
     expected: |-
       Word-style Markdown outline with H1/H2 sections plus the appendix table.
-evaluators: []
+evaluators:
+  - name: Output starts with '# '
+    string:
+      startsWith: '# '

--- a/biostatistics_prompts/11_submission_ready_sap.prompt.yaml
+++ b/biostatistics_prompts/11_submission_ready_sap.prompt.yaml
@@ -37,4 +37,7 @@ testData:
       study_overview: example_study_overview
     expected: |-
       Markdown document with numbered sections and mock tables.
-evaluators: []
+evaluators:
+  - name: Output starts with '## 1'
+    string:
+      startsWith: '## 1'

--- a/biostatistics_prompts/12_submission_ready_tlfs.prompt.yaml
+++ b/biostatistics_prompts/12_submission_ready_tlfs.prompt.yaml
@@ -38,4 +38,7 @@ testData:
       adlb_path: example_adlb_path
     expected: |-
       SAS code block(s) with header comments, followed by a QC checklist in a markdown table and brief usage notes (≤120 words).
-evaluators: []
+evaluators:
+  - name: Output starts with '```sas'
+    string:
+      startsWith: '```sas'


### PR DESCRIPTION
## Summary
- ensure each biostatistics prompt defines a string-based evaluator to check output structure
- keep prompt conventions intact

## Testing
- `yamllint biostatistics_prompts/*.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e26e887d4832c8757634268957272