### PR TITLE
Add evaluators for biological safety prompts

### DIFF
--- a/biological_safety_prompts/01_risk_assessment_expert.prompt.yaml
+++ b/biological_safety_prompts/01_risk_assessment_expert.prompt.yaml
@@ -29,4 +29,7 @@ testData:
       medical_device_type: example_medical_device_type
     expected: |-
       Markdown table summarizing hazards, risk level, and mitigation steps.
-evaluators: []
+evaluators:
+  - name: Output starts with markdown table
+    string:
+      startsWith: '|'

--- a/biological_safety_prompts/02_biological_safety_plan_developer.prompt.yaml
+++ b/biological_safety_prompts/02_biological_safety_plan_developer.prompt.yaml
@@ -30,4 +30,7 @@ testData:
       device_description: example_device_description
     expected: |-
       Bullet points and headings that form a ready-to-review plan.
-evaluators: []
+evaluators:
+  - name: Contains markdown headings
+    string:
+      contains: '##'

--- a/biological_safety_prompts/03_regulatory_submission_support.prompt.yaml
+++ b/biological_safety_prompts/03_regulatory_submission_support.prompt.yaml
@@ -29,4 +29,7 @@ testData:
       device_description: example_device_description
     expected: |-
       Bullet points and tables suitable for inclusion in a submission dossier.
-evaluators: []
+evaluators:
+  - name: Contains a markdown table
+    string:
+      contains: '|'

--- a/biological_safety_prompts/04_bep_builder.prompt.yaml
+++ b/biological_safety_prompts/04_bep_builder.prompt.yaml
@@ -29,4 +29,7 @@ testData:
       device_details: example_device_details
     expected: |-
       Executive-summary paragraph followed by a markdown table and bulleted notes.
-evaluators: []
+evaluators:
+  - name: Contains a markdown table
+    string:
+      contains: '|'

--- a/biological_safety_prompts/05_comprehensive_test_matrix.prompt.yaml
+++ b/biological_safety_prompts/05_comprehensive_test_matrix.prompt.yaml
@@ -30,4 +30,7 @@ testData:
       device_materials: example_device_materials
     expected: |-
       Two-level markdown table followed by concise explanatory notes.
-evaluators: []
+evaluators:
+  - name: Output starts with markdown table
+    string:
+      startsWith: '|'

--- a/biological_safety_prompts/06_chemical_characterization_work_plan.prompt.yaml
+++ b/biological_safety_prompts/06_chemical_characterization_work_plan.prompt.yaml
@@ -32,4 +32,7 @@ testData:
       device_information: example_device_information
     expected: |-
       Numbered work plan followed by a short summary paragraph.
-evaluators: []
+evaluators:
+  - name: Output starts with numbered list
+    string:
+      startsWith: '1.'


### PR DESCRIPTION
## Summary
- add simple output evaluators for biological safety prompt suite
- ensure markdown tables, headings, and numbered lists are validated

## Testing
- `yamllint biological_safety_prompts/*.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e26e288c4832caf1f8c056549734a