### PR TITLE
Add testData and evaluator sections for VP statistics prompts

### DIFF
--- a/vp_statistics_prompts/01_interim_results_executive_brief.prompt.yaml
+++ b/vp_statistics_prompts/01_interim_results_executive_brief.prompt.yaml
@@ -1,6 +1,6 @@
 ---
 name: Interim Results Executive Brief
-description: Summarize interim analysis findings for cross-functional 
+description: Summarize interim analysis findings for cross-functional
   leadership.
 model: gpt-4o
 modelParameters:
@@ -36,5 +36,14 @@ messages:
       - **Key Findings**
       - **Risk Assessment**
       - **Recommended Actions**
-testData: []
-evaluators: []
+testData:
+  - vars:
+      analysis_results: example_analysis_results
+      statistical_plan: example_statistical_plan
+      safety_listings: example_safety_listings
+    expected: |-
+      Markdown headings **Introduction**, **Key Findings**, **Risk Assessment**, and **Recommended Actions**.
+evaluators:
+  - name: Contains Key Findings section
+    string:
+      contains: "Key Findings"

--- a/vp_statistics_prompts/02_sap_first_draft_builder.prompt.yaml
+++ b/vp_statistics_prompts/02_sap_first_draft_builder.prompt.yaml
@@ -40,5 +40,12 @@ messages:
       6. Table, Listing and Figure shells
       7. SAS-style pseudocode for primary analyses
       8. Reviewer Checklist boxes
-testData: []
-evaluators: []
+testData:
+  - vars:
+      protocol_synopsis: example_protocol_synopsis
+    expected: |-
+      Markdown sections for Objectives and estimands and Analysis populations.
+evaluators:
+  - name: Includes Objectives and estimands heading
+    string:
+      contains: "Objectives and estimands"

--- a/vp_statistics_prompts/03_data_quality_risk_heatmap.prompt.yaml
+++ b/vp_statistics_prompts/03_data_quality_risk_heatmap.prompt.yaml
@@ -36,5 +36,13 @@ messages:
       2. ASCII heat map (rows = sites, columns = risk deciles)
       3. Mitigation bullets (three per high-risk site)
       4. Python (pandas) code block used for calculations
-testData: []
-evaluators: []
+testData:
+  - vars:
+      raw_eds_dump: sample_dataset
+      query_log: sample_query_log
+    expected: |-
+      Markdown table of top ten high-risk sites.
+evaluators:
+  - name: Mentions risk deciles
+    string:
+      contains: "risk deciles"


### PR DESCRIPTION
## Summary
- populate VP statistics prompts with `testData` placeholders and basic `evaluators`
- ensure YAML formatting adheres to repo standards

## Testing
- `yamllint vp_statistics_prompts/01_interim_results_executive_brief.prompt.yaml vp_statistics_prompts/02_sap_first_draft_builder.prompt.yaml vp_statistics_prompts/03_data_quality_risk_heatmap.prompt.yaml`
- `python scripts/update_docs_index.py`


------
https://chatgpt.com/codex/tasks/task_e_689e36fabb0c832c88a1cf61b5a4ed8b