### PR TITLE
Add test data and evaluators to sterility prompts

### DIFF
--- a/sterility_prompts/01_sterility_validation_protocol_builder.prompt.yaml
+++ b/sterility_prompts/01_sterility_validation_protocol_builder.prompt.yaml
@@ -32,5 +32,15 @@ messages:
       - Include all equations explicitly.
       - Cite each standard or guidance section by clause number.
       - Think through the solution step-by-step internally and reveal only the final protocol.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      device_description: example_device_description
+    expected: |-
+      Protocol includes sections: Overview, Materials, Methods, Acceptance Criteria, Timeline, References.
+evaluators:
+  - name: Contains Overview section
+    string:
+      contains: "Overview"
+  - name: Contains References section
+    string:
+      contains: "References"

--- a/sterility_prompts/02_regulatory_gap_analysis_comparator.prompt.yaml
+++ b/sterility_prompts/02_regulatory_gap_analysis_comparator.prompt.yaml
@@ -29,5 +29,15 @@ messages:
       Additional notes:
       - Use bold red text `**<text>**` for high‑risk gaps.
       - Do not expose your chain of thought.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      device_description: example_device_description
+    expected: |-
+      Markdown table comparing sterility requirements with a brief executive summary.
+evaluators:
+  - name: Output starts with table row
+    string:
+      startsWith: '|'
+  - name: Contains summary section
+    string:
+      contains: 'Summary'

--- a/sterility_prompts/03_eto_sterilization_process_fmea.prompt.yaml
+++ b/sterility_prompts/03_eto_sterilization_process_fmea.prompt.yaml
@@ -30,5 +30,15 @@ messages:
 
       Additional notes:
       Think step-by-step internally and share only the finished FMEA table and summary.
-testData: []
-evaluators: []
+testData:
+  - vars:
+      process_description: example_process_description
+    expected: |-
+      Markdown table with FMEA columns followed by a bullet list summary.
+evaluators:
+  - name: Contains RPN column
+    string:
+      contains: "| RPN |"
+  - name: Contains bullet list
+    string:
+      contains: "- "


### PR DESCRIPTION
## Summary
- add example testData and evaluation rules for sterility validation protocol builder
- add test inputs and evaluators for regulatory gap analysis comparator prompt
- include test data and checks for EtO sterilization process FMEA prompt

## Testing
- `yamllint sterility_prompts/01_sterility_validation_protocol_builder.prompt.yaml sterility_prompts/02_regulatory_gap_analysis_comparator.prompt.yaml sterility_prompts/03_eto_sterilization_process_fmea.prompt.yaml`
- `python scripts/update_docs_index.py`

------
https://chatgpt.com/codex/tasks/task_e_689e36f771e0832c8b718334b8d8b6f6