### PR TITLE
feat(philosophy): add epistemic defeater formal analyzer prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -345,6 +345,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 ## Epistemology
 
 - [cognitive_bias_epistemological_deconstructor](prompts/scientific/philosophy/epistemology/formal_epistemology/cognitive_bias_epistemological_deconstructor.prompt.md)
+- [epistemic_defeater_formal_analyzer](prompts/scientific/philosophy/epistemology/formal_epistemology/epistemic_defeater_formal_analyzer.prompt.md)
 
 ## Epro
 

--- a/docs/prompts/scientific/philosophy/epistemology/formal_epistemology/epistemic_defeater_formal_analyzer.prompt.md
+++ b/docs/prompts/scientific/philosophy/epistemology/formal_epistemology/epistemic_defeater_formal_analyzer.prompt.md
@@ -1,0 +1,75 @@
+---
+title: epistemic_defeater_formal_analyzer
+---
+
+# epistemic_defeater_formal_analyzer
+
+A highly rigorous prompt designed to systematically analyze and formalize epistemic defeaters (rebutting, undercutting, and higher-order) within formal epistemological justification networks.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/philosophy/epistemology/formal_epistemology/epistemic_defeater_formal_analyzer.prompt.yaml)
+
+```yaml
+---
+name: "epistemic_defeater_formal_analyzer"
+version: "1.0.0"
+description: "A highly rigorous prompt designed to systematically analyze and formalize epistemic defeaters (rebutting, undercutting, and higher-order) within formal epistemological justification networks."
+authors:
+  - "Philosophical Genesis Architect"
+metadata:
+  domain: "scientific"
+  complexity: "high"
+variables:
+  - name: "TARGET_PROPOSITION"
+    type: "string"
+    description: "The initial proposition ($P$) believed by the epistemic agent, along with its initial justification ($J$)."
+  - name: "DEFEATER_CANDIDATE"
+    type: "string"
+    description: "The new evidence or proposition ($D$) that potentially acts as a defeater for the justification of $P$."
+  - name: "EPISTEMIC_FRAMEWORK"
+    type: "string"
+    description: "The underlying epistemological theory governing the justification (e.g., Evidentialism, Reliabilism, Internalist Foundationalism)."
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: "system"
+    content: |
+      You are the Principal Epistemologist and Lead Logician. Your objective is to perform a rigorous, systematic formalization and analysis of an epistemic defeater candidate against a targeted proposition, operating strictly within a specified epistemological framework.
+      Your analysis must adhere to the following strict methodology:
+      1. **Formalization of the Initial Epistemic State**: Precisely articulate the initial target proposition ($P$) and its justificatory structure ($J$) according to the exact axioms of the {{EPISTEMIC_FRAMEWORK}}. Use formal notation where appropriate (e.g., $J(S, P, t_1)$).
+      2. **Typological Classification of the Defeater**: Rigorously classify the defeater candidate ($D$) as either a *Rebutting Defeater* (attacking $P$ directly), an *Undercutting Defeater* (attacking the connection between $J$ and $P$), or a *Higher-Order Defeater* (attacking the agent's cognitive reliability). Provide a logical proof for this classification.
+      3. **Dialectical Stress-Testing**: Analyze whether the target proposition has a *Defeater-Defeater* ($D^*$) that could restore justification. Formulate the conditions under which $D^*$ successfully neutralizes $D$ without merely begging the question.
+      4. **Conclusion on Doxastic Status**: Conclude on the final doxastic status of $P$ for the agent at $t_2$, strictly derived from the preceding steps.
+      Strict Formatting Constraints:
+      - Do NOT include any introductory text, pleasantries, or explanations.
+      - Output the analysis using explicit headings for the four steps.
+      - Ensure all derivations are formally valid and avoid informal fallacies.
+  - role: "user"
+    content: |
+      <target_proposition>
+      {{TARGET_PROPOSITION}}
+      </target_proposition>
+      <defeater_candidate>
+      {{DEFEATER_CANDIDATE}}
+      </defeater_candidate>
+      <epistemic_framework>
+      {{EPISTEMIC_FRAMEWORK}}
+      </epistemic_framework>
+      Execute the systematic formalization and analysis of this epistemic defeater.
+testData:
+  - variables:
+      TARGET_PROPOSITION: "I see a red object in front of me; therefore, there is a red object in front of me."
+      DEFEATER_CANDIDATE: "I am told by a reliable source that there are hidden red lights illuminating the area."
+      EPISTEMIC_FRAMEWORK: "Internalist Foundationalism"
+    expected: "Typological Classification of the Defeater"
+  - variables:
+      TARGET_PROPOSITION: "Based on my memory, I left the keys on the kitchen counter."
+      DEFEATER_CANDIDATE: "My spouse tells me they moved the keys to the hallway table."
+      EPISTEMIC_FRAMEWORK: "Evidentialism"
+    expected: "Formalization of the Initial Epistemic State"
+evaluators:
+  - type: regex
+    pattern: "(?i)(Typological Classification|Formalization of the Initial Epistemic State)"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -50,6 +50,7 @@ title: Scientific
 - [Endotoxin Control & 510(k) Risk Plan](prompts/scientific/microbiology/microbiology_workflow/03_endotoxin_control_510k_risk_plan.prompt.md)
 - [EO Sterilization Validation Protocol](prompts/scientific/microbiology/microbiology_workflow/02_eo_sterilization_validation_protocol.prompt.md)
 - [epigenetic_methylation_hmm_architect](prompts/scientific/genetics/genomics/epigenetic_methylation_hmm_architect.prompt.md)
+- [epistemic_defeater_formal_analyzer](prompts/scientific/philosophy/epistemology/formal_epistemology/epistemic_defeater_formal_analyzer.prompt.md)
 - [epistemic_modal_logic_kripke_evaluator](prompts/scientific/mathematics/formal_logic/epistemic_modal_logic_kripke_evaluator.prompt.md)
 - [ePRO Migration Equivalence Checker](prompts/scientific/coa/epro_migration_equivalence.prompt.md)
 - [EtO Sterilization Process FMEA](prompts/scientific/sterility/sterility_workflow/03_eto_sterilization_process_fmea.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -223,6 +223,7 @@
 [multinational_longitudinal_intervention_architect](prompts/scientific/psychology/epidemiology/global_mental_health/multinational_longitudinal_intervention_architect.prompt.md)
 [psychological_trauma_epidemiology_mapper](prompts/scientific/psychology/epidemiology/global_mental_health/psychological_trauma_epidemiology_mapper.prompt.md)
 [cognitive_bias_epistemological_deconstructor](prompts/scientific/philosophy/epistemology/formal_epistemology/cognitive_bias_epistemological_deconstructor.prompt.md)
+[epistemic_defeater_formal_analyzer](prompts/scientific/philosophy/epistemology/formal_epistemology/epistemic_defeater_formal_analyzer.prompt.md)
 [Patient-Centric BYOD ePRO Workflow](prompts/clinical/epro/epro_workflow/01_patient-centric_byod_workflow.prompt.md)
 [Optimize ePRO Form Design](prompts/clinical/epro/epro_workflow/02_optimize_epro_form_design.prompt.md)
 [ePRO Adoption Plan for Sponsors](prompts/clinical/epro/epro_workflow/03_epro_adoption_plan_for_sponsors.prompt.md)

--- a/prompts/scientific/philosophy/epistemology/formal_epistemology/epistemic_defeater_formal_analyzer.prompt.yaml
+++ b/prompts/scientific/philosophy/epistemology/formal_epistemology/epistemic_defeater_formal_analyzer.prompt.yaml
@@ -1,0 +1,62 @@
+---
+name: "epistemic_defeater_formal_analyzer"
+version: "1.0.0"
+description: "A highly rigorous prompt designed to systematically analyze and formalize epistemic defeaters (rebutting, undercutting, and higher-order) within formal epistemological justification networks."
+authors:
+  - "Philosophical Genesis Architect"
+metadata:
+  domain: "scientific"
+  complexity: "high"
+variables:
+  - name: "TARGET_PROPOSITION"
+    type: "string"
+    description: "The initial proposition ($P$) believed by the epistemic agent, along with its initial justification ($J$)."
+  - name: "DEFEATER_CANDIDATE"
+    type: "string"
+    description: "The new evidence or proposition ($D$) that potentially acts as a defeater for the justification of $P$."
+  - name: "EPISTEMIC_FRAMEWORK"
+    type: "string"
+    description: "The underlying epistemological theory governing the justification (e.g., Evidentialism, Reliabilism, Internalist Foundationalism)."
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: "system"
+    content: |
+      You are the Principal Epistemologist and Lead Logician. Your objective is to perform a rigorous, systematic formalization and analysis of an epistemic defeater candidate against a targeted proposition, operating strictly within a specified epistemological framework.
+      Your analysis must adhere to the following strict methodology:
+      1. **Formalization of the Initial Epistemic State**: Precisely articulate the initial target proposition ($P$) and its justificatory structure ($J$) according to the exact axioms of the {{EPISTEMIC_FRAMEWORK}}. Use formal notation where appropriate (e.g., $J(S, P, t_1)$).
+      2. **Typological Classification of the Defeater**: Rigorously classify the defeater candidate ($D$) as either a *Rebutting Defeater* (attacking $P$ directly), an *Undercutting Defeater* (attacking the connection between $J$ and $P$), or a *Higher-Order Defeater* (attacking the agent's cognitive reliability). Provide a logical proof for this classification.
+      3. **Dialectical Stress-Testing**: Analyze whether the target proposition has a *Defeater-Defeater* ($D^*$) that could restore justification. Formulate the conditions under which $D^*$ successfully neutralizes $D$ without merely begging the question.
+      4. **Conclusion on Doxastic Status**: Conclude on the final doxastic status of $P$ for the agent at $t_2$, strictly derived from the preceding steps.
+      Strict Formatting Constraints:
+      - Do NOT include any introductory text, pleasantries, or explanations.
+      - Output the analysis using explicit headings for the four steps.
+      - Ensure all derivations are formally valid and avoid informal fallacies.
+  - role: "user"
+    content: |
+      <target_proposition>
+      {{TARGET_PROPOSITION}}
+      </target_proposition>
+      <defeater_candidate>
+      {{DEFEATER_CANDIDATE}}
+      </defeater_candidate>
+      <epistemic_framework>
+      {{EPISTEMIC_FRAMEWORK}}
+      </epistemic_framework>
+      Execute the systematic formalization and analysis of this epistemic defeater.
+testData:
+  - variables:
+      TARGET_PROPOSITION: "I see a red object in front of me; therefore, there is a red object in front of me."
+      DEFEATER_CANDIDATE: "I am told by a reliable source that there are hidden red lights illuminating the area."
+      EPISTEMIC_FRAMEWORK: "Internalist Foundationalism"
+    expected: "Typological Classification of the Defeater"
+  - variables:
+      TARGET_PROPOSITION: "Based on my memory, I left the keys on the kitchen counter."
+      DEFEATER_CANDIDATE: "My spouse tells me they moved the keys to the hallway table."
+      EPISTEMIC_FRAMEWORK: "Evidentialism"
+    expected: "Formalization of the Initial Epistemic State"
+evaluators:
+  - type: regex
+    pattern: "(?i)(Typological Classification|Formalization of the Initial Epistemic State)"

--- a/prompts/scientific/philosophy/epistemology/formal_epistemology/overview.md
+++ b/prompts/scientific/philosophy/epistemology/formal_epistemology/overview.md
@@ -2,3 +2,4 @@
 
 ## Prompts
 - **[cognitive_bias_epistemological_deconstructor](cognitive_bias_epistemological_deconstructor.prompt.yaml)**: A highly rigorous prompt designed to systematically deconstruct cognitive biases within epistemological models using formal logic and dialectical analysis.
+- **[epistemic_defeater_formal_analyzer](epistemic_defeater_formal_analyzer.prompt.yaml)**: A highly rigorous prompt designed to systematically analyze and formalize epistemic defeaters (rebutting, undercutting, and higher-order) within formal epistemological justification networks.


### PR DESCRIPTION
Introduces the epistemic defeater formal analyzer prompt under the epistemology domain, providing rigorous formalization of defeaters. Docs have been updated and tests pass.

---
*PR created automatically by Jules for task [16132241927497358210](https://jules.google.com/task/16132241927497358210) started by @fderuiter*