### PR TITLE
Add test data and evaluators for technical writer prompts

### DIFF
--- a/technical_writer_prompts/01_csr_results_safety_section.prompt.yaml
+++ b/technical_writer_prompts/01_csr_results_safety_section.prompt.yaml
@@ -26,5 +26,15 @@ messages:
       1. **Efficacy Evaluation** section including Table 11‑1
       2. **Safety Evaluation** section including Table 12‑1 and Figure 12‑1
       3. Bullet list of missing information, if any
-testData: []
-evaluators: []
+testData:
+  - vars: {}
+    expected: |-
+      Efficacy Evaluation
+      Safety Evaluation
+evaluators:
+  - name: Includes Efficacy Evaluation heading
+    string:
+      contains: "Efficacy Evaluation"
+  - name: Includes Safety Evaluation heading
+    string:
+      contains: "Safety Evaluation"

--- a/technical_writer_prompts/02_ib_detailed_soc.prompt.yaml
+++ b/technical_writer_prompts/02_ib_detailed_soc.prompt.yaml
@@ -26,5 +26,12 @@ messages:
       Output Format:
       1. Markdown table(s) with columns: Section | Old text | New text | Rationale
       2. Concise narrative summarizing major changes
-testData: []
-evaluators: []
+testData:
+  - vars: {}
+    expected: |-
+      | Section | Old text | New text | Rationale |
+      | --- | --- | --- | --- |
+evaluators:
+  - name: Contains summary of changes table headers
+    string:
+      contains: "| Section | Old text | New text | Rationale |"

--- a/technical_writer_prompts/03_sae_reporting_sop.prompt.yaml
+++ b/technical_writer_prompts/03_sae_reporting_sop.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: SAE and Unanticipated Problem Reporting SOP
-description: Develop a standard operating procedure for reporting serious 
+description: Develop a standard operating procedure for reporting serious
   adverse events and unanticipated problems.
 model: gpt-4o
 modelParameters:
@@ -27,5 +27,15 @@ messages:
       1. Markdown SOP with sections: Purpose, Scope, Definitions, Responsibilities, Procedure, Timelines, Training, Record retention, Revision history
       2. ASCII or Markdown flowchart illustrating the reporting pathway
       3. Annex with template log examples
-testData: []
-evaluators: []
+testData:
+  - vars: {}
+    expected: |-
+      1. Purpose
+      2. Scope
+evaluators:
+  - name: Contains Purpose section heading
+    string:
+      contains: "1. Purpose"
+  - name: Contains Scope section heading
+    string:
+      contains: "2. Scope"


### PR DESCRIPTION
## Summary
- expand CSR, IB, and SAE prompts with test cases and evaluator checks

## Testing
- `yamllint technical_writer_prompts/01_csr_results_safety_section.prompt.yaml technical_writer_prompts/02_ib_detailed_soc.prompt.yaml technical_writer_prompts/03_sae_reporting_sop.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e36f8ca14832ca1a0cf3fa3d7f7d4