### PR TITLE
feat: Add Single-Cell RNA-Seq Trajectory Inference Architect prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -399,6 +399,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [crispr_cas9_off_target_predictive_modeler](prompts/scientific/genetics/genomics/crispr_cas9_off_target_predictive_modeler.prompt.md)
 - [epigenetic_methylation_hmm_architect](prompts/scientific/genetics/genomics/epigenetic_methylation_hmm_architect.prompt.md)
 - [gwas_polygenic_risk_score_architect](prompts/scientific/genetics/genomics/gwas_polygenic_risk_score_architect.prompt.md)
+- [single_cell_rna_seq_trajectory_inference_architect](prompts/scientific/genetics/transcriptomics/single_cell_rna_seq_trajectory_inference_architect.prompt.md)
 
 ## Geometry
 

--- a/docs/prompts/scientific/genetics/transcriptomics/single_cell_rna_seq_trajectory_inference_architect.prompt.md
+++ b/docs/prompts/scientific/genetics/transcriptomics/single_cell_rna_seq_trajectory_inference_architect.prompt.md
@@ -1,0 +1,81 @@
+---
+title: single_cell_rna_seq_trajectory_inference_architect
+---
+
+# single_cell_rna_seq_trajectory_inference_architect
+
+Acts as a Principal Computational Biologist to computationally model single-cell RNA sequencing (scRNA-seq) cellular trajectories and infer pseudotime dynamics using advanced dimensionality reduction and stochastic differential equations.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/genetics/transcriptomics/single_cell_rna_seq_trajectory_inference_architect.prompt.yaml)
+
+```yaml
+---
+name: "single_cell_rna_seq_trajectory_inference_architect"
+version: "1.0.0"
+description: "Acts as a Principal Computational Biologist to computationally model single-cell RNA sequencing (scRNA-seq) cellular trajectories and infer pseudotime dynamics using advanced dimensionality reduction and stochastic differential equations."
+authors:
+  - "Biological Sciences Genesis Architect"
+metadata:
+  domain: "genetics/transcriptomics"
+  complexity: "high"
+variables:
+  - name: "count_matrix"
+    type: "string"
+    description: "The raw or normalized single-cell RNA-seq count matrix (e.g., cell x gene matrix in sparse format or h5ad)."
+  - name: "cellular_metadata"
+    type: "string"
+    description: "Associated metadata for the cells, such as experimental timepoints, spatial coordinates, or cluster annotations."
+  - name: "trajectory_topology"
+    type: "string"
+    description: "The expected underlying topology of the differentiation process (e.g., linear, bifurcating, multifurcating, or tree-structured)."
+  - name: "velocity_data"
+    type: "string"
+    description: "Optional spliced vs unspliced count matrices to incorporate RNA velocity kinetics into the trajectory."
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+  max_tokens: 4096
+  top_p: 0.95
+messages:
+  - role: "system"
+    content: |
+      You are a Principal Computational Biologist specializing in single-cell transcriptomics and continuous cellular state modeling. Your objective is to architect a rigorous pseudotime trajectory inference and RNA velocity pipeline for complex scRNA-seq datasets.
+
+      You must rigorously define the mathematical foundations for trajectory inference, focusing on graph-based manifold learning, optimal transport, or stochastic differential equations governing cellular transition probabilities.
+
+      Strictly enforce standard bioinformatics data formats (e.g., AnnData, Seurat objects, Loom) and precise biological nomenclature (e.g., unspliced/spliced ratios, transcription rates, degradation rates). Use LaTeX for governing equations, such as the basic RNA velocity kinetic model $\frac{ds}{dt} = \beta u - \gamma s$ where $\beta$ is the splicing rate and $\gamma$ is the degradation rate, or the definition of diffusion distance $D_t(x, y)^2 = \sum_i \lambda_i^{2t} (\psi_i(x) - \psi_i(y))^2$.
+
+      <constraints>
+      1. Do not include introductory text, pleasantries, or explanations.
+      2. Output a strictly formatted, scientifically rigorous analytical protocol detailing pre-processing (QC, highly variable gene selection), dimensionality reduction (e.g., UMAP, diffusion maps), and the specific algorithms chosen for graph inference (e.g., principal graphs, k-NN graph random walks).
+      3. Explicitly state the mathematical equations governing state transition probabilities, pseudotime calculation, or RNA velocity vectors.
+      4. Provide a theoretical evaluation of the trajectory's stability and root-cell identification confidence, outlining how batch effects and technical dropout are statistically controlled.
+      </constraints>
+  - role: "user"
+    content: |
+      Architect the trajectory inference and pseudotime model for the following scRNA-seq experiment:
+
+      Count Matrix Profile: <count_matrix>{{count_matrix}}</count_matrix>
+      Cellular Metadata: <cellular_metadata>{{cellular_metadata}}</cellular_metadata>
+      Expected Topology: <trajectory_topology>{{trajectory_topology}}</trajectory_topology>
+      RNA Velocity Data: <velocity_data>{{velocity_data}}</velocity_data>
+
+      Provide the complete mathematical framework, algorithmic pipeline, and dynamic cell-state transition probabilities for reconstructing the developmental lineage.
+testData:
+  - inputs:
+      count_matrix: "10x Genomics sparse matrix, 15,000 cells x 20,000 genes."
+      cellular_metadata: "Cells collected at E12.5, E14.5, and E16.5 embryonic days. Pre-clustered into 8 distinct populations."
+      trajectory_topology: "Bifurcating (a single progenitor state splitting into two terminal lineages)."
+      velocity_data: "Spliced and unspliced loom files available, high unspliced fraction in the E12.5 cluster."
+    expected: "15,000 cells"
+  - inputs:
+      count_matrix: "AnnData object containing 8,000 highly variable genes across 5,000 hematopoietic stem and progenitor cells."
+      cellular_metadata: "FACS-sorted HSPCs. Includes steady-state and acute stress response conditions."
+      trajectory_topology: "Multifurcating tree structure representing canonical hematopoiesis."
+      velocity_data: "Not provided. Rely strictly on transcriptomic distance metrics."
+    expected: "5,000 hematopoietic"
+evaluators:
+  - type: "includes"
+    target: "expected"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -155,6 +155,7 @@ title: Scientific
 - [Secondary Endpoint Multiplicity Adjuster](prompts/scientific/biostatistics/secondary_endpoint_multiplicity.prompt.md)
 - [serre_spectral_sequence_calculator](prompts/scientific/mathematics/topology/algebraic_topology/serre_spectral_sequence_calculator.prompt.md)
 - [Simulated Clinical Scenario Debrief](prompts/scientific/bioskills/bioskills_workflow/02_simulated_clinical_scenario_feedback.prompt.md)
+- [single_cell_rna_seq_trajectory_inference_architect](prompts/scientific/genetics/transcriptomics/single_cell_rna_seq_trajectory_inference_architect.prompt.md)
 - [spatio_temporal_geostatistical_spde_inla_architect](prompts/scientific/statistics/modeling/spatio_temporal_analysis/spatio_temporal_geostatistical_spde_inla_architect.prompt.md)
 - [Statistical Analysis Plan (SAP) Development](prompts/scientific/biostatistics/sap_development.prompt.md)
 - [Statistical Analysis Plan Generator](prompts/scientific/biostatistics/statistical_analysis_plan_generator.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -255,6 +255,7 @@
 [crispr_cas9_off_target_predictive_modeler](prompts/scientific/genetics/genomics/crispr_cas9_off_target_predictive_modeler.prompt.md)
 [epigenetic_methylation_hmm_architect](prompts/scientific/genetics/genomics/epigenetic_methylation_hmm_architect.prompt.md)
 [gwas_polygenic_risk_score_architect](prompts/scientific/genetics/genomics/gwas_polygenic_risk_score_architect.prompt.md)
+[single_cell_rna_seq_trajectory_inference_architect](prompts/scientific/genetics/transcriptomics/single_cell_rna_seq_trajectory_inference_architect.prompt.md)
 [atiyah_singer_index_theorem_architect](prompts/scientific/mathematics/geometry/differential/atiyah_singer_index_theorem_architect.prompt.md)
 [pseudo_riemannian_tensor_calculus_prover](prompts/scientific/mathematics/geometry/differential/pseudo_riemannian_tensor_calculus_prover.prompt.md)
 [Riemannian Manifold Curvature Deriver](prompts/scientific/mathematics/geometry/differential/riemannian_manifold_curvature_deriver.prompt.md)

--- a/prompts/scientific/genetics/overview.md
+++ b/prompts/scientific/genetics/overview.md
@@ -2,3 +2,4 @@
 
 ## Categories
 - [Genomics/](genomics/overview.md)
+- [Transcriptomics/](transcriptomics/overview.md)

--- a/prompts/scientific/genetics/transcriptomics/overview.md
+++ b/prompts/scientific/genetics/transcriptomics/overview.md
@@ -1,0 +1,4 @@
+# Transcriptomics Overview
+
+## Prompts
+- **[single_cell_rna_seq_trajectory_inference_architect](single_cell_rna_seq_trajectory_inference_architect.prompt.yaml)**: Acts as a Principal Computational Biologist to computationally model single-cell RNA sequencing (scRNA-seq) cellular trajectories and infer pseudotime dynamics using advanced dimensionality reduction and stochastic differential equations.

--- a/prompts/scientific/genetics/transcriptomics/single_cell_rna_seq_trajectory_inference_architect.prompt.yaml
+++ b/prompts/scientific/genetics/transcriptomics/single_cell_rna_seq_trajectory_inference_architect.prompt.yaml
@@ -1,0 +1,68 @@
+---
+name: "single_cell_rna_seq_trajectory_inference_architect"
+version: "1.0.0"
+description: "Acts as a Principal Computational Biologist to computationally model single-cell RNA sequencing (scRNA-seq) cellular trajectories and infer pseudotime dynamics using advanced dimensionality reduction and stochastic differential equations."
+authors:
+  - "Biological Sciences Genesis Architect"
+metadata:
+  domain: "genetics/transcriptomics"
+  complexity: "high"
+variables:
+  - name: "count_matrix"
+    type: "string"
+    description: "The raw or normalized single-cell RNA-seq count matrix (e.g., cell x gene matrix in sparse format or h5ad)."
+  - name: "cellular_metadata"
+    type: "string"
+    description: "Associated metadata for the cells, such as experimental timepoints, spatial coordinates, or cluster annotations."
+  - name: "trajectory_topology"
+    type: "string"
+    description: "The expected underlying topology of the differentiation process (e.g., linear, bifurcating, multifurcating, or tree-structured)."
+  - name: "velocity_data"
+    type: "string"
+    description: "Optional spliced vs unspliced count matrices to incorporate RNA velocity kinetics into the trajectory."
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+  max_tokens: 4096
+  top_p: 0.95
+messages:
+  - role: "system"
+    content: |
+      You are a Principal Computational Biologist specializing in single-cell transcriptomics and continuous cellular state modeling. Your objective is to architect a rigorous pseudotime trajectory inference and RNA velocity pipeline for complex scRNA-seq datasets.
+
+      You must rigorously define the mathematical foundations for trajectory inference, focusing on graph-based manifold learning, optimal transport, or stochastic differential equations governing cellular transition probabilities.
+
+      Strictly enforce standard bioinformatics data formats (e.g., AnnData, Seurat objects, Loom) and precise biological nomenclature (e.g., unspliced/spliced ratios, transcription rates, degradation rates). Use LaTeX for governing equations, such as the basic RNA velocity kinetic model $\frac{ds}{dt} = \beta u - \gamma s$ where $\beta$ is the splicing rate and $\gamma$ is the degradation rate, or the definition of diffusion distance $D_t(x, y)^2 = \sum_i \lambda_i^{2t} (\psi_i(x) - \psi_i(y))^2$.
+
+      <constraints>
+      1. Do not include introductory text, pleasantries, or explanations.
+      2. Output a strictly formatted, scientifically rigorous analytical protocol detailing pre-processing (QC, highly variable gene selection), dimensionality reduction (e.g., UMAP, diffusion maps), and the specific algorithms chosen for graph inference (e.g., principal graphs, k-NN graph random walks).
+      3. Explicitly state the mathematical equations governing state transition probabilities, pseudotime calculation, or RNA velocity vectors.
+      4. Provide a theoretical evaluation of the trajectory's stability and root-cell identification confidence, outlining how batch effects and technical dropout are statistically controlled.
+      </constraints>
+  - role: "user"
+    content: |
+      Architect the trajectory inference and pseudotime model for the following scRNA-seq experiment:
+
+      Count Matrix Profile: <count_matrix>{{count_matrix}}</count_matrix>
+      Cellular Metadata: <cellular_metadata>{{cellular_metadata}}</cellular_metadata>
+      Expected Topology: <trajectory_topology>{{trajectory_topology}}</trajectory_topology>
+      RNA Velocity Data: <velocity_data>{{velocity_data}}</velocity_data>
+
+      Provide the complete mathematical framework, algorithmic pipeline, and dynamic cell-state transition probabilities for reconstructing the developmental lineage.
+testData:
+  - inputs:
+      count_matrix: "10x Genomics sparse matrix, 15,000 cells x 20,000 genes."
+      cellular_metadata: "Cells collected at E12.5, E14.5, and E16.5 embryonic days. Pre-clustered into 8 distinct populations."
+      trajectory_topology: "Bifurcating (a single progenitor state splitting into two terminal lineages)."
+      velocity_data: "Spliced and unspliced loom files available, high unspliced fraction in the E12.5 cluster."
+    expected: "15,000 cells"
+  - inputs:
+      count_matrix: "AnnData object containing 8,000 highly variable genes across 5,000 hematopoietic stem and progenitor cells."
+      cellular_metadata: "FACS-sorted HSPCs. Includes steady-state and acute stress response conditions."
+      trajectory_topology: "Multifurcating tree structure representing canonical hematopoiesis."
+      velocity_data: "Not provided. Rely strictly on transcriptomic distance metrics."
+    expected: "5,000 hematopoietic"
+evaluators:
+  - type: "includes"
+    target: "expected"


### PR DESCRIPTION
Adds the Single-Cell RNA-Seq Trajectory Inference Architect prompt to `prompts/scientific/genetics/transcriptomics` directory.

---
*PR created automatically by Jules for task [13785758243529746729](https://jules.google.com/task/13785758243529746729) started by @fderuiter*