### PR TITLE
Add evaluators to bioskills prompts

### DIFF
--- a/bioskills_prompts/01_hands_on_procedure_coaching.prompt.yaml
+++ b/bioskills_prompts/01_hands_on_procedure_coaching.prompt.yaml
@@ -27,6 +27,8 @@ messages:
 testData:
   - vars:
       procedure_name: example_procedure_name
-    expected: |-
-      Bullet list of steps and checkpoints.
-evaluators: []
+    expected: "- "
+evaluators:
+  - name: Output starts with a bullet
+    string:
+      startsWith: "- "

--- a/bioskills_prompts/02_simulated_clinical_scenario_feedback.prompt.yaml
+++ b/bioskills_prompts/02_simulated_clinical_scenario_feedback.prompt.yaml
@@ -26,6 +26,8 @@ messages:
 testData:
   - vars:
       procedure_notes: example_procedure_notes
-    expected: |-
-      Bullet points followed by a short reflective question.
-evaluators: []
+    expected: "- "
+evaluators:
+  - name: Output starts with a bullet
+    string:
+      startsWith: "- "

--- a/bioskills_prompts/03_objective_skills_assessment.prompt.yaml
+++ b/bioskills_prompts/03_objective_skills_assessment.prompt.yaml
@@ -29,9 +29,8 @@ messages:
 testData:
   - vars:
       procedure_name: example_procedure_name
-    expected: |-
-      Markdown table:
-
-      | Criterion | Description | Pass threshold |
-      |-----------|-------------|----------------|
-evaluators: []
+    expected: "Markdown table:"
+evaluators:
+  - name: Output starts with 'Markdown table:'
+    string:
+      startsWith: "Markdown table:"


### PR DESCRIPTION
## Summary
- add simple start-of-output evaluators for hands-on procedure coaching
- ensure simulated clinical scenario feedback and skills assessment prompts include evaluators

## Testing
- `yamllint bioskills_prompts/*.prompt.yaml`
- `yamllint **/*.prompt.yaml` *(fails: trailing spaces in many other files)*

------
https://chatgpt.com/codex/tasks/task_e_689e26e7a988832cae465c724401b6f8