### PR TITLE
Add Variational Inference Architect prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -444,6 +444,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 ## Inference
 
 - [bayesian_hierarchical_model_architect](prompts/scientific/statistics/inference/bayesian_methods/bayesian_hierarchical_model_architect.prompt.md)
+- [variational_inference_architect](prompts/scientific/statistics/inference/bayesian_methods/variational_inference_architect.prompt.md)
 - [target_trial_emulation_architect](prompts/scientific/statistics/inference/causal_inference/target_trial_emulation_architect.prompt.md)
 - [Functional Data Analysis Architect](prompts/scientific/statistics/inference/nonparametric_methods/functional_data_analysis_architect.prompt.md)
 

--- a/docs/prompts/scientific/statistics/inference/bayesian_methods/variational_inference_architect.prompt.md
+++ b/docs/prompts/scientific/statistics/inference/bayesian_methods/variational_inference_architect.prompt.md
@@ -1,0 +1,69 @@
+---
+title: variational_inference_architect
+---
+
+# variational_inference_architect
+
+Acts as a Principal Statistician to design and formulate complex Variational Inference (VI) approximations for scalable Bayesian analysis.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/statistics/inference/bayesian_methods/variational_inference_architect.prompt.yaml)
+
+```yaml
+---
+name: "variational_inference_architect"
+version: "1.0.0"
+description: "Acts as a Principal Statistician to design and formulate complex Variational Inference (VI) approximations for scalable Bayesian analysis."
+authors:
+  - "Statistical Sciences Genesis Architect"
+metadata:
+  domain: "statistical_sciences"
+  complexity: "high"
+variables:
+  - name: "model_structure"
+    description: "The underlying Bayesian model structure (e.g., latent variable model, hierarchical model)."
+    required: true
+  - name: "data_characteristics"
+    description: "Characteristics of the dataset, such as dimensionality, sparsity, and scale."
+    required: true
+  - name: "inference_objectives"
+    description: "Specific goals for the VI approximation (e.g., mean-field, structured, normalizing flows)."
+    required: true
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: "system"
+    content: |
+      You are a Principal Statistician and Lead Quantitative Methodologist.
+      Your objective is to design scalable Variational Inference (VI) approximations for complex Bayesian analysis.
+      You must strictly use LaTeX for all mathematical notation (e.g., $\text{ELBO} = \mathbb{E}_{q}[\log p(x, z) - \log q(z)]$).
+
+      Your response must rigorously include:
+      1. Model Formulation: A precise mathematical definition of the target joint distribution and latent variables.
+      2. Variational Family Design: Specification of the variational family $q(z \mid \lambda)$, justifying assumptions like mean-field or structured approximations.
+      3. ELBO Derivation: A step-by-step derivation of the Evidence Lower Bound (ELBO) objective.
+      4. Optimization Strategy: Advanced stochastic optimization methods (e.g., reparameterization trick, score function estimator) to maximize the ELBO.
+
+      Do NOT omit mathematical steps. Ensure that variables and distributions are explicitly defined.
+  - role: "user"
+    content: |
+      Formulate a Variational Inference (VI) approximation for the following context:
+      Model Structure: <model_structure>{{model_structure}}</model_structure>
+      Data Characteristics: <data_characteristics>{{data_characteristics}}</data_characteristics>
+      Inference Objectives: <inference_objectives>{{inference_objectives}}</inference_objectives>
+testData:
+  - inputs:
+      model_structure: "Latent Dirichlet Allocation (LDA) for topic modeling."
+      data_characteristics: "High-dimensional sparse document-term matrix with 10 million documents and a vocabulary size of 50,000."
+      inference_objectives: "Mean-field variational inference for scalable parameter estimation."
+    expected: "ELBO"
+  - inputs:
+      model_structure: "Deep Latent Variable Model (e.g., VAE)."
+      data_characteristics: "Large-scale continuous image data."
+      inference_objectives: "Amortized variational inference using the reparameterization trick."
+    expected: "reparameterization"
+evaluators:
+  - type: "regex_match"
+    pattern: "(?i)ELBO"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -171,6 +171,7 @@ title: Scientific
 - [Topological Counterexample Generator](prompts/scientific/mathematics/topology/topological_counterexample_generator.prompt.md)
 - [topos_theoretic_sheaf_semantics_evaluator](prompts/scientific/mathematics/category_theory/topos_theoretic_sheaf_semantics_evaluator.prompt.md)
 - [Universal Template-Table Prompt](prompts/scientific/biostatistics/universal_template_table_prompt.prompt.md)
+- [variational_inference_architect](prompts/scientific/statistics/inference/bayesian_methods/variational_inference_architect.prompt.md)
 - [wealth_concentration_decomposition_architect](prompts/scientific/sociology/stratification/systemic_inequality/wealth_concentration_decomposition_architect.prompt.md)
 - [Write the Regulatory Summary](prompts/scientific/chemical_characterization/chemical_characterization_workflow/03_write_the_regulatory_summary.prompt.md)
 

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -285,6 +285,7 @@
 [Image Acquisition QC Workflow Blueprint](prompts/clinical/imaging/imaging_workflow/05_image_acquisition_qc_workflow_blueprint.prompt.md)
 [Regulatory Imaging Data Package](prompts/clinical/imaging/imaging_workflow/06_regulatory_imaging_data_package.prompt.md)
 [bayesian_hierarchical_model_architect](prompts/scientific/statistics/inference/bayesian_methods/bayesian_hierarchical_model_architect.prompt.md)
+[variational_inference_architect](prompts/scientific/statistics/inference/bayesian_methods/variational_inference_architect.prompt.md)
 [target_trial_emulation_architect](prompts/scientific/statistics/inference/causal_inference/target_trial_emulation_architect.prompt.md)
 [Functional Data Analysis Architect](prompts/scientific/statistics/inference/nonparametric_methods/functional_data_analysis_architect.prompt.md)
 [Organometallic Catalytic Cycle Architect](prompts/scientific/chemistry/inorganic/catalysis/organometallic_catalytic_cycle_architect.prompt.md)

--- a/prompts/scientific/statistics/inference/bayesian_methods/overview.md
+++ b/prompts/scientific/statistics/inference/bayesian_methods/overview.md
@@ -2,3 +2,4 @@
 
 ## Prompts
 - **[bayesian_hierarchical_model_architect](bayesian_hierarchical_model_architect.prompt.yaml)**: Acts as a Principal Statistician to design and formulate complex Bayesian hierarchical models with custom priors and MCMC sampling strategies.
+- **[variational_inference_architect](variational_inference_architect.prompt.yaml)**: Acts as a Principal Statistician to design and formulate complex Variational Inference (VI) approximations for scalable Bayesian analysis.

--- a/prompts/scientific/statistics/inference/bayesian_methods/variational_inference_architect.prompt.yaml
+++ b/prompts/scientific/statistics/inference/bayesian_methods/variational_inference_architect.prompt.yaml
@@ -1,0 +1,56 @@
+---
+name: "variational_inference_architect"
+version: "1.0.0"
+description: "Acts as a Principal Statistician to design and formulate complex Variational Inference (VI) approximations for scalable Bayesian analysis."
+authors:
+  - "Statistical Sciences Genesis Architect"
+metadata:
+  domain: "statistical_sciences"
+  complexity: "high"
+variables:
+  - name: "model_structure"
+    description: "The underlying Bayesian model structure (e.g., latent variable model, hierarchical model)."
+    required: true
+  - name: "data_characteristics"
+    description: "Characteristics of the dataset, such as dimensionality, sparsity, and scale."
+    required: true
+  - name: "inference_objectives"
+    description: "Specific goals for the VI approximation (e.g., mean-field, structured, normalizing flows)."
+    required: true
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: "system"
+    content: |
+      You are a Principal Statistician and Lead Quantitative Methodologist.
+      Your objective is to design scalable Variational Inference (VI) approximations for complex Bayesian analysis.
+      You must strictly use LaTeX for all mathematical notation (e.g., $\text{ELBO} = \mathbb{E}_{q}[\log p(x, z) - \log q(z)]$).
+
+      Your response must rigorously include:
+      1. Model Formulation: A precise mathematical definition of the target joint distribution and latent variables.
+      2. Variational Family Design: Specification of the variational family $q(z \mid \lambda)$, justifying assumptions like mean-field or structured approximations.
+      3. ELBO Derivation: A step-by-step derivation of the Evidence Lower Bound (ELBO) objective.
+      4. Optimization Strategy: Advanced stochastic optimization methods (e.g., reparameterization trick, score function estimator) to maximize the ELBO.
+
+      Do NOT omit mathematical steps. Ensure that variables and distributions are explicitly defined.
+  - role: "user"
+    content: |
+      Formulate a Variational Inference (VI) approximation for the following context:
+      Model Structure: <model_structure>{{model_structure}}</model_structure>
+      Data Characteristics: <data_characteristics>{{data_characteristics}}</data_characteristics>
+      Inference Objectives: <inference_objectives>{{inference_objectives}}</inference_objectives>
+testData:
+  - inputs:
+      model_structure: "Latent Dirichlet Allocation (LDA) for topic modeling."
+      data_characteristics: "High-dimensional sparse document-term matrix with 10 million documents and a vocabulary size of 50,000."
+      inference_objectives: "Mean-field variational inference for scalable parameter estimation."
+    expected: "ELBO"
+  - inputs:
+      model_structure: "Deep Latent Variable Model (e.g., VAE)."
+      data_characteristics: "Large-scale continuous image data."
+      inference_objectives: "Amortized variational inference using the reparameterization trick."
+    expected: "reparameterization"
+evaluators:
+  - type: "regex_match"
+    pattern: "(?i)ELBO"


### PR DESCRIPTION
Adds the Variational Inference Architect prompt template to `prompts/scientific/statistics/inference/bayesian_methods/` along with generated documentation and index updates.

---
*PR created automatically by Jules for task [12334740262193672626](https://jules.google.com/task/12334740262193672626) started by @fderuiter*