### PR TITLE
Add output evaluators to agentic coding prompts

### DIFF
--- a/agentic_coding/01_product_brief.prompt.yaml
+++ b/agentic_coding/01_product_brief.prompt.yaml
@@ -32,4 +32,7 @@ testData:
       context_notes: example_context_notes
     expected: |-
       Markdown sections titled **Vision**, **Key Features and Roadmap**, **Overall Architecture**, and **Additional Context**.
-evaluators: []
+evaluators:
+  - name: Output starts with 'Vision'
+    string:
+      startsWith: 'Vision'

--- a/agentic_coding/02_project_brief_epic.prompt.yaml
+++ b/agentic_coding/02_project_brief_epic.prompt.yaml
@@ -36,4 +36,7 @@ testData:
       project_description: example_project_description
     expected: |-
       Markdown sections titled **Project Description**, **Key Features**, **Technical Entities & Data Models**, **Business Rules & Logic**, **Success Metrics**, and **Additional Implementation Details**.
-evaluators: []
+evaluators:
+  - name: Output starts with 'Project Description'
+    string:
+      startsWith: 'Project Description'

--- a/agentic_coding/03_technical_implementation_plan.prompt.yaml
+++ b/agentic_coding/03_technical_implementation_plan.prompt.yaml
@@ -34,4 +34,7 @@ testData:
       technology_choices: example_technology_choices
     expected: |-
       Markdown sections for Architecture Breakdown, Libraries and Tools, Data Models & Specifications, Business Logic & Rules, Dependencies & Risk Analysis, and Implementation Steps.
-evaluators: []
+evaluators:
+  - name: Output starts with 'Architecture Breakdown'
+    string:
+      startsWith: 'Architecture Breakdown'

--- a/agentic_coding/04_coding_session_guidelines.prompt.yaml
+++ b/agentic_coding/04_coding_session_guidelines.prompt.yaml
@@ -31,4 +31,7 @@ testData:
   - vars: {}
     expected: |-
       Clear Markdown checklist of steps completed during the session.
-evaluators: []
+evaluators:
+  - name: Output starts with checklist item
+    string:
+      startsWith: '- [ ]'

--- a/agentic_coding/05_project_review.prompt.yaml
+++ b/agentic_coding/05_project_review.prompt.yaml
@@ -28,4 +28,7 @@ testData:
   - vars: {}
     expected: |-
       Markdown checklist confirming each step was completed.
-evaluators: []
+evaluators:
+  - name: Output starts with checklist item
+    string:
+      startsWith: '- [ ]'

--- a/agentic_coding/06_project_memory.prompt.yaml
+++ b/agentic_coding/06_project_memory.prompt.yaml
@@ -25,4 +25,7 @@ testData:
   - vars: {}
     expected: |-
       Markdown file with sections **Current Project State** and **Contextual Notes**.
-evaluators: []
+evaluators:
+  - name: Output starts with 'Current Project State'
+    string:
+      startsWith: 'Current Project State'

--- a/agentic_coding/06_todo_generation.prompt.yaml
+++ b/agentic_coding/06_todo_generation.prompt.yaml
@@ -24,4 +24,7 @@ testData:
   - vars: {}
     expected: |-
       Markdown checklist under **To-Do** and **Completed Tasks** sections.
-evaluators: []
+evaluators:
+  - name: Output starts with 'To-Do'
+    string:
+      startsWith: 'To-Do'

--- a/agentic_coding/07_e2e_test_discovery.prompt.yaml
+++ b/agentic_coding/07_e2e_test_discovery.prompt.yaml
@@ -54,4 +54,7 @@ testData:
       1. Environment & Tooling
       1. Proposed E2E Test Suite
       1. Coverage Gaps & Risk Register
-evaluators: []
+evaluators:
+  - name: Output starts with 'Repository Overview'
+    string:
+      startsWith: 'Repository Overview'

--- a/agentic_coding/07_folder_module_organization.prompt.yaml
+++ b/agentic_coding/07_folder_module_organization.prompt.yaml
@@ -30,4 +30,7 @@ testData:
       repo_path: example_repo_path
     expected: |-
       Markdown plan detailing the checklist, migration steps, validation commands, and follow-up prompts.
-evaluators: []
+evaluators:
+  - name: Output starts with 'Checklist'
+    string:
+      startsWith: 'Checklist'

--- a/agentic_coding/07_requirements_prompt.prompt.yaml
+++ b/agentic_coding/07_requirements_prompt.prompt.yaml
@@ -36,4 +36,7 @@ testData:
       repository_url: example_repository_url
     expected: |-
       Return the finished `REQUIREMENTS.md` content only.
-evaluators: []
+evaluators:
+  - name: Output starts with Markdown heading
+    string:
+      startsWith: '#'

--- a/agentic_coding/08_reflexion_agent_bug_patch.prompt.yaml
+++ b/agentic_coding/08_reflexion_agent_bug_patch.prompt.yaml
@@ -25,4 +25,7 @@ testData:
       code: example_code
     expected: |-
       Markdown with code fences for the patch and a short rationale. Entire reply ≤ 120 words.
-evaluators: []
+evaluators:
+  - name: Output starts with 'Hypothesis:'
+    string:
+      startsWith: 'Hypothesis:'


### PR DESCRIPTION
## Summary
- add start-of-output evaluators to all agentic coding prompts to enforce key section headings

## Testing
- `python3 scripts/validate_prompt_schema.py`
- `yamllint agentic_coding/*.prompt.yaml`
- `scripts/validate_prompts.sh` *(fails: trailing spaces in vp_statistics_prompts/01_interim_results_executive_brief.prompt.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_689e26e20b60832cb0a94402c7fba9f6