### PR TITLE
Add templates to project starter pack prompt

### DIFF
--- a/starter_pack/01_project_starter_pack.prompt.yaml
+++ b/starter_pack/01_project_starter_pack.prompt.yaml
@@ -1,7 +1,6 @@
 ---
 name: Project Starter Pack Prompts
-description: Provide ready-to-copy prompt templates for common project 
-  documentation.
+description: Provide ready-to-copy prompt templates for common project documentation.
 model: gpt-4o
 modelParameters:
   temperature: 0.2
@@ -14,7 +13,7 @@ messages:
       Copy the relevant prompt below and replace the placeholders with your project details.
 
       Inputs:
-      Variables such as `{{Project Name}}`, `{{Feature Area}}`, and similar placeholders appear in the subprompts.
+      Variables such as `{{project_name}}`, `{{feature_area}}`, and similar placeholders appear in the subprompts.
 
       Output format:
       Plain-text prompts grouped by deliverable.
@@ -23,5 +22,32 @@ messages:
       Prompts marked with * may result in multi-page outputs.
 
       ---
+      ### Project Charter and Scope Definition *
+      You are a senior project-management consultant beginning a new initiative. Draft a project charter covering Background, Objectives, In-Scope, Out-of-Scope, Major Deliverables, Success Criteria or KPIs, Assumptions, Constraints, Top Three Risks, Milestone Schedule, High-Level Budget Table, and Approval Signatures. Use H2 headings and a two-column table for the milestone schedule. Keep each paragraph under 120 words. Ask clarifying questions if any details are missing.
+
+      Inputs:
+      - `{{project_name}}`
+      - `{{project_description}}`
+      - `{{budget}}`
+      - `{{deadline}}`
+      - `{{stakeholders}}`
+      - `{{business_outcome}}`
+
+      Output format:
+      Markdown document with the sections listed above.
+
+      ---
+      ### Architecture Decision Record
+      You are the lead software architect documenting a key technical decision. Summarize the Context, Decision, Options Considered, Pros and Cons, Rationale, and Consequences. Keep sections concise and focused on trade-offs. Include a Status and a Decision Date. End with a list of Related Decisions.
+
+      Inputs:
+      - `{{project_name}}`
+      - `{{feature_area}}`
+      - `{{decision}}`
+      - `{{alternatives}}`
+      - `{{decision_date}}`
+
+      Output format:
+      Markdown ADR with headings for each section and bullet lists where appropriate.
 testData: []
 evaluators: []


### PR DESCRIPTION
## Summary
- expand project starter pack with project charter and ADR templates

## Testing
- `yamllint starter_pack/01_project_starter_pack.prompt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689e36f5834c832c88d2ed67bacfd3ee