### PR TITLE
Set workflow permissions and tighten commit conditions

### DIFF
--- a/.github/workflows/fix-markdown-issues.yml
+++ b/.github/workflows/fix-markdown-issues.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/fix-markdown-issues.yml'
       - 'scripts/fix_markdown_issues.py'
 
+permissions:
+  contents: write
+
 jobs:
   autofix:
     runs-on: ubuntu-latest
@@ -43,7 +46,7 @@ jobs:
             echo "changed=1" >> "$GITHUB_OUTPUT"
           fi
       - name: Commit and push fixes
-        if: steps.diff.outputs.changed == '1'
+        if: github.event_name == 'push' && steps.diff.outputs.changed == '1'
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"

--- a/.github/workflows/generate-overviews.yml
+++ b/.github/workflows/generate-overviews.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/generate-overviews.yml'
       - 'scripts/generate_overviews.py'
 
+permissions:
+  contents: write
+
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -43,7 +46,7 @@ jobs:
             echo "changed=1" >> "$GITHUB_OUTPUT"
           fi
       - name: Commit and push changes
-        if: steps.diff.outputs.changed == '1'
+        if: github.event_name == 'push' && steps.diff.outputs.changed == '1'
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -17,6 +17,9 @@ on:
       - 'scripts/check_prompts.py'
       - 'scripts/validate_prompt_schema.py'
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -12,6 +12,9 @@ on:
       - '**/*.prompt.yaml'
       - '**/*.prompt.yml'
 
+permissions:
+  contents: write
+
 jobs:
   update-docs:
     runs-on: ubuntu-latest
@@ -38,7 +41,7 @@ jobs:
             echo "changed=1" >> "$GITHUB_OUTPUT"
           fi
       - name: Commit and push changes
-        if: steps.diff.outputs.changed == '1'
+        if: github.event_name == 'push' && steps.diff.outputs.changed == '1'
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"

--- a/.github/workflows/yaml-validation.yml
+++ b/.github/workflows/yaml-validation.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/yaml-validation.yml'
       - 'scripts/validate_prompts.sh'
 
+permissions:
+  contents: read
+
 jobs:
   prompt-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit contents permissions to workflows
- only commit auto-generated changes on push events with diffs

## Testing
- `yamllint .github/workflows/fix-markdown-issues.yml .github/workflows/generate-overviews.yml .github/workflows/update-docs.yml .github/workflows/repo-checks.yml .github/workflows/yaml-validation.yml`


------
https://chatgpt.com/codex/tasks/task_e_689e4213aadc832c94cf28a338461582