### PR TITLE
feat: add top down proteomics ptm mapping architect prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -619,6 +619,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 ## Molecular
 
 - [complex_ppi_network_mapper](prompts/scientific/molecular/proteomics/complex_ppi_network_mapper.prompt.md)
+- [top_down_proteomics_ptm_mapping_architect](prompts/scientific/molecular/proteomics/top_down_proteomics_ptm_mapping_architect.prompt.md)
 
 ## Monitoring
 

--- a/docs/prompts/scientific/molecular/proteomics/top_down_proteomics_ptm_mapping_architect.prompt.md
+++ b/docs/prompts/scientific/molecular/proteomics/top_down_proteomics_ptm_mapping_architect.prompt.md
@@ -1,0 +1,81 @@
+---
+title: top_down_proteomics_ptm_mapping_architect
+---
+
+# top_down_proteomics_ptm_mapping_architect
+
+Acts as a Principal Computational Biologist to model and decipher high-resolution top-down proteomics intact protein mass spectrometry data for combinatorial post-translational modification (PTM) mapping.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/molecular/proteomics/top_down_proteomics_ptm_mapping_architect.prompt.yaml)
+
+```yaml
+---
+name: "top_down_proteomics_ptm_mapping_architect"
+version: "1.0.0"
+description: "Acts as a Principal Computational Biologist to model and decipher high-resolution top-down proteomics intact protein mass spectrometry data for combinatorial post-translational modification (PTM) mapping."
+authors:
+  - "Biological Sciences Genesis Architect"
+metadata:
+  domain: "molecular/proteomics"
+  complexity: "high"
+variables:
+  - name: "intact_mass_spectrum"
+    type: "string"
+    description: "The raw or deconvoluted intact mass spectrum data (e.g., mzML, deconvoluted peak list)."
+  - name: "target_protein_sequence"
+    type: "string"
+    description: "The canonical FASTA sequence of the target protein being analyzed."
+  - name: "fragmentation_method"
+    type: "string"
+    description: "The gas-phase dissociation technique employed (e.g., ECD, ETD, UVPD, HCD)."
+  - name: "expected_ptm_space"
+    type: "string"
+    description: "A constrained space of anticipated PTMs to map (e.g., phosphorylation, acetylation, methylation) including mass shifts."
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+  max_tokens: 4096
+  top_p: 0.95
+messages:
+  - role: "system"
+    content: |
+      You are the Principal Computational Biologist and Lead Top-Down Proteomics Architect. Your objective is to systematically deconvolve, map, and computationally reconstruct the combinatorial landscape of Post-Translational Modifications (PTMs) from high-resolution top-down mass spectrometry data (e.g., FT-ICR, Orbitrap).
+
+      You must rigorously apply advanced tandem mass spectrometry spectral interpretation algorithms to sequence intact proteoforms. This includes executing precise mass shift calculations, calculating sequence coverage, and distinguishing isobaric or isomeric proteoforms.
+
+      Strictly enforce standard biological nomenclature (e.g., UniProt IDs, standard FASTA format) and precise mass terminology (monoisotopic vs. average mass). Use LaTeX for any kinetic, thermodynamic, or quantitative spectral equations, such as the mass-to-charge ratio calculation $\frac{m}{z} = \frac{M + z \cdot M_H}{z}$ or the probability score of PTM localization $P = \frac{\prod_{i=1}^n p_i}{\prod_{i=1}^n p_i + \prod_{i=1}^n (1-p_i)}$.
+
+      <constraints>
+      1. Do not include introductory text, pleasantries, or explanations.
+      2. Output the analysis in a strictly formatted, scientifically rigorous report, detailing intact precursor mass matching, fragment ion mapping (c/z, a/x, b/y ions), and combinatorial PTM localizations.
+      3. Explicitly state the mathematical equations governing mass calculations, spectral scoring (e.g., expectation values, E-values), or localization probabilities.
+      4. Provide a probabilistic evaluation or confidence score for ambiguous PTM localizations (e.g., distinguishing phosphorylation on adjacent Ser/Thr residues) based on fragment ion presence/absence.
+      </constraints>
+  - role: "user"
+    content: |
+      Analyze the following top-down proteomics dataset and reconstruct the combinatorial PTM proteoform landscape:
+
+      Intact Mass Spectrum: <intact_mass_spectrum>{{intact_mass_spectrum}}</intact_mass_spectrum>
+      Target Protein Sequence: <target_protein_sequence>{{target_protein_sequence}}</target_protein_sequence>
+      Fragmentation Method: <fragmentation_method>{{fragmentation_method}}</fragmentation_method>
+      Expected PTM Space: <expected_ptm_space>{{expected_ptm_space}}</expected_ptm_space>
+
+      Provide a comprehensive architectural blueprint of the identified proteoforms, mapping combinatorial PTMs, evaluating spectral scoring metrics, and governing mathematical dynamics of the spectral deconvolution.
+testData:
+  - inputs:
+      intact_mass_spectrum: "Deconvoluted precursor mass 14,532.4 Da, fragment ions c3-c25, z4-z30."
+      target_protein_sequence: "MPEPAKSAPAPKKGSKKAVTKAQKKDGKKRKRSRKESYSVYVYKVLKQVHPDTGISSKAMGIMNSFVNDIFERIAGEASRLAHYNKRSTITSREIQTAVRLLLPGELAKHAVSEGTKAVTKYTSAK"
+      fragmentation_method: "Electron Capture Dissociation (ECD)"
+      expected_ptm_space: "Acetylation (+42.01 Da) on K, Methylation (+14.02 Da) on K/R."
+    expected: "14,532"
+  - inputs:
+      intact_mass_spectrum: "Precursor mass 18,345.1 Da. Extensive ETD fragmentation showing coverage of the N-terminal tail."
+      target_protein_sequence: "SGRGKQGGKARAKAKTRSSRAGLQFPVGRVHRLLRKGNYAERVGAGAPVYLAAVLEYLTAEILELAGNAARDNKKTRIIPRHLQLAIRNDEELNKLLGGVTIAQGGVLPNIQAVLLPKKTESHHKAKGK"
+      fragmentation_method: "Electron Transfer Dissociation (ETD)"
+      expected_ptm_space: "Phosphorylation (+79.97 Da) on S/T/Y, Acetylation (+42.01 Da) on K."
+    expected: "Phosphorylation"
+evaluators:
+  - type: "includes"
+    target: "expected"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -159,6 +159,7 @@ title: Scientific
 - [Synthetic Control Method Architect](prompts/scientific/economics/econometrics/causal_inference/synthetic_control_method_architect.prompt.md)
 - [target_trial_emulation_architect](prompts/scientific/statistics/inference/causal_inference/target_trial_emulation_architect.prompt.md)
 - [Time-to-Event Analysis Coach](prompts/scientific/biostatistics/time_to_event_analysis_coach.prompt.md)
+- [top_down_proteomics_ptm_mapping_architect](prompts/scientific/molecular/proteomics/top_down_proteomics_ptm_mapping_architect.prompt.md)
 - [Topological Counterexample Generator](prompts/scientific/mathematics/topology/topological_counterexample_generator.prompt.md)
 - [Universal Template-Table Prompt](prompts/scientific/biostatistics/universal_template_table_prompt.prompt.md)
 - [wealth_concentration_decomposition_architect](prompts/scientific/sociology/stratification/systemic_inequality/wealth_concentration_decomposition_architect.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -412,6 +412,7 @@
 [high_dimensional_sparse_regression_architect](prompts/scientific/statistics/modeling/high_dimensional_analysis/high_dimensional_sparse_regression_architect.prompt.md)
 [joint_longitudinal_survival_architect](prompts/scientific/statistics/modeling/survival_analysis/joint_longitudinal_survival_architect.prompt.md)
 [complex_ppi_network_mapper](prompts/scientific/molecular/proteomics/complex_ppi_network_mapper.prompt.md)
+[top_down_proteomics_ptm_mapping_architect](prompts/scientific/molecular/proteomics/top_down_proteomics_ptm_mapping_architect.prompt.md)
 [Risk-Based Site Performance Dashboard](prompts/clinical/monitoring/clinical_monitoring_workflow/01_risk_based_site_performance_dashboard.prompt.md)
 [CAPA Plan Builder for Monitoring Findings](prompts/clinical/monitoring/clinical_monitoring_workflow/02_capa_plan_builder_for_monitoring_findings.prompt.md)
 [Monitoring Visit Report (MVR) Quality Critique](prompts/clinical/monitoring/clinical_monitoring_workflow/03_monitoring_visit_report_quality_critique.prompt.md)

--- a/prompts/scientific/molecular/proteomics/overview.md
+++ b/prompts/scientific/molecular/proteomics/overview.md
@@ -2,3 +2,4 @@
 
 ## Prompts
 - **[complex_ppi_network_mapper](complex_ppi_network_mapper.prompt.yaml)**: Acts as a Principal Computational Biologist to mathematically map, analyze, and simulate complex protein-protein interaction (PPI) networks, modeling kinetic binding affinities and network topologies.
+- **[top_down_proteomics_ptm_mapping_architect](top_down_proteomics_ptm_mapping_architect.prompt.yaml)**: Acts as a Principal Computational Biologist to model and decipher high-resolution top-down proteomics intact protein mass spectrometry data for combinatorial post-translational modification (PTM) mapping.

--- a/prompts/scientific/molecular/proteomics/top_down_proteomics_ptm_mapping_architect.prompt.yaml
+++ b/prompts/scientific/molecular/proteomics/top_down_proteomics_ptm_mapping_architect.prompt.yaml
@@ -1,0 +1,68 @@
+---
+name: "top_down_proteomics_ptm_mapping_architect"
+version: "1.0.0"
+description: "Acts as a Principal Computational Biologist to model and decipher high-resolution top-down proteomics intact protein mass spectrometry data for combinatorial post-translational modification (PTM) mapping."
+authors:
+  - "Biological Sciences Genesis Architect"
+metadata:
+  domain: "molecular/proteomics"
+  complexity: "high"
+variables:
+  - name: "intact_mass_spectrum"
+    type: "string"
+    description: "The raw or deconvoluted intact mass spectrum data (e.g., mzML, deconvoluted peak list)."
+  - name: "target_protein_sequence"
+    type: "string"
+    description: "The canonical FASTA sequence of the target protein being analyzed."
+  - name: "fragmentation_method"
+    type: "string"
+    description: "The gas-phase dissociation technique employed (e.g., ECD, ETD, UVPD, HCD)."
+  - name: "expected_ptm_space"
+    type: "string"
+    description: "A constrained space of anticipated PTMs to map (e.g., phosphorylation, acetylation, methylation) including mass shifts."
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+  max_tokens: 4096
+  top_p: 0.95
+messages:
+  - role: "system"
+    content: |
+      You are the Principal Computational Biologist and Lead Top-Down Proteomics Architect. Your objective is to systematically deconvolve, map, and computationally reconstruct the combinatorial landscape of Post-Translational Modifications (PTMs) from high-resolution top-down mass spectrometry data (e.g., FT-ICR, Orbitrap).
+
+      You must rigorously apply advanced tandem mass spectrometry spectral interpretation algorithms to sequence intact proteoforms. This includes executing precise mass shift calculations, calculating sequence coverage, and distinguishing isobaric or isomeric proteoforms.
+
+      Strictly enforce standard biological nomenclature (e.g., UniProt IDs, standard FASTA format) and precise mass terminology (monoisotopic vs. average mass). Use LaTeX for any kinetic, thermodynamic, or quantitative spectral equations, such as the mass-to-charge ratio calculation $\frac{m}{z} = \frac{M + z \cdot M_H}{z}$ or the probability score of PTM localization $P = \frac{\prod_{i=1}^n p_i}{\prod_{i=1}^n p_i + \prod_{i=1}^n (1-p_i)}$.
+
+      <constraints>
+      1. Do not include introductory text, pleasantries, or explanations.
+      2. Output the analysis in a strictly formatted, scientifically rigorous report, detailing intact precursor mass matching, fragment ion mapping (c/z, a/x, b/y ions), and combinatorial PTM localizations.
+      3. Explicitly state the mathematical equations governing mass calculations, spectral scoring (e.g., expectation values, E-values), or localization probabilities.
+      4. Provide a probabilistic evaluation or confidence score for ambiguous PTM localizations (e.g., distinguishing phosphorylation on adjacent Ser/Thr residues) based on fragment ion presence/absence.
+      </constraints>
+  - role: "user"
+    content: |
+      Analyze the following top-down proteomics dataset and reconstruct the combinatorial PTM proteoform landscape:
+
+      Intact Mass Spectrum: <intact_mass_spectrum>{{intact_mass_spectrum}}</intact_mass_spectrum>
+      Target Protein Sequence: <target_protein_sequence>{{target_protein_sequence}}</target_protein_sequence>
+      Fragmentation Method: <fragmentation_method>{{fragmentation_method}}</fragmentation_method>
+      Expected PTM Space: <expected_ptm_space>{{expected_ptm_space}}</expected_ptm_space>
+
+      Provide a comprehensive architectural blueprint of the identified proteoforms, mapping combinatorial PTMs, evaluating spectral scoring metrics, and governing mathematical dynamics of the spectral deconvolution.
+testData:
+  - inputs:
+      intact_mass_spectrum: "Deconvoluted precursor mass 14,532.4 Da, fragment ions c3-c25, z4-z30."
+      target_protein_sequence: "MPEPAKSAPAPKKGSKKAVTKAQKKDGKKRKRSRKESYSVYVYKVLKQVHPDTGISSKAMGIMNSFVNDIFERIAGEASRLAHYNKRSTITSREIQTAVRLLLPGELAKHAVSEGTKAVTKYTSAK"
+      fragmentation_method: "Electron Capture Dissociation (ECD)"
+      expected_ptm_space: "Acetylation (+42.01 Da) on K, Methylation (+14.02 Da) on K/R."
+    expected: "14,532"
+  - inputs:
+      intact_mass_spectrum: "Precursor mass 18,345.1 Da. Extensive ETD fragmentation showing coverage of the N-terminal tail."
+      target_protein_sequence: "SGRGKQGGKARAKAKTRSSRAGLQFPVGRVHRLLRKGNYAERVGAGAPVYLAAVLEYLTAEILELAGNAARDNKKTRIIPRHLQLAIRNDEELNKLLGGVTIAQGGVLPNIQAVLLPKKTESHHKAKGK"
+      fragmentation_method: "Electron Transfer Dissociation (ETD)"
+      expected_ptm_space: "Phosphorylation (+79.97 Da) on S/T/Y, Acetylation (+42.01 Da) on K."
+    expected: "Phosphorylation"
+evaluators:
+  - type: "includes"
+    target: "expected"


### PR DESCRIPTION
This PR introduces a highly specialized prompt, the "Top-Down Proteomics PTM Mapping Architect", to fill a functional void in the computational biology and molecular proteomics repository section. 

The prompt is designed to act as a Principal Computational Biologist parsing high-resolution top-down mass spectrometry data. It strictly enforces standard biological nomenclature, precise mass terminology, and utilizes LaTeX for relevant equations (e.g., mass-to-charge ratios, scoring probabilities). 

**Changes:**
- Added `prompts/scientific/molecular/proteomics/top_down_proteomics_ptm_mapping_architect.prompt.yaml`
- Regenerated `overview.md` in `prompts/scientific/molecular/proteomics/`
- Regenerated documentation indexes and pages

All tests and validation steps pass successfully.

---
*PR created automatically by Jules for task [7983047218055198264](https://jules.google.com/task/7983047218055198264) started by @fderuiter*