### PR TITLE
fix: update deploy pages workflow for YAML prompts

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Install yamllint
+        run: sudo apt-get update && sudo apt-get install -y yamllint
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Validate JSON
-        run: ./scripts/validate_json.sh
+      - name: Validate prompts
+        run: ./scripts/validate_prompts.sh
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:


### PR DESCRIPTION
## Summary
- use yamllint and validate_prompts.sh in deploy-pages workflow

## Testing
- `pip install yamllint`
- `./scripts/validate_prompts.sh`
- `yamllint .github/workflows/deploy-pages.yml` *(fails: missing document start)*

------
https://chatgpt.com/codex/tasks/task_e_689e4c86b8dc832c924cb7ca6d64d153