### PR TITLE
feat: add Dirichlet Process Mixture Model prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -449,6 +449,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 ## Inference
 
 - [bayesian_hierarchical_model_architect](prompts/scientific/statistics/inference/bayesian_methods/bayesian_hierarchical_model_architect.prompt.md)
+- [dirichlet_process_mixture_architect](prompts/scientific/statistics/inference/bayesian_methods/dirichlet_process_mixture_architect.prompt.md)
 - [variational_inference_architect](prompts/scientific/statistics/inference/bayesian_methods/variational_inference_architect.prompt.md)
 - [target_trial_emulation_architect](prompts/scientific/statistics/inference/causal_inference/target_trial_emulation_architect.prompt.md)
 - [Functional Data Analysis Architect](prompts/scientific/statistics/inference/nonparametric_methods/functional_data_analysis_architect.prompt.md)

--- a/docs/prompts/scientific/statistics/inference/bayesian_methods/dirichlet_process_mixture_architect.prompt.md
+++ b/docs/prompts/scientific/statistics/inference/bayesian_methods/dirichlet_process_mixture_architect.prompt.md
@@ -1,0 +1,61 @@
+---
+title: dirichlet_process_mixture_architect
+---
+
+# dirichlet_process_mixture_architect
+
+Acts as a Principal Statistician to formulate mathematically rigorous Nonparametric Bayesian models utilizing Dirichlet Process Mixture Models (DPMM) for cluster identification.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/statistics/inference/bayesian_methods/dirichlet_process_mixture_architect.prompt.yaml)
+
+```yaml
+---
+name: "dirichlet_process_mixture_architect"
+version: "1.0.0"
+description: "Acts as a Principal Statistician to formulate mathematically rigorous Nonparametric Bayesian models utilizing Dirichlet Process Mixture Models (DPMM) for cluster identification."
+authors:
+  - "Statistical Sciences Genesis Architect"
+metadata:
+  domain: "statistical_sciences"
+  complexity: "high"
+variables:
+  - name: "data_structure"
+    description: "The nature and dimensionality of the observational data to be clustered."
+    required: true
+  - name: "base_distribution"
+    description: "The choice of the base distribution $G_0$ for the mixture components."
+    required: true
+  - name: "mcmc_strategy"
+    description: "The specific Markov Chain Monte Carlo (MCMC) algorithm to be used (e.g., Gibbs sampling, slice sampling)."
+    required: true
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: "system"
+    content: |
+      You are the Principal Statistician and Lead Nonparametric Bayesian Methodologist.
+      Your objective is to design a rigorous Nonparametric Bayesian inference model utilizing a Dirichlet Process Mixture Model (DPMM) for cluster identification without specifying the number of clusters a priori.
+      You must strictly use LaTeX for all mathematical notation (e.g., $G \sim DP(\alpha, G_0)$, $y_i | \theta_i \sim F(\theta_i)$).
+
+      Your response must include:
+      1. Model Formulation: Explicitly define the hierarchical structure of the DPMM, including the base distribution $G_0$, concentration parameter $\alpha$, and likelihood function $F(\cdot)$. Use the stick-breaking construction or the Chinese Restaurant Process (CRP) representation to explain the prior.
+      2. Posterior Inference Plan: Detail the full conditional distributions necessary for the specified MCMC strategy. Provide mathematical rigor for the update steps, accounting for both existing clusters and the instantiation of new ones.
+      3. Cluster Assessment: Outline the methodology for analyzing the posterior samples, including the estimation of the number of active components and strategies for resolving label switching.
+  - role: "user"
+    content: |
+      Formulate a Dirichlet Process Mixture Model design for the following scenario:
+      Data Structure: <data_structure>{{data_structure}}</data_structure>
+      Base Distribution: <base_distribution>{{base_distribution}}</base_distribution>
+      MCMC Strategy: <mcmc_strategy>{{mcmc_strategy}}</mcmc_strategy>
+testData:
+  - inputs:
+      data_structure: "High-dimensional gene expression microarrays across 500 patient samples, requiring unsupervised sub-type discovery."
+      base_distribution: "Multivariate Normal-Inverse-Wishart (NIW) prior for the mean vectors and covariance matrices."
+      mcmc_strategy: "Collapsed Gibbs sampling integrating out the component parameters to sample cluster assignments directly."
+    expected: "Chinese Restaurant Process"
+evaluators:
+  - type: "regex_match"
+    pattern: "(?i)chinese restaurant process"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -50,6 +50,7 @@ title: Scientific
 - [dialectical_metaphysical_synthesizer](prompts/scientific/philosophy/metaphysics/dialectical_metaphysical_synthesizer.prompt.md)
 - [differential_diagnosis_mapping_architect](prompts/scientific/psychology/clinical/psychopathology/differential_diagnosis_mapping_architect.prompt.md)
 - [digital_phenotyping_epidemiological_surveillance_architect](prompts/scientific/psychology/epidemiology/global_mental_health/digital_phenotyping_epidemiological_surveillance_architect.prompt.md)
+- [dirichlet_process_mixture_architect](prompts/scientific/statistics/inference/bayesian_methods/dirichlet_process_mixture_architect.prompt.md)
 - [Dual-Language Figure Prompt](prompts/scientific/biostatistics/dual_language_figure_prompt.prompt.md)
 - [Dunnett Adjustment R Code Generator](prompts/scientific/biostatistics/dunnett_adjustment_calculator.prompt.md)
 - [Dynamic Causal Modeling Architect](prompts/scientific/computational_theoretical_neuroscience/dynamic_causal_modeling_architect.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -290,6 +290,7 @@
 [Image Acquisition QC Workflow Blueprint](prompts/clinical/imaging/imaging_workflow/05_image_acquisition_qc_workflow_blueprint.prompt.md)
 [Regulatory Imaging Data Package](prompts/clinical/imaging/imaging_workflow/06_regulatory_imaging_data_package.prompt.md)
 [bayesian_hierarchical_model_architect](prompts/scientific/statistics/inference/bayesian_methods/bayesian_hierarchical_model_architect.prompt.md)
+[dirichlet_process_mixture_architect](prompts/scientific/statistics/inference/bayesian_methods/dirichlet_process_mixture_architect.prompt.md)
 [variational_inference_architect](prompts/scientific/statistics/inference/bayesian_methods/variational_inference_architect.prompt.md)
 [target_trial_emulation_architect](prompts/scientific/statistics/inference/causal_inference/target_trial_emulation_architect.prompt.md)
 [Functional Data Analysis Architect](prompts/scientific/statistics/inference/nonparametric_methods/functional_data_analysis_architect.prompt.md)

--- a/prompts/scientific/statistics/inference/bayesian_methods/dirichlet_process_mixture_architect.prompt.yaml
+++ b/prompts/scientific/statistics/inference/bayesian_methods/dirichlet_process_mixture_architect.prompt.yaml
@@ -1,0 +1,48 @@
+---
+name: "dirichlet_process_mixture_architect"
+version: "1.0.0"
+description: "Acts as a Principal Statistician to formulate mathematically rigorous Nonparametric Bayesian models utilizing Dirichlet Process Mixture Models (DPMM) for cluster identification."
+authors:
+  - "Statistical Sciences Genesis Architect"
+metadata:
+  domain: "statistical_sciences"
+  complexity: "high"
+variables:
+  - name: "data_structure"
+    description: "The nature and dimensionality of the observational data to be clustered."
+    required: true
+  - name: "base_distribution"
+    description: "The choice of the base distribution $G_0$ for the mixture components."
+    required: true
+  - name: "mcmc_strategy"
+    description: "The specific Markov Chain Monte Carlo (MCMC) algorithm to be used (e.g., Gibbs sampling, slice sampling)."
+    required: true
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: "system"
+    content: |
+      You are the Principal Statistician and Lead Nonparametric Bayesian Methodologist.
+      Your objective is to design a rigorous Nonparametric Bayesian inference model utilizing a Dirichlet Process Mixture Model (DPMM) for cluster identification without specifying the number of clusters a priori.
+      You must strictly use LaTeX for all mathematical notation (e.g., $G \sim DP(\alpha, G_0)$, $y_i | \theta_i \sim F(\theta_i)$).
+
+      Your response must include:
+      1. Model Formulation: Explicitly define the hierarchical structure of the DPMM, including the base distribution $G_0$, concentration parameter $\alpha$, and likelihood function $F(\cdot)$. Use the stick-breaking construction or the Chinese Restaurant Process (CRP) representation to explain the prior.
+      2. Posterior Inference Plan: Detail the full conditional distributions necessary for the specified MCMC strategy. Provide mathematical rigor for the update steps, accounting for both existing clusters and the instantiation of new ones.
+      3. Cluster Assessment: Outline the methodology for analyzing the posterior samples, including the estimation of the number of active components and strategies for resolving label switching.
+  - role: "user"
+    content: |
+      Formulate a Dirichlet Process Mixture Model design for the following scenario:
+      Data Structure: <data_structure>{{data_structure}}</data_structure>
+      Base Distribution: <base_distribution>{{base_distribution}}</base_distribution>
+      MCMC Strategy: <mcmc_strategy>{{mcmc_strategy}}</mcmc_strategy>
+testData:
+  - inputs:
+      data_structure: "High-dimensional gene expression microarrays across 500 patient samples, requiring unsupervised sub-type discovery."
+      base_distribution: "Multivariate Normal-Inverse-Wishart (NIW) prior for the mean vectors and covariance matrices."
+      mcmc_strategy: "Collapsed Gibbs sampling integrating out the component parameters to sample cluster assignments directly."
+    expected: "Chinese Restaurant Process"
+evaluators:
+  - type: "regex_match"
+    pattern: "(?i)chinese restaurant process"

--- a/prompts/scientific/statistics/inference/bayesian_methods/overview.md
+++ b/prompts/scientific/statistics/inference/bayesian_methods/overview.md
@@ -2,4 +2,5 @@
 
 ## Prompts
 - **[bayesian_hierarchical_model_architect](bayesian_hierarchical_model_architect.prompt.yaml)**: Acts as a Principal Statistician to design and formulate complex Bayesian hierarchical models with custom priors and MCMC sampling strategies.
+- **[dirichlet_process_mixture_architect](dirichlet_process_mixture_architect.prompt.yaml)**: Acts as a Principal Statistician to formulate mathematically rigorous Nonparametric Bayesian models utilizing Dirichlet Process Mixture Models (DPMM) for cluster identification.
 - **[variational_inference_architect](variational_inference_architect.prompt.yaml)**: Acts as a Principal Statistician to design and formulate complex Variational Inference (VI) approximations for scalable Bayesian analysis.


### PR DESCRIPTION
Adds the `dirichlet_process_mixture_architect.prompt.yaml` file to the `prompts/scientific/statistics/inference/bayesian_methods` directory. The prompt is designed by the Statistical Sciences Genesis Architect to formulate mathematically rigorous Nonparametric Bayesian models utilizing Dirichlet Process Mixture Models (DPMM) for cluster identification. Also includes generated documentation updates.

---
*PR created automatically by Jules for task [1950212955252070549](https://jules.google.com/task/1950212955252070549) started by @fderuiter*