### PR TITLE
Add evaluators for biosafety prompts

### DIFF
--- a/biosafety_prompts/01_risk_assessment_expert.prompt.yaml
+++ b/biosafety_prompts/01_risk_assessment_expert.prompt.yaml
@@ -29,4 +29,7 @@ testData:
       medical_device_type: example_medical_device_type
     expected: |-
       Markdown table summarizing hazards and mitigations.
-evaluators: []
+evaluators:
+  - name: Output starts with a markdown table row
+    string:
+      startsWith: '|'

--- a/biosafety_prompts/02_biological_safety_plan_developer.prompt.yaml
+++ b/biosafety_prompts/02_biological_safety_plan_developer.prompt.yaml
@@ -30,4 +30,7 @@ testData:
       device_description: example_device_description
     expected: |-
       Bullet points and headings forming a clear plan.
-evaluators: []
+evaluators:
+  - name: Output starts with a bullet point
+    string:
+      startsWith: '-'

--- a/biosafety_prompts/03_regulatory_submission_support.prompt.yaml
+++ b/biosafety_prompts/03_regulatory_submission_support.prompt.yaml
@@ -29,4 +29,7 @@ testData:
       device_description: example_device_description
     expected: |-
       Bullet points and tables suitable for submission documentation.
-evaluators: []
+evaluators:
+  - name: Output starts with a bullet point
+    string:
+      startsWith: '-'


### PR DESCRIPTION
## Summary
- add basic evaluation rules to biosafety prompt files to enforce expected output formats

## Testing
- `yamllint biosafety_prompts/01_risk_assessment_expert.prompt.yaml biosafety_prompts/02_biological_safety_plan_developer.prompt.yaml biosafety_prompts/03_regulatory_submission_support.prompt.yaml && echo "yamllint: success"`


------
https://chatgpt.com/codex/tasks/task_e_689e26e395d8832c91d08ada3cd07eee