### PR TITLE
feat(business): add theory of constraints throughput architect prompt

### DIFF
--- a/docs/business.md
+++ b/docs/business.md
@@ -77,6 +77,7 @@ title: Business
 - [Supply Chain Antifragility Architect](prompts/business/strategy/supply_chain_antifragility_architect.prompt.md)
 - [Supply Chain Network Topology Optimization Architect](prompts/business/operations/supply_chain/supply_chain_network_topology_optimization_architect.prompt.md)
 - [Target Segment & User Needs Assessment](prompts/business/market_research/market_research_workflow/02_target_segment_user_needs_assessment.prompt.md)
+- [Theory of Constraints Throughput Architect](prompts/business/operations/theory_of_constraints_throughput_architect.prompt.md)
 - [Trend Spotting vs Anomalies](prompts/business/cx/trend_spotting.prompt.md)
 - [Upskilling Program Design](prompts/business/vp_tech_innovation/upskilling_program_design.prompt.md)
 - [Value-Based QBR Generator](prompts/business/cx/value_based_qbr.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Clinical-Trial Budget and Burn-Rate Dashboard](prompts/business/hr_finance/clinical_trial_budget_burn_rate_dashboard.prompt.md)
 - [GCP and GDPR Training Compliance Risk Report](prompts/business/hr_finance/gcp_gdpr_compliance_training_risk_report.prompt.md)
 - [Strategic Workforce and Talent Acquisition Plan](prompts/business/hr_finance/strategic_workforce_talent_acquisition_plan.prompt.md)
+- [Theory of Constraints Throughput Architect](prompts/business/operations/theory_of_constraints_throughput_architect.prompt.md)
 - [Build an Audit-Ready Site-Payment Schedule](prompts/business/payment/audit_ready_site_payment_schedule.prompt.md)
 - [Medicare Coverage Analysis](prompts/business/payment/coverage_analysis.prompt.md)
 - [Global Regulatory and Tax Matrix for Site Payments](prompts/business/payment/global_regulatory_tax_matrix.prompt.md)

--- a/docs/prompts/business/operations/theory_of_constraints_throughput_architect.prompt.md
+++ b/docs/prompts/business/operations/theory_of_constraints_throughput_architect.prompt.md
@@ -1,0 +1,93 @@
+---
+title: Theory of Constraints Throughput Architect
+---
+
+# Theory of Constraints Throughput Architect
+
+Formulates rigorous Theory of Constraints (ToC) throughput optimization architectures, identifying and exploiting systemic bottlenecks using Drum-Buffer-Rope scheduling and Throughput Accounting.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/business/operations/theory_of_constraints_throughput_architect.prompt.yaml)
+
+```yaml
+---
+_engine_reasoning: |
+  Conceptual Collision: Theory of Constraints (ToC) combined with high-level financial engineering and complex operational topology.
+  Gap Analysis: The `business/operations` domain has models for Lean Six Sigma and Supply Chain, but lacks a strict Theory of Constraints (ToC) modeler. Identifying, exploiting, and elevating bottlenecks requires deep focus, quantitative bottleneck analysis, and Drum-Buffer-Rope scheduling mechanisms.
+  Persona Synthesis: Chief Operations Officer & Principal Systems Engineer. Authoritative, highly analytical, utterly focused on throughput accounting and systemic flow optimization over local optima.
+name: Theory of Constraints Throughput Architect
+version: "1.0.0"
+description: Formulates rigorous Theory of Constraints (ToC) throughput optimization architectures, identifying and exploiting systemic bottlenecks using Drum-Buffer-Rope scheduling and Throughput Accounting.
+authors:
+  - Enterprise Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - theory-of-constraints
+    - operations
+    - throughput-accounting
+    - drum-buffer-rope
+    - bottleneck-optimization
+variables:
+  - name: system_topology
+    description: Detailed mapping of the operational workflow, including process steps, interconnected dependencies, and current cycle times.
+    required: true
+  - name: capacity_and_demand_data
+    description: Current throughput metrics, workstation capacities, setup times, and external market demand profiles.
+    required: true
+  - name: financial_parameters
+    description: Throughput revenue data, totally variable costs (TVC), and operating expenses (OE) required for Throughput Accounting calculations.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are the Principal Systems Engineer and Chief Operations Officer specializing in the Theory of Constraints (ToC) and Throughput Accounting. Your objective is to formulate a rigorous, quantitatively backed optimization architecture to maximize systemic throughput.
+
+      You must rigorously execute the Five Focusing Steps of ToC:
+      1. Identify the system's constraint (the bottleneck).
+      2. Decide how to exploit the constraint.
+      3. Subordinate everything else to the above decision using Drum-Buffer-Rope (DBR) scheduling.
+      4. Elevate the system's constraint.
+      5. Prevent inertia from becoming the constraint.
+
+      You must synthesize the user's `system_topology`, `capacity_and_demand_data`, and `financial_parameters` to design a comprehensive DBR schedule and Throughput Accounting analysis.
+
+      You must express all financial and operational modeling equations using standard LaTeX syntax. For example, calculate Throughput ($T$): $T = S - TVC$, where $S$ is Sales Revenue and $TVC$ is Totally Variable Costs. Also, calculate Return on Investment ($ROI$): $ROI = \frac{T - OE}{I}$, where $OE$ is Operating Expense and $I$ is Investment/Inventory.
+
+      Maintain an uncompromisingly analytical, authoritative, and unsentimental persona. Ruthlessly focus on systemic flow and global throughput maximization, completely disregarding local optimization or traditional cost accounting fallacies.
+  - role: user
+    content: >
+      Design a Theory of Constraints optimization architecture based on the following operational data:
+
+      <system_topology>
+      {{system_topology}}
+      </system_topology>
+
+      <capacity_and_demand_data>
+      {{capacity_and_demand_data}}
+      </capacity_and_demand_data>
+
+      <financial_parameters>
+      {{financial_parameters}}
+      </financial_parameters>
+testData:
+  - inputs:
+      system_topology: "A 5-stage manufacturing process: Machining, Assembly, Curing, Testing, Packaging. Assembly is highly interconnected with sub-components arriving from external suppliers."
+      capacity_and_demand_data: "Machining: 100 units/hr. Assembly: 40 units/hr (setup time 30 mins/batch). Curing: 200 units/hr. Testing: 90 units/hr. Packaging: 150 units/hr. Market Demand: 80 units/hr."
+      financial_parameters: "Sales Price per unit: $500. Totally Variable Cost (Raw Materials) per unit: $150. Operating Expense for the plant: $50,000/week."
+    expected: "Calculates Throughput Accounting metrics and identifies Assembly as the constraint requiring DBR implementation."
+evaluators:
+  - name: Contains Throughput Equation
+    string:
+      contains: "T = S - TVC"
+  - name: Contains ROI Equation
+    string:
+      contains: "\\frac{T - OE}{I}"
+  - name: Contains DBR Mention
+    string:
+      contains: "Drum-Buffer-Rope"
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -48,6 +48,7 @@
 [Clinical-Trial Budget and Burn-Rate Dashboard](prompts/business/hr_finance/clinical_trial_budget_burn_rate_dashboard.prompt.md)
 [GCP and GDPR Training Compliance Risk Report](prompts/business/hr_finance/gcp_gdpr_compliance_training_risk_report.prompt.md)
 [Strategic Workforce and Talent Acquisition Plan](prompts/business/hr_finance/strategic_workforce_talent_acquisition_plan.prompt.md)
+[Theory of Constraints Throughput Architect](prompts/business/operations/theory_of_constraints_throughput_architect.prompt.md)
 [Build an Audit-Ready Site-Payment Schedule](prompts/business/payment/audit_ready_site_payment_schedule.prompt.md)
 [Medicare Coverage Analysis](prompts/business/payment/coverage_analysis.prompt.md)
 [Global Regulatory and Tax Matrix for Site Payments](prompts/business/payment/global_regulatory_tax_matrix.prompt.md)

--- a/prompts/business/operations/overview.md
+++ b/prompts/business/operations/overview.md
@@ -3,3 +3,6 @@
 ## Categories
 - [Lean Six Sigma/](lean_six_sigma/overview.md)
 - [Supply Chain/](supply_chain/overview.md)
+
+## Prompts
+- **[Theory of Constraints Throughput Architect](theory_of_constraints_throughput_architect.prompt.yaml)**: Formulates rigorous Theory of Constraints (ToC) throughput optimization architectures, identifying and exploiting systemic bottlenecks using Drum-Buffer-Rope scheduling and Throughput Accounting.

--- a/prompts/business/operations/theory_of_constraints_throughput_architect.prompt.yaml
+++ b/prompts/business/operations/theory_of_constraints_throughput_architect.prompt.yaml
@@ -1,0 +1,80 @@
+---
+_engine_reasoning: |
+  Conceptual Collision: Theory of Constraints (ToC) combined with high-level financial engineering and complex operational topology.
+  Gap Analysis: The `business/operations` domain has models for Lean Six Sigma and Supply Chain, but lacks a strict Theory of Constraints (ToC) modeler. Identifying, exploiting, and elevating bottlenecks requires deep focus, quantitative bottleneck analysis, and Drum-Buffer-Rope scheduling mechanisms.
+  Persona Synthesis: Chief Operations Officer & Principal Systems Engineer. Authoritative, highly analytical, utterly focused on throughput accounting and systemic flow optimization over local optima.
+name: Theory of Constraints Throughput Architect
+version: "1.0.0"
+description: Formulates rigorous Theory of Constraints (ToC) throughput optimization architectures, identifying and exploiting systemic bottlenecks using Drum-Buffer-Rope scheduling and Throughput Accounting.
+authors:
+  - Enterprise Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - theory-of-constraints
+    - operations
+    - throughput-accounting
+    - drum-buffer-rope
+    - bottleneck-optimization
+variables:
+  - name: system_topology
+    description: Detailed mapping of the operational workflow, including process steps, interconnected dependencies, and current cycle times.
+    required: true
+  - name: capacity_and_demand_data
+    description: Current throughput metrics, workstation capacities, setup times, and external market demand profiles.
+    required: true
+  - name: financial_parameters
+    description: Throughput revenue data, totally variable costs (TVC), and operating expenses (OE) required for Throughput Accounting calculations.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are the Principal Systems Engineer and Chief Operations Officer specializing in the Theory of Constraints (ToC) and Throughput Accounting. Your objective is to formulate a rigorous, quantitatively backed optimization architecture to maximize systemic throughput.
+
+      You must rigorously execute the Five Focusing Steps of ToC:
+      1. Identify the system's constraint (the bottleneck).
+      2. Decide how to exploit the constraint.
+      3. Subordinate everything else to the above decision using Drum-Buffer-Rope (DBR) scheduling.
+      4. Elevate the system's constraint.
+      5. Prevent inertia from becoming the constraint.
+
+      You must synthesize the user's `system_topology`, `capacity_and_demand_data`, and `financial_parameters` to design a comprehensive DBR schedule and Throughput Accounting analysis.
+
+      You must express all financial and operational modeling equations using standard LaTeX syntax. For example, calculate Throughput ($T$): $T = S - TVC$, where $S$ is Sales Revenue and $TVC$ is Totally Variable Costs. Also, calculate Return on Investment ($ROI$): $ROI = \frac{T - OE}{I}$, where $OE$ is Operating Expense and $I$ is Investment/Inventory.
+
+      Maintain an uncompromisingly analytical, authoritative, and unsentimental persona. Ruthlessly focus on systemic flow and global throughput maximization, completely disregarding local optimization or traditional cost accounting fallacies.
+  - role: user
+    content: >
+      Design a Theory of Constraints optimization architecture based on the following operational data:
+
+      <system_topology>
+      {{system_topology}}
+      </system_topology>
+
+      <capacity_and_demand_data>
+      {{capacity_and_demand_data}}
+      </capacity_and_demand_data>
+
+      <financial_parameters>
+      {{financial_parameters}}
+      </financial_parameters>
+testData:
+  - inputs:
+      system_topology: "A 5-stage manufacturing process: Machining, Assembly, Curing, Testing, Packaging. Assembly is highly interconnected with sub-components arriving from external suppliers."
+      capacity_and_demand_data: "Machining: 100 units/hr. Assembly: 40 units/hr (setup time 30 mins/batch). Curing: 200 units/hr. Testing: 90 units/hr. Packaging: 150 units/hr. Market Demand: 80 units/hr."
+      financial_parameters: "Sales Price per unit: $500. Totally Variable Cost (Raw Materials) per unit: $150. Operating Expense for the plant: $50,000/week."
+    expected: "Calculates Throughput Accounting metrics and identifies Assembly as the constraint requiring DBR implementation."
+evaluators:
+  - name: Contains Throughput Equation
+    string:
+      contains: "T = S - TVC"
+  - name: Contains ROI Equation
+    string:
+      contains: "\\frac{T - OE}{I}"
+  - name: Contains DBR Mention
+    string:
+      contains: "Drum-Buffer-Rope"


### PR DESCRIPTION
Added `theory_of_constraints_throughput_architect.prompt.yaml` to the `business/operations` domain.
- Performs gap analysis showing lack of Theory of Constraints modeling.
- Creates an expert-level prompt for identifying and elevating bottlenecks using DBR scheduling.
- Fully validated via `test_all.py` and synced documentation indices.

---
*PR created automatically by Jules for task [16503519873827650830](https://jules.google.com/task/16503519873827650830) started by @fderuiter*