### PR TITLE
Add test cases and evaluators for trial execution prompts

### DIFF
--- a/trial_execution_prompts/01_protocol_optimization_risk_simulation.prompt.yaml
+++ b/trial_execution_prompts/01_protocol_optimization_risk_simulation.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Protocol Optimization and Risk Simulation
-description: Evaluate a draft clinical protocol and simulate the effects of 
+description: Evaluate a draft clinical protocol and simulate the effects of
   simplifying key elements.
 model: gpt-4o
 modelParameters:
@@ -28,5 +28,12 @@ messages:
       - **Section B:** Scenario 1 – metrics and narrative
       - **Section C:** Scenario 2 – metrics and narrative
       - **Section D:** Recommendations
-testData: []
-evaluators: []
+testData:
+  - input: |
+      Draft includes 12 visits and 50 inclusion criteria.
+    expected: |
+      Section A:
+evaluators:
+  - name: Includes recommendations section
+    string:
+      contains: "Section D:"

--- a/trial_execution_prompts/02_ai_powered_site_recruitment.prompt.yaml
+++ b/trial_execution_prompts/02_ai_powered_site_recruitment.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: AI-Powered Site and Recruitment Strategy
-description: Select optimal sites and anticipate dropout risks using simulated 
+description: Select optimal sites and anticipate dropout risks using simulated
   EHR insights.
 model: gpt-4o
 modelParameters:
@@ -27,5 +27,13 @@ messages:
       - **Site Ranking Table** – site, enrollment projection, retention rate
       - **Dropout Risks** – list with explanations
       - **Mitigation Plan** – bullet points per risk
-testData: []
-evaluators: []
+testData:
+  - input: |
+      criteria: age 18-65
+      target_enrollment: 200
+    expected: |
+      Site Ranking Table
+evaluators:
+  - name: Lists mitigation strategies
+    string:
+      contains: "Mitigation Plan"

--- a/trial_execution_prompts/03_compliance_data_quality_monitoring_plan.prompt.yaml
+++ b/trial_execution_prompts/03_compliance_data_quality_monitoring_plan.prompt.yaml
@@ -26,5 +26,12 @@ messages:
       - **Part A:** Alert list (type, trigger condition)
       - **Part B:** Review schedule (who and how often)
       - **Part C:** Reporting plan (frequency, content, recipients)
-testData: []
-evaluators: []
+testData:
+  - input: |
+      Generate monitoring plan.
+    expected: |
+      Part A:
+evaluators:
+  - name: Mentions reporting plan
+    string:
+      contains: "Part C"

--- a/trial_execution_prompts/04_adaptive_recruitment_retention_strategy.prompt.yaml
+++ b/trial_execution_prompts/04_adaptive_recruitment_retention_strategy.prompt.yaml
@@ -26,5 +26,13 @@ messages:
       1. Pre‑screening workflow
       2. Site-level engagement tactics
       3. Recruitment and retention metrics
-testData: []
-evaluators: []
+testData:
+  - input: |
+      device_or_ivd: glucose monitor
+      patient_population: adults with diabetes
+    expected: |
+      Pre‑screening workflow
+evaluators:
+  - name: Contains metrics section
+    string:
+      contains: "Recruitment and retention metrics"

--- a/trial_execution_prompts/05_portfolio_clin_ops_roadmap.prompt.yaml
+++ b/trial_execution_prompts/05_portfolio_clin_ops_roadmap.prompt.yaml
@@ -25,5 +25,12 @@ messages:
 
       - **Executive Summary** (≤ 150 words)
       - **Detailed Roadmap** (table)
-testData: []
-evaluators: []
+testData:
+  - input: |
+      Outline roadmap.
+    expected: |
+      Executive Summary
+evaluators:
+  - name: Provides detailed roadmap
+    string:
+      contains: "Detailed Roadmap"

--- a/trial_execution_prompts/06_risk_based_monitoring_plan.prompt.yaml
+++ b/trial_execution_prompts/06_risk_based_monitoring_plan.prompt.yaml
@@ -22,5 +22,12 @@ messages:
       Output Format:
       1. Executive slide outline (bulleted)
       2. Editable risk register in a Markdown table
-testData: []
-evaluators: []
+testData:
+  - input: |
+      Create plan.
+    expected: |
+      risk register
+evaluators:
+  - name: Notes escalation workflow
+    string:
+      contains: "communication matrix"

--- a/trial_execution_prompts/07_recruitment_diversity_acceleration.prompt.yaml
+++ b/trial_execution_prompts/07_recruitment_diversity_acceleration.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Patient Recruitment and Diversity Acceleration Plan
-description: Boost enrollment and improve demographic diversity in a stalled 
+description: Boost enrollment and improve demographic diversity in a stalled
   Phase III study.
 model: gpt-4o
 modelParameters:
@@ -23,5 +23,12 @@ messages:
 
       Output Format:
       Concise report (≤ 1 000 words) plus a one‑slide KPI dashboard sketch in text form.
-testData: []
-evaluators: []
+testData:
+  - input: |
+      Create recovery plan.
+    expected: |
+      metrics dashboard
+evaluators:
+  - name: Includes ROI projection
+    string:
+      contains: "ROI"


### PR DESCRIPTION
## Summary
- add sample `testData` inputs and evaluator checks across trial execution prompts for protocol optimization, site recruitment, compliance monitoring, and more

## Testing
- `python scripts/update_docs_index.py`
- `yamllint trial_execution_prompts/*.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e36f94db4832cb370694429f5b40c