### PR TITLE
chore: bump GitHub Actions versions

### DIFF
--- a/.github/workflows/fix-markdown-issues.yml
+++ b/.github/workflows/fix-markdown-issues.yml
@@ -19,11 +19,11 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install jq

--- a/.github/workflows/generate-overviews.yml
+++ b/.github/workflows/generate-overviews.yml
@@ -19,11 +19,11 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Generate missing overview files

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -21,9 +21,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Run repository checks

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -16,11 +16,11 @@ jobs:
   update-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Update documentation index

--- a/.github/workflows/yaml-validation.yml
+++ b/.github/workflows/yaml-validation.yml
@@ -19,7 +19,7 @@ jobs:
   prompt-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Validate prompts
         run: |
           ./scripts/validate_prompts.sh


### PR DESCRIPTION
## Summary
- upgrade actions/checkout to v4 in workflow files
- upgrade actions/setup-python to v5 where used

## Testing
- `yamllint .github/workflows/fix-markdown-issues.yml`
- `yamllint .github/workflows/generate-overviews.yml`
- `yamllint .github/workflows/repo-checks.yml`
- `yamllint .github/workflows/update-docs.yml`
- `yamllint .github/workflows/yaml-validation.yml`


------
https://chatgpt.com/codex/tasks/task_e_689e420e7a60832c87d47583ea916e58