### PR TITLE
feat: Add prompts for GitHub-native stacks

### DIFF
--- a/prompts/technical/github_native_stack/01_global_github_hygiene.prompt.yaml
+++ b/prompts/technical/github_native_stack/01_global_github_hygiene.prompt.yaml
@@ -1,0 +1,61 @@
+# yamllint disable rule:line-length
+---
+name: Global GitHub Hygiene
+description: Applies a GitHub-native baseline to a repository, setting up a standard suite of tools for CI/CD, security, and project management.
+model: gpt-4-turbo
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |-
+      You are an expert software engineer specializing in DevOps and repository setup.
+      Your task is to apply a comprehensive GitHub-native baseline to a given repository.
+      Follow the user's instructions precisely, creating all specified files and configurations.
+      Ensure all deliverables are met and the acceptance criteria are satisfied.
+  - role: user
+    content: |-
+      Goal: Apply a GitHub-native baseline to {{REPO_URL_OR_PATH}}.
+
+      Decisions:
+      - Pkg mgr: Poetry
+      - CI: GitHub Actions
+      - Image registry: GHCR
+      - Scanners: CodeQL + Dependabot
+      - Releases: release-please
+      - Docs: mkdocs-material on GitHub Pages
+
+      Tasks:
+      1) Add .github/:
+         - workflows/ci.yml (matrix: 3.12; jobs: lint -> typecheck -> tests -> build-image; cache Poetry; pytest with --cov --cov-fail-under={{COV}})
+         - workflows/release-please.yml
+         - workflows/codeql.yml (language: python)
+         - dependabot.yml (ecosystems: github-actions, pip, docker)
+         - PULL_REQUEST_TEMPLATE.md, ISSUE_TEMPLATE/{bug_report.md,feature_request.md}
+         - CODEOWNERS
+      2) Add SECURITY.md, CONTRIBUTING.md, LICENSE.
+      3) Enable pre-commit with ruff, black, trailing-whitespace, end-of-file-fixer, codespell.
+      4) Configure release-please (conventional commits). Add CHANGELOG.md.
+      5) Docker:
+         - Multi-stage Dockerfile (non-root). .dockerignore.
+         - docker-compose.dev.yml for local stack.
+      6) Push images to ghcr.io using GITHUB_TOKEN. Tag: ghcr.io/${{ github.repository }}:${{ github.sha }}.
+      7) mkdocs.yml + docs/; publish via pages workflow or ci.yml job.
+      8) Branch protections documented: require status checks from ci.yml and codeql.yml.
+
+      Deliverables:
+      - New/changed files listed with diffs.
+      - Commands: `poetry install`, `pytest -q`, `ruff`, `mypy`, `docker build`, `docker compose -f docker-compose.dev.yml up`.
+
+      Acceptance:
+      - CI green on PR from clean clone.
+      - CodeQL initialized.
+      - Dependabot opens sample PRs.
+testData:
+  - vars:
+      REPO_URL_OR_PATH: "my-new-repo"
+      COV: "80"
+    expected: "Plan to apply Global GitHub Hygiene to my-new-repo created."
+evaluators:
+  - name: "Asserts plan creation"
+    string:
+      startsWith: "Plan to apply Global GitHub Hygiene"

--- a/prompts/technical/github_native_stack/02_django_refactor.prompt.yaml
+++ b/prompts/technical/github_native_stack/02_django_refactor.prompt.yaml
@@ -1,0 +1,43 @@
+# yamllint disable rule:line-length
+---
+name: Refactor Existing Django Repo (GitHub-Native)
+description: Refactors an existing Django repository for maintainability, applying the Global GitHub Hygiene baseline and modern best practices.
+model: gpt-4-turbo
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |-
+      You are an expert Django developer tasked with refactoring an existing repository to align with modern best practices and a standardized GitHub-native toolchain.
+      Your first step should always be to apply the "Global GitHub Hygiene" standards unless they are already present.
+      Follow the user's refactoring plan meticulously.
+  - role: user
+    content: |-
+      Goal: Refactor {{REPO_URL_OR_PATH}} for maintainability using the Global GitHub hygiene.
+
+      Decisions: Django {{Y}}, Python 3.12, Poetry, DRF optional, Redis optional, Postgres.
+
+      Tasks:
+      - Apply Global GitHub hygiene.
+      - Adopt /src layout and settings split: /src/config/settings/{base,local,test,prod}.py with django-environ.
+      - Pre-commit + ruff+black+mypy (plugin: django-stubs). pytest baseline with pytest-django, pytest-cov, factory_boy, freezegun.
+      - docker-compose.dev: web, postgres, redis, mailhog.
+      - CI: run `python manage.py check --deploy` under prod settings; run migrations.
+      - Optional: DRF skeleton under /api/v1 with drf-spectacular.
+
+      Deliverables:
+      - audit.md, refactor_plan.md, PRs by topic.
+      - README updates with GitHub Actions badges.
+
+      Acceptance:
+      - No behavior change. `manage.py check --deploy` clean. Coverage ≥ {{COV}}.
+testData:
+  - vars:
+      REPO_URL_OR_PATH: "my-django-app"
+      Y: "4.2"
+      COV: "90"
+    expected: "Plan to refactor Django repo my-django-app created."
+evaluators:
+  - name: "Asserts plan creation"
+    string:
+      startsWith: "Plan to refactor Django repo"

--- a/prompts/technical/github_native_stack/03_django_new_project.prompt.yaml
+++ b/prompts/technical/github_native_stack/03_django_new_project.prompt.yaml
@@ -1,0 +1,39 @@
+# yamllint disable rule:line-length
+---
+name: New Django Project (GitHub-Native)
+description: Creates a new, production-ready Django project from scratch using the GitHub-Native stack.
+model: gpt-4-turbo
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |-
+      You are an expert Django developer tasked with bootstrapping a new, production-ready project.
+      Your goal is to create a repository that is maintainable, scalable, and secure from day one.
+      Start by applying the "Global GitHub Hygiene" standards and then proceed with the Django-specific setup.
+  - role: user
+    content: |-
+      Goal: Create production-ready Django repo {{REPO_NAME}} on GitHub.
+
+      Tasks:
+      - Apply Global GitHub hygiene.
+      - Bootstrap tree:
+        /src/config/{asgi.py,wsgi.py,urls.py}
+        /src/config/settings/{base,local,test,prod}.py
+        /src/apps/core  /src/libs  /tests  /scripts  /infra/docker
+      - Implement a healthcheck endpoint at /healthcheck and a version endpoint at /__version__.
+      - Configure Poetry + pyproject.toml with ruff, black, mypy[django], pytest, coverage, and bandit.
+      - Enable pre-commit.
+      - Create a multi-stage Dockerfile and a docker-compose.dev.yml with postgres and redis services.
+
+      Acceptance:
+      - `pytest` and `pre-commit run --all-files` pass.
+      - CI is green and the Docker image is successfully pushed to GHCR.
+testData:
+  - vars:
+      REPO_NAME: "my-new-django-app"
+    expected: "Plan to create new Django project my-new-django-app created."
+evaluators:
+  - name: "Asserts plan creation"
+    string:
+      startsWith: "Plan to create new Django project"

--- a/prompts/technical/github_native_stack/04_fastapi_refactor.prompt.yaml
+++ b/prompts/technical/github_native_stack/04_fastapi_refactor.prompt.yaml
@@ -1,0 +1,50 @@
+# yamllint disable rule:line-length
+---
+name: Refactor Existing FastAPI Repo (GitHub-Native)
+description: Refactors an existing FastAPI repository for maintainability, applying the Global GitHub Hygiene baseline and modern best practices for async Python.
+model: gpt-4-turbo
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |-
+      You are an expert Python developer specializing in FastAPI and modern asynchronous applications.
+      Your task is to refactor an existing repository to align with current best practices and a standardized GitHub-native toolchain.
+      Your first step should always be to apply the "Global GitHub Hygiene" standards unless they are already present.
+      Follow the user's refactoring plan meticulously, paying close attention to the prescribed project layout and technologies.
+  - role: user
+    content: |-
+      Goal: Refactor {{REPO_URL_OR_PATH}} for maintainability using the Global GitHub hygiene.
+
+      Decisions: FastAPI {{Y}}, Pydantic 2, SQLAlchemy 2 async, Poetry.
+
+      Tasks:
+      - Apply Global GitHub hygiene.
+      - Adopt the following project layout:
+        /src/app/main.py
+        /src/app/api/v1/routers/*.py
+        /src/app/core/{config.py,logging.py}
+        /src/app/db/{models.py,session.py}
+        /src/app/services
+        /src/app/repositories
+        /src/app/schemas
+      - Use Pydantic BaseSettings for configuration, with support for local, test, and prod environments.
+      - Establish a testing baseline with pytest-asyncio, httpx, and asgi-lifespan, ensuring adequate test coverage.
+      - Implement SQLAlchemy 2 for asynchronous database operations and manage migrations with Alembic, following standard naming conventions.
+      - Create a docker-compose.dev.yml file with services for the api, postgres, and redis.
+      - Ensure the OpenAPI schema is available at /openapi.json and interactive docs are enabled in non-production environments.
+
+      Acceptance:
+      - Test coverage is at or above {{COV}}%.
+      - The CI pipeline passes successfully.
+      - The Docker image is successfully built and pushed to GHCR.
+testData:
+  - vars:
+      REPO_URL_OR_PATH: "my-fastapi-app"
+      Y: "0.104"
+      COV: "85"
+    expected: "Plan to refactor FastAPI repo my-fastapi-app created."
+evaluators:
+  - name: "Asserts plan creation"
+    string:
+      startsWith: "Plan to refactor FastAPI repo"

--- a/prompts/technical/github_native_stack/05_fastapi_new_project.prompt.yaml
+++ b/prompts/technical/github_native_stack/05_fastapi_new_project.prompt.yaml
@@ -1,0 +1,37 @@
+# yamllint disable rule:line-length
+---
+name: New FastAPI Project (GitHub-Native)
+description: Creates a new, production-ready FastAPI project from scratch using the GitHub-Native stack.
+model: gpt-4-turbo
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |-
+      You are an expert Python developer specializing in FastAPI and modern asynchronous applications.
+      Your task is to bootstrap a new, production-ready project from scratch.
+      Your goal is to create a repository that is maintainable, scalable, and secure from day one.
+      Start by applying the "Global GitHub Hygiene" standards and then proceed with the FastAPI-specific setup.
+  - role: user
+    content: |-
+      Goal: Create production-ready FastAPI repo {{REPO_NAME}} on GitHub.
+
+      Tasks:
+      - Apply Global GitHub hygiene.
+      - Bootstrap the directory tree using the standard layout from the refactoring prompt (main.py, api/v1, core, db, services, etc.).
+      - Implement a healthcheck endpoint at /healthcheck and a version endpoint at /__version__.
+      - Configure Poetry + pyproject.toml with ruff, black, mypy (with sqlalchemy and pydantic plugins), pytest-asyncio, coverage, and bandit.
+      - Enable pre-commit.
+      - Create a multi-stage Dockerfile and a docker-compose.dev.yml with postgres and redis services.
+
+      Acceptance:
+      - `pytest` and `pre-commit run --all-files` pass.
+      - CI is green and the Docker image is successfully pushed to GHCR.
+testData:
+  - vars:
+      REPO_NAME: "my-new-fastapi-app"
+    expected: "Plan to create new FastAPI project my-new-fastapi-app created."
+evaluators:
+  - name: "Asserts plan creation"
+    string:
+      startsWith: "Plan to create new FastAPI project"

--- a/prompts/technical/github_native_stack/06_flask_refactor.prompt.yaml
+++ b/prompts/technical/github_native_stack/06_flask_refactor.prompt.yaml
@@ -1,0 +1,50 @@
+# yamllint disable rule:line-length
+---
+name: Refactor Existing Flask Repo (GitHub-Native)
+description: Refactors an existing Flask repository for maintainability, applying the Global GitHub Hygiene baseline and the app factory pattern.
+model: gpt-4-turbo
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |-
+      You are an expert Python developer specializing in Flask applications.
+      Your task is to refactor an existing repository to align with modern best practices, including the app factory pattern and a standardized GitHub-native toolchain.
+      Your first step should always be to apply the "Global GitHub Hygiene" standards unless they are already present.
+      Follow the user's refactoring plan meticulously.
+  - role: user
+    content: |-
+      Goal: Refactor {{REPO_URL_OR_PATH}} for maintainability using the Global GitHub hygiene.
+
+      Decisions: Flask {{Y}}, SQLAlchemy 2, Poetry.
+
+      Tasks:
+      - Apply Global GitHub hygiene.
+      - Refactor to use the app factory pattern (`create_app`) and environment-driven configuration with `pydantic-settings`.
+      - Adopt the following project layout:
+        /src/app/__init__.py  # create_app is here
+        /src/app/api/v1/blueprints/*.py
+        /src/app/core/{config.py,logging.py}
+        /src/app/db/{models.py,session.py}
+        /src/app/services
+        /src/app/repositories
+        /src/app/schemas
+      - Establish a testing baseline with pytest, pytest-flask, and coverage, using factories for test data.
+      - Implement Alembic for database migrations.
+      - Create a docker-compose.dev.yml file with services for the web, postgres, and redis.
+      - Optional: Integrate Flask-Smorest for automated OpenAPI documentation.
+
+      Acceptance:
+      - Test coverage is at or above {{COV}}%.
+      - The CI pipeline passes successfully.
+      - The Docker image is successfully built and pushed to GHCR.
+testData:
+  - vars:
+      REPO_URL_OR_PATH: "my-flask-app"
+      Y: "2.3"
+      COV: "85"
+    expected: "Plan to refactor Flask repo my-flask-app created."
+evaluators:
+  - name: "Asserts plan creation"
+    string:
+      startsWith: "Plan to refactor Flask repo"

--- a/prompts/technical/github_native_stack/07_flask_new_project.prompt.yaml
+++ b/prompts/technical/github_native_stack/07_flask_new_project.prompt.yaml
@@ -1,0 +1,37 @@
+# yamllint disable rule:line-length
+---
+name: New Flask Project (GitHub-Native)
+description: Creates a new, production-ready Flask project from scratch using the GitHub-Native stack and the app factory pattern.
+model: gpt-4-turbo
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |-
+      You are an expert Python developer specializing in Flask applications.
+      Your task is to bootstrap a new, production-ready project from scratch.
+      Your goal is to create a repository that is maintainable, scalable, and secure from day one.
+      Start by applying the "Global GitHub Hygiene" standards and then proceed with the Flask-specific setup, including the app factory pattern.
+  - role: user
+    content: |-
+      Goal: Create production-ready Flask repo {{REPO_NAME}} on GitHub.
+
+      Tasks:
+      - Apply Global GitHub hygiene.
+      - Bootstrap the directory tree using the standard app factory layout (app/__init__.py, api/v1, core, db, etc.).
+      - Implement a healthcheck endpoint at /health and a version endpoint at /__version__.
+      - Configure Poetry + pyproject.toml with ruff, black, mypy, pytest, coverage, and bandit.
+      - Enable pre-commit.
+      - Create a multi-stage Dockerfile and a docker-compose.dev.yml with postgres and redis services.
+
+      Acceptance:
+      - `pytest` and `pre-commit run --all-files` pass.
+      - CI is green and the Docker image is successfully pushed to GHCR.
+testData:
+  - vars:
+      REPO_NAME: "my-new-flask-app"
+    expected: "Plan to create new Flask project my-new-flask-app created."
+evaluators:
+  - name: "Asserts plan creation"
+    string:
+      startsWith: "Plan to create new Flask project"

--- a/prompts/technical/github_native_stack/ci_example.yml
+++ b/prompts/technical/github_native_stack/ci_example.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  pull_request:
+  push: { branches: [main] }
+permissions: { contents: read, packages: write }
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency: ci-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12', cache: poetry }
+      - run: pipx install poetry
+      - run: poetry install --no-interaction --no-root
+      - run: poetry run ruff check .
+      - run: poetry run black --check .
+      - run: poetry run mypy .
+      - run: poetry run pytest -q --cov --cov-fail-under={{COV}}
+      - uses: docker/login-action@v3
+        with: { registry: ghcr.io, username: ${{ github.actor }}, password: ${{ secrets.GITHUB_TOKEN }} }
+      - run: docker build -t ghcr.io/${{ github.repository }}:${{ github.sha }} .
+      - run: docker push ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/prompts/technical/github_native_stack/overview.md
+++ b/prompts/technical/github_native_stack/overview.md
@@ -1,0 +1,28 @@
+# Prompts for GitHub-Native Stacks
+
+This collection of prompts is designed to guide an AI software engineering agent in setting up or refactoring projects to use a modern, "GitHub-native" stack.
+
+The core philosophy is to use a consistent, best-practice toolchain that integrates deeply with GitHub's ecosystem.
+
+## Core Tooling
+
+The "Global GitHub Hygiene" prompt establishes a baseline that includes:
+
+- **Package Management:** Poetry
+- **CI/CD:** GitHub Actions
+- **Containerization:** Docker with GHCR (GitHub Container Registry)
+- **Code Quality:** Ruff, Black, Mypy, pre-commit
+- **Testing:** Pytest
+- **Security:** CodeQL, Dependabot
+- **Release Management:** `release-please`
+- **Documentation:** MkDocs with GitHub Pages
+
+The framework-specific prompts (Django, FastAPI, Flask) build upon this foundation.
+
+## CI/CD Example
+
+A minimal, drop-in CI workflow file is available at `ci_example.yml`. The prompts may instruct the agent to use this as a starting point.
+
+## Usage Note
+
+If you want the agent to generate ready-to-commit files based on these prompts, provide a repository URL and specify the framework.


### PR DESCRIPTION
This commit introduces a comprehensive suite of prompts for bootstrapping and refactoring Python projects (Django, FastAPI, Flask) using a modern, GitHub-native toolchain.

The new prompts guide an AI agent to set up projects with:
- Poetry for dependency management
- GitHub Actions for CI/CD
- Docker and GHCR for containerization
- Ruff, Black, Mypy, and pre-commit for code quality
- CodeQL and Dependabot for security
- `release-please` for release management

All prompts are created in the required `.prompt.yaml` format and are located in the new `prompts/technical/github_native_stack/` directory, following the repository's contribution guidelines.