### PR TITLE
Add validation examples for study director prompts

### DIFF
--- a/study_director_prompts/01_draft_glp_compliant_study_protocol.prompt.yaml
+++ b/study_director_prompts/01_draft_glp_compliant_study_protocol.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Draft a GLP-Compliant Study Protocol
-description: Produce a detailed study plan that satisfies OECD and FDA GLP 
+description: Produce a detailed study plan that satisfies OECD and FDA GLP
   regulations.
 model: gpt-4o
 modelParameters:
@@ -26,5 +26,16 @@ messages:
       Output Format:
       1. Numbered outline covering all requested sections
       2. CSV-ready risk-mitigation table with columns: Phase, Risk, Impact, Mitigation
-testData: []
-evaluators: []
+testData:
+  - input: |
+      protocol_basics: |
+        Test Article: Compound A
+        Species: Sprague-Dawley rats
+        Duration: 28 days
+    expected: |
+      1. Objectives and scientific rationale
+      Phase,Risk,Impact,Mitigation
+evaluators:
+  - name: Includes mitigation table headers
+    string:
+      contains: 'Phase,Risk,Impact,Mitigation'

--- a/study_director_prompts/02_audit_raw_data_capa_summary.prompt.yaml
+++ b/study_director_prompts/02_audit_raw_data_capa_summary.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Audit Raw Data and Draft a CAPA Summary
-description: Review study data for deviations and produce a corrective-action 
+description: Review study data for deviations and produce a corrective-action
   plan.
 model: gpt-4o
 modelParameters:
@@ -25,5 +25,17 @@ messages:
       Output Format:
       1. Markdown table with columns: Issue ID | Impact | CAPA
       2. CAPA memo addressed to the Study Director (≤300 words)
-testData: []
-evaluators: []
+testData:
+  - input: |
+      data_csv: |
+        id,weight
+        1,200
+        2,150
+        3,250
+    expected: |
+      | Issue ID | Impact | CAPA |
+      | 1 | Low | ... |
+evaluators:
+  - name: Includes CAPA memo
+    string:
+      contains: 'CAPA memo'

--- a/study_director_prompts/03_executive_summary_final_report.prompt.yaml
+++ b/study_director_prompts/03_executive_summary_final_report.prompt.yaml
@@ -24,5 +24,19 @@ messages:
       Output Format:
       1. Two-page summary in formal language aligned with CTD headings
       2. Final four-item sign-off checklist for the Study Director
-testData: []
-evaluators: []
+testData:
+  - input: |
+      report_sections: |
+        Module 4.2.3: Study design and dose levels
+        Module 4.2.5: Results and discussion
+    expected: |
+      NOAEL: 50 mg/kg
+      Checklist:
+      - Sign protocol
+      - Review deviations
+      - Confirm NOAEL
+      - Approve submission
+evaluators:
+  - name: Mentions NOAEL
+    string:
+      contains: 'NOAEL'


### PR DESCRIPTION
## Summary
- add sample testData blocks to study director prompts
- include basic evaluators to ensure key content

## Testing
- `yamllint study_director_prompts/01_draft_glp_compliant_study_protocol.prompt.yaml study_director_prompts/02_audit_raw_data_capa_summary.prompt.yaml study_director_prompts/03_executive_summary_final_report.prompt.yaml`
- `python scripts/validate_prompt_schema.py`
- `scripts/validate_prompts.sh` *(fails: process did not complete in a reasonable time and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689e36f86730832c9c157b0482081bb2