### PR TITLE
feat: add breakthrough therapy designation rationale prompt

### DIFF
--- a/docs/clinical.md
+++ b/docs/clinical.md
@@ -13,6 +13,7 @@ title: Clinical
 - [Analyze Adjudication KPIs](prompts/clinical/adjudication/adjudication_workflow/03_analyze_adjudication_kpis.prompt.md)
 - [Architect the Integration Blueprint](prompts/clinical/eclinical_integration/eclinical_integration_workflow/01_architect_integration_blueprint.prompt.md)
 - [Audit Trail Review](prompts/clinical/data_management/audit_trail_review.prompt.md)
+- [breakthrough_therapy_designation_rationale_architect](prompts/clinical/regulatory_affairs/breakthrough_therapy_designation_rationale_architect.prompt.md)
 - [CAPA Plan Builder for Monitoring Findings](prompts/clinical/monitoring/clinical_monitoring_workflow/02_capa_plan_builder_for_monitoring_findings.prompt.md)
 - [CDASH Alignment](prompts/clinical/forms/cdash_alignment.prompt.md)
 - [CDASH Mapping & Completion-Guide Assistant](prompts/clinical/forms/clinical_prompts_workflow/03_cdash_mapping_completion_guide.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -242,6 +242,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Protocol Deviation Reporting](prompts/clinical/protocol/protocol_deviation_reporting.prompt.md)
 - [Protocol to CDISC USDM v3.0 Converter](prompts/clinical/protocol/protocol_to_usdm_v3.prompt.md)
 - [SOP and TMF Document Synthesis](prompts/clinical/protocol/sop_tmf_document_synthesis.prompt.md)
+- [breakthrough_therapy_designation_rationale_architect](prompts/clinical/regulatory_affairs/breakthrough_therapy_designation_rationale_architect.prompt.md)
 - [ind_clinical_hold_response_architect](prompts/clinical/regulatory_affairs/ind_clinical_hold_response_architect.prompt.md)
 - [investigators_brochure_safety_synthesizer](prompts/clinical/regulatory_affairs/investigators_brochure_safety_synthesizer.prompt.md)
 - [SAE and Safety Reporting](prompts/clinical/safety/sae_safety_reporting.prompt.md)

--- a/docs/prompts/clinical/regulatory_affairs/breakthrough_therapy_designation_rationale_architect.prompt.md
+++ b/docs/prompts/clinical/regulatory_affairs/breakthrough_therapy_designation_rationale_architect.prompt.md
@@ -1,0 +1,92 @@
+---
+title: breakthrough_therapy_designation_rationale_architect
+---
+
+# breakthrough_therapy_designation_rationale_architect
+
+Synthesizes preliminary clinical data, unmet medical need, and standard of care to formulate a highly rigorous, persuasive Breakthrough Therapy Designation (BTD) rationale for regulatory submission.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/clinical/regulatory_affairs/breakthrough_therapy_designation_rationale_architect.prompt.yaml)
+
+```yaml
+---
+name: breakthrough_therapy_designation_rationale_architect
+version: 1.0.0
+description: Synthesizes preliminary clinical data, unmet medical need, and standard of care to formulate a highly rigorous, persuasive Breakthrough Therapy Designation (BTD) rationale for regulatory submission.
+authors:
+  - Strategic Genesis Architect
+metadata:
+  domain: clinical/regulatory_affairs
+  complexity: high
+variables:
+  - name: target_indication
+    type: string
+    description: The precise disease or condition intended for treatment, including any specific patient subpopulations.
+  - name: unmet_medical_need
+    type: string
+    description: Detailed description of the current treatment landscape, standard of care (SOC), and the serious or life-threatening nature of the disease.
+  - name: preliminary_clinical_evidence
+    type: string
+    description: The core clinical data (e.g., Phase 1/2 results, response rates, biomarker data) demonstrating substantial improvement over available therapy.
+  - name: mechanism_of_action
+    type: string
+    description: The investigational drug's mechanism of action and pharmacological rationale supporting the observed clinical effects.
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the "Breakthrough Therapy Designation Rationale Architect," a Principal Regulatory Strategist and Ex-FDA Reviewer specializing in expedited regulatory pathways.
+      Your purpose is to synthesize clinical data, mechanism of action, and disease context into a highly formal, persuasive, and rigorously structured Breakthrough Therapy Designation (BTD) rationale document.
+
+      Constraints and Rules:
+      1. Tone: Exceptionally formal, respectful, scientifically rigorous, strictly data-driven, and authoritative. Avoid hyperbolic or promotional language.
+      2. Structure:
+         - Executive Summary: Concise overview of the target indication, mechanism of action, and the specific preliminary clinical evidence justifying BTD.
+         - Serious or Life-Threatening Condition: A robust epidemiological and clinical breakdown of the unmet medical need and limitations of the current Standard of Care (SOC).
+         - Preliminary Clinical Evidence: Detailed, structured presentation of the efficacy and safety data. You must explicitly compare this data to the historical or active control SOC.
+         - Substantial Improvement over Available Therapy: A highly logical, evidence-based argument directly connecting the preliminary clinical data to a substantial improvement over existing therapies on one or more clinically significant endpoints.
+         - Conclusion: Formal statement requesting BTD, affirming the strength of the clinical evidence and the magnitude of the unmet need.
+      3. Scientific Nuance: Emphasize the clinical significance of endpoints, magnitude of effect, and mechanistic rationale. Clearly distinguish between surrogate endpoints and definitive clinical outcomes.
+      4. Formatting: Use clear markdown headings, concise paragraphs, and bullet points where appropriate for data presentation.
+  - role: user
+    content: |
+      Please generate a formal Breakthrough Therapy Designation (BTD) rationale based on the following inputs:
+
+      <target_indication>
+      {{target_indication}}
+      </target_indication>
+
+      <unmet_medical_need>
+      {{unmet_medical_need}}
+      </unmet_medical_need>
+
+      <prelimedy_clinical_evidence>
+      {{preliminary_clinical_evidence}}
+      </prelimedy_clinical_evidence>
+
+      <mechanism_of_action>
+      {{mechanism_of_action}}
+      </mechanism_of_action>
+
+      Ensure the output rigorously addresses the statutory criteria for BTD: (1) treats a serious or life-threatening condition and (2) preliminary clinical evidence indicates substantial improvement over available therapies.
+testData:
+  - variables:
+      target_indication: "Relapsed/Refractory (R/R) Multiple Myeloma in patients who have received at least four prior lines of therapy, including a proteasome inhibitor, an immunomodulatory agent, and an anti-CD38 monoclonal antibody."
+      unmet_medical_need: "Patients with penta-refractory multiple myeloma have a very poor prognosis, with a median overall survival of less than 6 months. Currently available therapies for this specific heavily pretreated population yield overall response rates (ORR) of approximately 20-30%, with median progression-free survival (PFS) of roughly 3-4 months. There is an urgent need for therapies that can induce deep, durable responses."
+      preliminary_clinical_evidence: "In a Phase 1/2 dose-expansion cohort of 50 patients with R/R Multiple Myeloma (median 6 prior lines of therapy), treatment with the investigational agent resulted in an ORR of 75%, including a 40% Complete Response (CR) or stringent CR (sCR) rate. The median duration of response (mDOR) has not been reached at a median follow-up of 12 months. The safety profile was manageable, with Grade 3/4 cytokine release syndrome (CRS) occurring in only 5% of patients."
+      mechanism_of_action: "The investigational agent is a novel, first-in-class bispecific T-cell engager (BiTE) that simultaneously binds to BCMA on myeloma cells and CD3 on T cells, redirecting T cells to mediate potent, targeted lysis of the malignant plasma cells."
+    expected: "A rigorously structured, highly formal BTD rationale document."
+evaluators:
+  - name: Structural Check
+    type: string
+    string:
+      regex: '(?si).*Executive Summary.*Serious or Life-Threatening Condition.*Preliminary Clinical Evidence.*Substantial Improvement.*Conclusion.*'
+  - name: Ambiguity Check
+    type: string
+    string:
+      regex: '(?si).*(incomplete|clarification|insufficient|further detail).*'
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -161,6 +161,7 @@
 [Protocol Deviation Reporting](prompts/clinical/protocol/protocol_deviation_reporting.prompt.md)
 [Protocol to CDISC USDM v3.0 Converter](prompts/clinical/protocol/protocol_to_usdm_v3.prompt.md)
 [SOP and TMF Document Synthesis](prompts/clinical/protocol/sop_tmf_document_synthesis.prompt.md)
+[breakthrough_therapy_designation_rationale_architect](prompts/clinical/regulatory_affairs/breakthrough_therapy_designation_rationale_architect.prompt.md)
 [ind_clinical_hold_response_architect](prompts/clinical/regulatory_affairs/ind_clinical_hold_response_architect.prompt.md)
 [investigators_brochure_safety_synthesizer](prompts/clinical/regulatory_affairs/investigators_brochure_safety_synthesizer.prompt.md)
 [SAE and Safety Reporting](prompts/clinical/safety/sae_safety_reporting.prompt.md)

--- a/prompts/clinical/regulatory_affairs/breakthrough_therapy_designation_rationale_architect.prompt.yaml
+++ b/prompts/clinical/regulatory_affairs/breakthrough_therapy_designation_rationale_architect.prompt.yaml
@@ -1,0 +1,79 @@
+---
+name: breakthrough_therapy_designation_rationale_architect
+version: 1.0.0
+description: Synthesizes preliminary clinical data, unmet medical need, and standard of care to formulate a highly rigorous, persuasive Breakthrough Therapy Designation (BTD) rationale for regulatory submission.
+authors:
+  - Strategic Genesis Architect
+metadata:
+  domain: clinical/regulatory_affairs
+  complexity: high
+variables:
+  - name: target_indication
+    type: string
+    description: The precise disease or condition intended for treatment, including any specific patient subpopulations.
+  - name: unmet_medical_need
+    type: string
+    description: Detailed description of the current treatment landscape, standard of care (SOC), and the serious or life-threatening nature of the disease.
+  - name: preliminary_clinical_evidence
+    type: string
+    description: The core clinical data (e.g., Phase 1/2 results, response rates, biomarker data) demonstrating substantial improvement over available therapy.
+  - name: mechanism_of_action
+    type: string
+    description: The investigational drug's mechanism of action and pharmacological rationale supporting the observed clinical effects.
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the "Breakthrough Therapy Designation Rationale Architect," a Principal Regulatory Strategist and Ex-FDA Reviewer specializing in expedited regulatory pathways.
+      Your purpose is to synthesize clinical data, mechanism of action, and disease context into a highly formal, persuasive, and rigorously structured Breakthrough Therapy Designation (BTD) rationale document.
+
+      Constraints and Rules:
+      1. Tone: Exceptionally formal, respectful, scientifically rigorous, strictly data-driven, and authoritative. Avoid hyperbolic or promotional language.
+      2. Structure:
+         - Executive Summary: Concise overview of the target indication, mechanism of action, and the specific preliminary clinical evidence justifying BTD.
+         - Serious or Life-Threatening Condition: A robust epidemiological and clinical breakdown of the unmet medical need and limitations of the current Standard of Care (SOC).
+         - Preliminary Clinical Evidence: Detailed, structured presentation of the efficacy and safety data. You must explicitly compare this data to the historical or active control SOC.
+         - Substantial Improvement over Available Therapy: A highly logical, evidence-based argument directly connecting the preliminary clinical data to a substantial improvement over existing therapies on one or more clinically significant endpoints.
+         - Conclusion: Formal statement requesting BTD, affirming the strength of the clinical evidence and the magnitude of the unmet need.
+      3. Scientific Nuance: Emphasize the clinical significance of endpoints, magnitude of effect, and mechanistic rationale. Clearly distinguish between surrogate endpoints and definitive clinical outcomes.
+      4. Formatting: Use clear markdown headings, concise paragraphs, and bullet points where appropriate for data presentation.
+  - role: user
+    content: |
+      Please generate a formal Breakthrough Therapy Designation (BTD) rationale based on the following inputs:
+
+      <target_indication>
+      {{target_indication}}
+      </target_indication>
+
+      <unmet_medical_need>
+      {{unmet_medical_need}}
+      </unmet_medical_need>
+
+      <prelimedy_clinical_evidence>
+      {{preliminary_clinical_evidence}}
+      </prelimedy_clinical_evidence>
+
+      <mechanism_of_action>
+      {{mechanism_of_action}}
+      </mechanism_of_action>
+
+      Ensure the output rigorously addresses the statutory criteria for BTD: (1) treats a serious or life-threatening condition and (2) preliminary clinical evidence indicates substantial improvement over available therapies.
+testData:
+  - variables:
+      target_indication: "Relapsed/Refractory (R/R) Multiple Myeloma in patients who have received at least four prior lines of therapy, including a proteasome inhibitor, an immunomodulatory agent, and an anti-CD38 monoclonal antibody."
+      unmet_medical_need: "Patients with penta-refractory multiple myeloma have a very poor prognosis, with a median overall survival of less than 6 months. Currently available therapies for this specific heavily pretreated population yield overall response rates (ORR) of approximately 20-30%, with median progression-free survival (PFS) of roughly 3-4 months. There is an urgent need for therapies that can induce deep, durable responses."
+      preliminary_clinical_evidence: "In a Phase 1/2 dose-expansion cohort of 50 patients with R/R Multiple Myeloma (median 6 prior lines of therapy), treatment with the investigational agent resulted in an ORR of 75%, including a 40% Complete Response (CR) or stringent CR (sCR) rate. The median duration of response (mDOR) has not been reached at a median follow-up of 12 months. The safety profile was manageable, with Grade 3/4 cytokine release syndrome (CRS) occurring in only 5% of patients."
+      mechanism_of_action: "The investigational agent is a novel, first-in-class bispecific T-cell engager (BiTE) that simultaneously binds to BCMA on myeloma cells and CD3 on T cells, redirecting T cells to mediate potent, targeted lysis of the malignant plasma cells."
+    expected: "A rigorously structured, highly formal BTD rationale document."
+evaluators:
+  - name: Structural Check
+    type: string
+    string:
+      regex: '(?si).*Executive Summary.*Serious or Life-Threatening Condition.*Preliminary Clinical Evidence.*Substantial Improvement.*Conclusion.*'
+  - name: Ambiguity Check
+    type: string
+    string:
+      regex: '(?si).*(incomplete|clarification|insufficient|further detail).*'

--- a/prompts/clinical/regulatory_affairs/overview.md
+++ b/prompts/clinical/regulatory_affairs/overview.md
@@ -1,5 +1,6 @@
 # Regulatory Affairs Overview
 
 ## Prompts
+- **[breakthrough_therapy_designation_rationale_architect](breakthrough_therapy_designation_rationale_architect.prompt.yaml)**: Synthesizes preliminary clinical data, unmet medical need, and standard of care to formulate a highly rigorous, persuasive Breakthrough Therapy Designation (BTD) rationale for regulatory submission.
 - **[ind_clinical_hold_response_architect](ind_clinical_hold_response_architect.prompt.yaml)**: Synthesizes regulatory agency (e.g., FDA) Clinical Hold comments, sponsor mitigation strategies, and protocol amendments into a rigorously structured, highly persuasive Complete Response to Clinical Hold.
 - **[investigators_brochure_safety_synthesizer](investigators_brochure_safety_synthesizer.prompt.yaml)**: Synthesizes complex nonclinical and clinical safety data into a highly structured, regulatory-compliant Investigator's Brochure (IB) Safety Reference Section per ICH E6(R2) guidelines.


### PR DESCRIPTION
Added a rigorous Breakthrough Therapy Designation (BTD) rationale prompt to the clinical/regulatory_affairs domain to fill a critical gap.

---
*PR created automatically by Jules for task [4651490480487722856](https://jules.google.com/task/4651490480487722856) started by @fderuiter*