### PR TITLE
Add evaluators to adjudication prompts

### DIFF
--- a/adjudication_prompts/01_real_time_adjudication_dashboard.prompt.yaml
+++ b/adjudication_prompts/01_real_time_adjudication_dashboard.prompt.yaml
@@ -37,4 +37,7 @@ testData:
       - **Section 2:** Dashboard data model (table)
       - **Section 3:** Alert rules (bullets)
       - **Section 4:** Platform recommendations (table)
-evaluators: []
+evaluators:
+  - name: Output includes 'Section 1:'
+    string:
+      contains: 'Section 1:'

--- a/adjudication_prompts/02_source_document_endpoint_checklist.prompt.yaml
+++ b/adjudication_prompts/02_source_document_endpoint_checklist.prompt.yaml
@@ -32,4 +32,7 @@ testData:
     expected: |-
       - Markdown table per endpoint with columns: *Doc Type*, *Required?*, *Acceptable Formats*, *Notes*.
       - Numbered list of **Clarification Needed** items.
-evaluators: []
+evaluators:
+  - name: Output includes 'Clarification Needed'
+    string:
+      contains: 'Clarification Needed'

--- a/adjudication_prompts/03_analyze_adjudication_kpis.prompt.yaml
+++ b/adjudication_prompts/03_analyze_adjudication_kpis.prompt.yaml
@@ -36,4 +36,7 @@ testData:
       - **Metrics Summary Table**
       - Embedded charts or download links for each PNG
       - Bullet list of recommendations
-evaluators: []
+evaluators:
+  - name: Output includes 'Metrics Summary Table'
+    string:
+      contains: 'Metrics Summary Table'


### PR DESCRIPTION
## Summary
- add string evaluators to ensure adjudication prompts output expected sections

## Testing
- `yamllint adjudication_prompts/01_real_time_adjudication_dashboard.prompt.yaml adjudication_prompts/02_source_document_endpoint_checklist.prompt.yaml adjudication_prompts/03_analyze_adjudication_kpis.prompt.yaml`
- `python scripts/validate_prompt_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_689e26e148cc832ca38b8103cd80d084