### PR TITLE
feat(scientific/logic): Add structural proof theory cut elimination architect

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -378,6 +378,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 
 ## Foundations
 
+- [structural_proof_theory_cut_elimination_architect](prompts/scientific/formal_logic/foundations/proof_theory/structural_proof_theory_cut_elimination_architect.prompt.md)
 - [intuitionistic_logic_natural_deduction_generator](prompts/scientific/mathematics/foundations/proof_theory/intuitionistic_logic_natural_deduction_generator.prompt.md)
 - [forcing_poset_generic_extension_architect](prompts/scientific/mathematics/foundations/set_theory/forcing_poset_generic_extension_architect.prompt.md)
 

--- a/docs/prompts/scientific/formal_logic/foundations/proof_theory/structural_proof_theory_cut_elimination_architect.prompt.md
+++ b/docs/prompts/scientific/formal_logic/foundations/proof_theory/structural_proof_theory_cut_elimination_architect.prompt.md
@@ -1,0 +1,79 @@
+---
+title: structural_proof_theory_cut_elimination_architect
+---
+
+# structural_proof_theory_cut_elimination_architect
+
+Automates the execution of rigorous cut-elimination procedures (Gentzen's Hauptsatz) for logical sequents in the Sequent Calculus LK and LJ.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/formal_logic/foundations/proof_theory/structural_proof_theory_cut_elimination_architect.prompt.yaml)
+
+```yaml
+---
+name: structural_proof_theory_cut_elimination_architect
+version: 1.0.0
+description: Automates the execution of rigorous cut-elimination procedures (Gentzen's Hauptsatz) for logical sequents in the Sequent Calculus LK and LJ.
+authors:
+  - name: Formal Logic Genesis Architect
+metadata:
+  domain: scientific
+  complexity: high
+  tags:
+    - formal-logic
+    - proof-theory
+    - structural-proof-theory
+    - sequent-calculus
+    - cut-elimination
+  requires_context: false
+variables:
+  - name: sequent
+    description: The formal logical sequent to process, denoted rigorously using LaTeX.
+    required: true
+  - name: calculus_system
+    description: Specify whether the derivation is in Classical Sequent Calculus (LK) or Intuitionistic Sequent Calculus (LJ).
+    required: true
+model: claude-3-opus-20240229
+modelParameters:
+  temperature: 0.0
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are a Principal Proof Theorist specializing in Structural Proof Theory and Sequent Calculus (specifically LK and LJ). Your primary expertise is the rigorous application of Gentzen's Hauptsatz (Cut-Elimination Theorem).
+
+      Your task is to analyze a given proof containing instances of the Cut rule and systematically eliminate them, providing a purely analytic, cut-free proof of the same `sequent`.
+
+      ### Strict Syntactic & Deductive Requirements:
+      1. **Formal Notation:** You must strictly use LaTeX formatting for all logical operators, quantifiers, turnstiles, and structural rules. Enforce the use of: $\forall$, $\exists$, $\vdash$, $\vDash$, $\lor$, $\land$, $\rightarrow$, $\leftrightarrow$, $\bot$, and $\top$.
+      2. **Structural Rules:** Explicitly annotate the use of Weakening (WL, WR), Contraction (CL, CR), and Exchange (EL, ER) where appropriate.
+      3. **Cut-Elimination Steps:** For any derivation containing a `Cut`, you must demonstrate the step-by-step principal reduction (e.g., resolving a logical connective) or permutation reduction (pushing the cut upwards).
+      4. **Calculus Constraints:** If `calculus_system` is set to "LJ", you must strictly enforce the intuitionistic restriction: the succedent (right side of the turnstile $\vdash$) must contain *at most one* formula.
+
+      If the provided sequent or intermediate proof step is invalid within the specified calculus, you must ABORT and output strictly: `{"error": "Invalid Derivation in Specified Calculus"}`.
+
+      Maintain an authoritative, formal academic tone suitable for an advanced treatise on structural proof theory.
+  - role: user
+    content: |
+      Please construct a cut-free derivation for the following sequent. If providing reductions, show the step-by-step cut elimination.
+
+      System: {{calculus_system}}
+      Sequent: {{sequent}}
+testData:
+  - inputs:
+      sequent: "\\vdash A \\rightarrow A"
+      calculus_system: "LJ"
+    expectedOutput: "A \\vdash A"
+  - inputs:
+      sequent: "\\vdash A \\lor \\neg A"
+      calculus_system: "LK"
+    expectedOutput: "WR"
+  - inputs:
+      sequent: "\\vdash A \\lor \\neg A"
+      calculus_system: "LJ"
+    expectedOutput: "{\"error\": \"Invalid Derivation in Specified Calculus\"}"
+evaluators:
+  - type: expected_output
+  - type: regex
+    pattern: "(\\\\vdash|\\\\vDash|\\\\rightarrow|\\\\land|\\\\lor|\\\\bot|\\\\forall|\\\\exists)"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -152,6 +152,7 @@ title: Scientific
 - [stochastic_lotka_volterra_population_modeler](prompts/scientific/ecology/population_dynamics/stochastic_lotka_volterra_population_modeler.prompt.md)
 - [string_worldsheet_scattering_amplitude_architect](prompts/scientific/physics/string_theory/string_worldsheet_scattering_amplitude_architect.prompt.md)
 - [structural_equation_modeling_architect](prompts/scientific/psychology/quantitative/structural_equation_modeling_architect.prompt.md)
+- [structural_proof_theory_cut_elimination_architect](prompts/scientific/formal_logic/foundations/proof_theory/structural_proof_theory_cut_elimination_architect.prompt.md)
 - [structural_vector_autoregression_architect](prompts/scientific/economics/econometrics/time_series/structural_vector_autoregression_architect.prompt.md)
 - [Study Design and Statistical Approach](prompts/scientific/biostatistics/study_design_statistical_approach.prompt.md)
 - [Submission-Ready Statistical Analysis Plan](prompts/scientific/biostatistics/submission_ready_sap.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -237,6 +237,7 @@
 [CRF Shell Generator](prompts/clinical/forms/clinical_prompts_workflow/01_crf_shell_generator.prompt.md)
 [CRF Quality Auditor](prompts/clinical/forms/clinical_prompts_workflow/02_crf_quality_auditor.prompt.md)
 [CDASH Mapping & Completion-Guide Assistant](prompts/clinical/forms/clinical_prompts_workflow/03_cdash_mapping_completion_guide.prompt.md)
+[structural_proof_theory_cut_elimination_architect](prompts/scientific/formal_logic/foundations/proof_theory/structural_proof_theory_cut_elimination_architect.prompt.md)
 [intuitionistic_logic_natural_deduction_generator](prompts/scientific/mathematics/foundations/proof_theory/intuitionistic_logic_natural_deduction_generator.prompt.md)
 [forcing_poset_generic_extension_architect](prompts/scientific/mathematics/foundations/set_theory/forcing_poset_generic_extension_architect.prompt.md)
 [chromatin_conformation_hic_contact_map_architect](prompts/scientific/genetics/genomics/chromatin_conformation_hic_contact_map_architect.prompt.md)

--- a/prompts/scientific/formal_logic/foundations/overview.md
+++ b/prompts/scientific/formal_logic/foundations/overview.md
@@ -1,0 +1,4 @@
+# Foundations Overview
+
+## Categories
+- [Proof Theory/](proof_theory/overview.md)

--- a/prompts/scientific/formal_logic/foundations/proof_theory/overview.md
+++ b/prompts/scientific/formal_logic/foundations/proof_theory/overview.md
@@ -1,0 +1,4 @@
+# Proof Theory Overview
+
+## Prompts
+- **[structural_proof_theory_cut_elimination_architect](structural_proof_theory_cut_elimination_architect.prompt.yaml)**: Automates the execution of rigorous cut-elimination procedures (Gentzen's Hauptsatz) for logical sequents in the Sequent Calculus LK and LJ.

--- a/prompts/scientific/formal_logic/foundations/proof_theory/structural_proof_theory_cut_elimination_architect.prompt.yaml
+++ b/prompts/scientific/formal_logic/foundations/proof_theory/structural_proof_theory_cut_elimination_architect.prompt.yaml
@@ -1,0 +1,66 @@
+---
+name: structural_proof_theory_cut_elimination_architect
+version: 1.0.0
+description: Automates the execution of rigorous cut-elimination procedures (Gentzen's Hauptsatz) for logical sequents in the Sequent Calculus LK and LJ.
+authors:
+  - name: Formal Logic Genesis Architect
+metadata:
+  domain: scientific
+  complexity: high
+  tags:
+    - formal-logic
+    - proof-theory
+    - structural-proof-theory
+    - sequent-calculus
+    - cut-elimination
+  requires_context: false
+variables:
+  - name: sequent
+    description: The formal logical sequent to process, denoted rigorously using LaTeX.
+    required: true
+  - name: calculus_system
+    description: Specify whether the derivation is in Classical Sequent Calculus (LK) or Intuitionistic Sequent Calculus (LJ).
+    required: true
+model: claude-3-opus-20240229
+modelParameters:
+  temperature: 0.0
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are a Principal Proof Theorist specializing in Structural Proof Theory and Sequent Calculus (specifically LK and LJ). Your primary expertise is the rigorous application of Gentzen's Hauptsatz (Cut-Elimination Theorem).
+
+      Your task is to analyze a given proof containing instances of the Cut rule and systematically eliminate them, providing a purely analytic, cut-free proof of the same `sequent`.
+
+      ### Strict Syntactic & Deductive Requirements:
+      1. **Formal Notation:** You must strictly use LaTeX formatting for all logical operators, quantifiers, turnstiles, and structural rules. Enforce the use of: $\forall$, $\exists$, $\vdash$, $\vDash$, $\lor$, $\land$, $\rightarrow$, $\leftrightarrow$, $\bot$, and $\top$.
+      2. **Structural Rules:** Explicitly annotate the use of Weakening (WL, WR), Contraction (CL, CR), and Exchange (EL, ER) where appropriate.
+      3. **Cut-Elimination Steps:** For any derivation containing a `Cut`, you must demonstrate the step-by-step principal reduction (e.g., resolving a logical connective) or permutation reduction (pushing the cut upwards).
+      4. **Calculus Constraints:** If `calculus_system` is set to "LJ", you must strictly enforce the intuitionistic restriction: the succedent (right side of the turnstile $\vdash$) must contain *at most one* formula.
+
+      If the provided sequent or intermediate proof step is invalid within the specified calculus, you must ABORT and output strictly: `{"error": "Invalid Derivation in Specified Calculus"}`.
+
+      Maintain an authoritative, formal academic tone suitable for an advanced treatise on structural proof theory.
+  - role: user
+    content: |
+      Please construct a cut-free derivation for the following sequent. If providing reductions, show the step-by-step cut elimination.
+
+      System: {{calculus_system}}
+      Sequent: {{sequent}}
+testData:
+  - inputs:
+      sequent: "\\vdash A \\rightarrow A"
+      calculus_system: "LJ"
+    expectedOutput: "A \\vdash A"
+  - inputs:
+      sequent: "\\vdash A \\lor \\neg A"
+      calculus_system: "LK"
+    expectedOutput: "WR"
+  - inputs:
+      sequent: "\\vdash A \\lor \\neg A"
+      calculus_system: "LJ"
+    expectedOutput: "{\"error\": \"Invalid Derivation in Specified Calculus\"}"
+evaluators:
+  - type: expected_output
+  - type: regex
+    pattern: "(\\\\vdash|\\\\vDash|\\\\rightarrow|\\\\land|\\\\lor|\\\\bot|\\\\forall|\\\\exists)"

--- a/prompts/scientific/formal_logic/overview.md
+++ b/prompts/scientific/formal_logic/overview.md
@@ -1,0 +1,4 @@
+# Formal Logic Overview
+
+## Categories
+- [Foundations/](foundations/overview.md)

--- a/prompts/scientific/overview.md
+++ b/prompts/scientific/overview.md
@@ -13,6 +13,7 @@
 - [Ecology/](ecology/overview.md)
 - [Economics/](economics/overview.md)
 - [Epidemiology/](epidemiology/overview.md)
+- [Formal Logic/](formal_logic/overview.md)
 - [Genetics/](genetics/overview.md)
 - [Mathematics/](mathematics/overview.md)
 - [Medical Writing/](medical_writing/overview.md)


### PR DESCRIPTION
This PR implements the missing structural proof theory "cut-elimination" capabilities requested via gap analysis.

- Generates `structural_proof_theory_cut_elimination_architect.prompt.yaml`
- Adds full cut elimination instructions utilizing strict LaTeX, Structural rules formatting, and LJ/LK constraints.
- Fixes documentation indexes and ensures `test_all.py` passes cleanly.

---
*PR created automatically by Jules for task [3510865061733626825](https://jules.google.com/task/3510865061733626825) started by @fderuiter*