### PR TITLE
Install yamllint in YAML validation workflow

### DIFF
--- a/.github/workflows/yaml-validation.yml
+++ b/.github/workflows/yaml-validation.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install yamllint
+        run: pip install yamllint
       - name: Validate prompts
         run: |
           ./scripts/validate_prompts.sh


### PR DESCRIPTION
## Summary
- install yamllint before validating prompts so the linter is available

## Testing
- `yamllint .github/workflows/yaml-validation.yml`

------
https://chatgpt.com/codex/tasks/task_e_689e421260b0832c946c074901fb4d4d