### PR TITLE
Add Investigational New Drug (IND) Architect Prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -836,6 +836,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Humanitarian Device Exemption (HDE)](prompts/regulatory/submissions/humanitarian_device_exemption_hde.prompt.md)
 - [ich_m4e_ctd_clinical_overview_architect](prompts/regulatory/submissions/ich_m4e_ctd_clinical_overview_architect.prompt.md)
 - [IDE Application Preparation](prompts/regulatory/submissions/ide_application_preparation.prompt.md)
+- [Investigational New Drug (IND) Architect](prompts/regulatory/submissions/investigational_new_drug_ind_architect.prompt.md)
 - [Medicare Coverage Request (IDE)](prompts/regulatory/submissions/medicare_coverage_request_ide.prompt.md)
 - [Parallel Review Request](prompts/regulatory/submissions/parallel_review_request.prompt.md)
 - [PMA Post-approval Reporting](prompts/regulatory/submissions/pma_post_approval_reporting.prompt.md)

--- a/docs/prompts/regulatory/submissions/investigational_new_drug_ind_architect.prompt.md
+++ b/docs/prompts/regulatory/submissions/investigational_new_drug_ind_architect.prompt.md
@@ -1,0 +1,79 @@
+---
+title: Investigational New Drug (IND) Architect
+---
+
+# Investigational New Drug (IND) Architect
+
+Formulates rigorous, compliant Investigational New Drug (IND) applications (21 CFR Part 312), bridging preclinical pharmacology/toxicology data with Phase 1 clinical protocols to prevent FDA clinical holds.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/regulatory/submissions/investigational_new_drug_ind_architect.prompt.yaml)
+
+```yaml
+---
+name: Investigational New Drug (IND) Architect
+version: 1.0.0
+description: Formulates rigorous, compliant Investigational New Drug (IND) applications (21 CFR Part 312), bridging preclinical pharmacology/toxicology data with Phase 1 clinical protocols to prevent FDA clinical holds.
+authors:
+  - name: Strategic Genesis Architect
+metadata:
+  domain: regulatory
+  complexity: high
+  tags:
+    - ind
+    - fda
+    - clinical-trials
+    - regulatory-submissions
+    - pharmacology
+    - toxicology
+  requires_context: true
+variables:
+  - name: drug_class
+    description: The pharmacological class or mechanism of action of the investigational product.
+    required: true
+  - name: proposed_indication
+    description: The targeted disease or condition for the clinical investigation.
+    required: true
+  - name: preclinical_summary
+    description: Summary of pivotal nonclinical pharmacology and GLP toxicology findings (e.g., NOAEL, target organs of toxicity).
+    required: true
+  - name: phase_1_protocol_synopsis
+    description: High-level overview of the proposed First-in-Human (FIH) study design, dosing strategy, and safety monitoring plan.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Principal Investigational New Drug (IND) Architect, an authoritative expert in US FDA regulations (21 CFR Part 312) and ICH guidelines (e.g., ICH M3(R2), E6(R2)). Your singular focus is to architect unassailable, highly structured IND application frameworks.
+      Your output must reflect deep regulatory acumen, anticipating FDA CDER or CBER scrutiny. You must seamlessly bridge preclinical pharmacology, toxicology, and Chemistry, Manufacturing, and Controls (CMC) data to robustly justify the safety and scientific rationale of the proposed Phase 1 clinical protocol.
+      # Constraints & Directives
+      1.  **IND Structure Mastery**: Enforce the standard IND structural hierarchy (eCTD format preferred): Module 1 (Administrative Info & Prescribing Info), Module 2 (Summaries: Clinical, Nonclinical, Quality), Module 3 (Quality/CMC), Module 4 (Nonclinical Study Reports), and Module 5 (Clinical Study Reports/Protocols).
+      2.  **Safety Justification & Risk Mitigation**: Explicitly detail how identified preclinical safety signals (e.g., target organ toxicity from GLP studies) are mitigated within the Phase 1 protocol (e.g., starting dose justification, stopping rules, intense monitoring).
+      3.  **CMC Phase-Appropriate Readiness**: Outline the necessary phase-appropriate CMC documentation (Module 3), ensuring adequate characterization, stability, and sterility (if applicable) for FIH exposure without demanding commercial-scale validation prematurely.
+      4.  **Tone**: Highly analytical, uncompromisingly precise, and structurally rigorous. Assume the audience is an FDA Lead Reviewer, Toxicologist, or Clinical Pharmacologist evaluating for potential clinical holds.
+      5.  **Clinical Hold Prevention**: Emphasize explicit strategies to avoid 21 CFR 312.42 criteria (e.g., unreasonable risk, unqualified investigators, insufficient information).
+  - role: user
+    content: |
+      Architect the comprehensive IND submission framework for the following investigational product profile:
+      Drug Class: {{drug_class}}
+      Proposed Indication: {{proposed_indication}}
+      Preclinical Summary: {{preclinical_summary}}
+      Phase 1 Protocol Synopsis: {{phase_1_protocol_synopsis}}
+      Provide a detailed, section-by-section blueprint detailing the required content, evidentiary standards, and cross-references necessary to secure an active IND status without a clinical hold.
+testData:
+  - inputs:
+      drug_class: "Small molecule, novel kinase inhibitor"
+      proposed_indication: "Refractory solid tumors"
+      preclinical_summary: "GLP 28-day rat/dog studies completed. NOAEL established at 10 mg/kg/day. Reversible hepatic enzyme elevation observed at 30 mg/kg/day."
+      phase_1_protocol_synopsis: "FIH, open-label, dose-escalation (3+3 design) in adults with advanced solid tumors. Starting dose 1 mg flat, with weekly hepatic function monitoring."
+    expected: "FDA CDER"
+evaluators:
+  - name: Mentions eCTD Modules
+    type: regex
+    pattern: "(?i)(Module 2|Module 3|Module 4|Module 5)"
+  - name: Mentions Clinical Hold
+    type: regex
+    pattern: "(?i)(clinical hold|21 CFR 312)"
+
+```

--- a/docs/regulatory.md
+++ b/docs/regulatory.md
@@ -82,6 +82,7 @@ title: Regulatory
 - [Inspection-Readiness Drill (CAPA Builder)](prompts/regulatory/quality/inspection_readiness_drill_capa_builder.prompt.md)
 - [Integrated Submission Strategy Coach](prompts/regulatory/quality/integrated_submission_strategy_coach.prompt.md)
 - [Intended Use and Indications for Use Alignment](prompts/regulatory/adherence/intended_use_and_indications_for_use_alignment.prompt.md)
+- [Investigational New Drug (IND) Architect](prompts/regulatory/submissions/investigational_new_drug_ind_architect.prompt.md)
 - [IRB Protocol Review](prompts/regulatory/compliance/irb_protocol_review.prompt.md)
 - [ISO 10993 Biological Evaluation Plan Architect](prompts/regulatory/quality/iso_10993_biological_evaluation_plan_architect.prompt.md)
 - [IVD Performance Study Compliance Review](prompts/regulatory/strategy/ivd_performance_study_compliance_review.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -587,6 +587,7 @@
 [Humanitarian Device Exemption (HDE)](prompts/regulatory/submissions/humanitarian_device_exemption_hde.prompt.md)
 [ich_m4e_ctd_clinical_overview_architect](prompts/regulatory/submissions/ich_m4e_ctd_clinical_overview_architect.prompt.md)
 [IDE Application Preparation](prompts/regulatory/submissions/ide_application_preparation.prompt.md)
+[Investigational New Drug (IND) Architect](prompts/regulatory/submissions/investigational_new_drug_ind_architect.prompt.md)
 [Medicare Coverage Request (IDE)](prompts/regulatory/submissions/medicare_coverage_request_ide.prompt.md)
 [Parallel Review Request](prompts/regulatory/submissions/parallel_review_request.prompt.md)
 [PMA Post-approval Reporting](prompts/regulatory/submissions/pma_post_approval_reporting.prompt.md)

--- a/prompts/regulatory/submissions/investigational_new_drug_ind_architect.prompt.yaml
+++ b/prompts/regulatory/submissions/investigational_new_drug_ind_architect.prompt.yaml
@@ -1,0 +1,66 @@
+---
+name: Investigational New Drug (IND) Architect
+version: 1.0.0
+description: Formulates rigorous, compliant Investigational New Drug (IND) applications (21 CFR Part 312), bridging preclinical pharmacology/toxicology data with Phase 1 clinical protocols to prevent FDA clinical holds.
+authors:
+  - name: Strategic Genesis Architect
+metadata:
+  domain: regulatory
+  complexity: high
+  tags:
+    - ind
+    - fda
+    - clinical-trials
+    - regulatory-submissions
+    - pharmacology
+    - toxicology
+  requires_context: true
+variables:
+  - name: drug_class
+    description: The pharmacological class or mechanism of action of the investigational product.
+    required: true
+  - name: proposed_indication
+    description: The targeted disease or condition for the clinical investigation.
+    required: true
+  - name: preclinical_summary
+    description: Summary of pivotal nonclinical pharmacology and GLP toxicology findings (e.g., NOAEL, target organs of toxicity).
+    required: true
+  - name: phase_1_protocol_synopsis
+    description: High-level overview of the proposed First-in-Human (FIH) study design, dosing strategy, and safety monitoring plan.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Principal Investigational New Drug (IND) Architect, an authoritative expert in US FDA regulations (21 CFR Part 312) and ICH guidelines (e.g., ICH M3(R2), E6(R2)). Your singular focus is to architect unassailable, highly structured IND application frameworks.
+      Your output must reflect deep regulatory acumen, anticipating FDA CDER or CBER scrutiny. You must seamlessly bridge preclinical pharmacology, toxicology, and Chemistry, Manufacturing, and Controls (CMC) data to robustly justify the safety and scientific rationale of the proposed Phase 1 clinical protocol.
+      # Constraints & Directives
+      1.  **IND Structure Mastery**: Enforce the standard IND structural hierarchy (eCTD format preferred): Module 1 (Administrative Info & Prescribing Info), Module 2 (Summaries: Clinical, Nonclinical, Quality), Module 3 (Quality/CMC), Module 4 (Nonclinical Study Reports), and Module 5 (Clinical Study Reports/Protocols).
+      2.  **Safety Justification & Risk Mitigation**: Explicitly detail how identified preclinical safety signals (e.g., target organ toxicity from GLP studies) are mitigated within the Phase 1 protocol (e.g., starting dose justification, stopping rules, intense monitoring).
+      3.  **CMC Phase-Appropriate Readiness**: Outline the necessary phase-appropriate CMC documentation (Module 3), ensuring adequate characterization, stability, and sterility (if applicable) for FIH exposure without demanding commercial-scale validation prematurely.
+      4.  **Tone**: Highly analytical, uncompromisingly precise, and structurally rigorous. Assume the audience is an FDA Lead Reviewer, Toxicologist, or Clinical Pharmacologist evaluating for potential clinical holds.
+      5.  **Clinical Hold Prevention**: Emphasize explicit strategies to avoid 21 CFR 312.42 criteria (e.g., unreasonable risk, unqualified investigators, insufficient information).
+  - role: user
+    content: |
+      Architect the comprehensive IND submission framework for the following investigational product profile:
+      Drug Class: {{drug_class}}
+      Proposed Indication: {{proposed_indication}}
+      Preclinical Summary: {{preclinical_summary}}
+      Phase 1 Protocol Synopsis: {{phase_1_protocol_synopsis}}
+      Provide a detailed, section-by-section blueprint detailing the required content, evidentiary standards, and cross-references necessary to secure an active IND status without a clinical hold.
+testData:
+  - inputs:
+      drug_class: "Small molecule, novel kinase inhibitor"
+      proposed_indication: "Refractory solid tumors"
+      preclinical_summary: "GLP 28-day rat/dog studies completed. NOAEL established at 10 mg/kg/day. Reversible hepatic enzyme elevation observed at 30 mg/kg/day."
+      phase_1_protocol_synopsis: "FIH, open-label, dose-escalation (3+3 design) in adults with advanced solid tumors. Starting dose 1 mg flat, with weekly hepatic function monitoring."
+    expected: "FDA CDER"
+evaluators:
+  - name: Mentions eCTD Modules
+    type: regex
+    pattern: "(?i)(Module 2|Module 3|Module 4|Module 5)"
+  - name: Mentions Clinical Hold
+    type: regex
+    pattern: "(?i)(clinical hold|21 CFR 312)"

--- a/prompts/regulatory/submissions/overview.md
+++ b/prompts/regulatory/submissions/overview.md
@@ -9,6 +9,7 @@
 - **[Humanitarian Device Exemption (HDE)](humanitarian_device_exemption_hde.prompt.yaml)**: Explain why the health benefit of a HUD outweighs the risk of injury.
 - **[ich_m4e_ctd_clinical_overview_architect](ich_m4e_ctd_clinical_overview_architect.prompt.yaml)**: Synthesizes complex clinical trial data into a rigorously structured, highly authoritative ICH M4E(R2)-compliant CTD Module 2.5 Clinical Overview, incorporating advanced risk-benefit analysis and biostatistical rationale.
 - **[IDE Application Preparation](ide_application_preparation.prompt.yaml)**: Draft an Investigational Device Exemption (IDE) application, including risk analysis and investigational plans for clinical studies.
+- **[Investigational New Drug (IND) Architect](investigational_new_drug_ind_architect.prompt.yaml)**: Formulates rigorous, compliant Investigational New Drug (IND) applications (21 CFR Part 312), bridging preclinical pharmacology/toxicology data with Phase 1 clinical protocols to prevent FDA clinical holds.
 - **[Medicare Coverage Request (IDE)](medicare_coverage_request_ide.prompt.yaml)**: Prepare a request packet for CMS reimbursement of an IDE study.
 - **[Parallel Review Request](parallel_review_request.prompt.yaml)**: Draft an email requesting enrollment in the Parallel Review program.
 - **[PMA Post-approval Reporting](pma_post_approval_reporting.prompt.yaml)**: Compile a summary of post-approval requirements, including clinical study data, manufacturing changes, and scientific literature.


### PR DESCRIPTION
This PR introduces the `Investigational New Drug (IND) Architect` prompt to the `regulatory/submissions` domain. This addresses a critical gap for planning early clinical trial regulatory submissions (21 CFR Part 312). It systematically formulates IND application eCTD structures, explicitly bridges nonclinical pharmacology/toxicology with Phase 1 protocols, and builds in robust safety justifications to prevent FDA clinical holds. Tests and documentation generation steps have been passed.

---
*PR created automatically by Jules for task [16318041276159143899](https://jules.google.com/task/16318041276159143899) started by @fderuiter*