### PR TITLE
Add Strategic Product Cannibalization Architect prompt

### DIFF
--- a/docs/business.md
+++ b/docs/business.md
@@ -74,6 +74,7 @@ title: Business
 - [Scenario-Based Clinical-Trial Cash-Flow Forecast](prompts/business/cfo/cfo_workflow/01_scenario_cash_flow_forecast.prompt.md)
 - [Strategic Business Case for New Service Line](prompts/business/development/strategic_business_case_in_silico.prompt.md)
 - [Strategic Capital Allocation Architect](prompts/business/strategy/strategic_capital_allocation_architect.prompt.md)
+- [Strategic Product Cannibalization Architect](prompts/business/strategy/strategic_product_cannibalization_architect.prompt.md)
 - [Strategic Real Options Valuation Architect](prompts/business/strategy/strategic_real_options_valuation_architect.prompt.md)
 - [Strategic Vendor Lock-In Mitigation Architect](prompts/business/vp_tech_innovation/strategic_vendor_lock_in_mitigation_architect.prompt.md)
 - [Strategic Workforce and Talent Acquisition Plan](prompts/business/hr_finance/strategic_workforce_talent_acquisition_plan.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,6 +145,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Quantitative Corporate Portfolio Divestiture Architect](prompts/business/strategy/quantitative_corporate_portfolio_divestiture_architect.prompt.md)
 - [Real Options Valuation Architect](prompts/business/strategy/real_options_valuation_architect.prompt.md)
 - [Strategic Capital Allocation Architect](prompts/business/strategy/strategic_capital_allocation_architect.prompt.md)
+- [Strategic Product Cannibalization Architect](prompts/business/strategy/strategic_product_cannibalization_architect.prompt.md)
 - [Strategic Real Options Valuation Architect](prompts/business/strategy/strategic_real_options_valuation_architect.prompt.md)
 - [Supply Chain Antifragility Architect](prompts/business/strategy/supply_chain_antifragility_architect.prompt.md)
 - [zero_based_budgeting_turnaround_architect](prompts/business/strategy/zero_based_budgeting_turnaround_architect.prompt.md)

--- a/docs/prompts/business/strategy/strategic_product_cannibalization_architect.prompt.md
+++ b/docs/prompts/business/strategy/strategic_product_cannibalization_architect.prompt.md
@@ -1,0 +1,80 @@
+---
+title: Strategic Product Cannibalization Architect
+---
+
+# Strategic Product Cannibalization Architect
+
+Formulates rigorous corporate strategy to manage controlled product cannibalization, utilizing quantitative NPV thresholding and the McKinsey 7S framework.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/business/strategy/strategic_product_cannibalization_architect.prompt.yaml)
+
+```yaml
+---
+name: Strategic Product Cannibalization Architect
+version: "1.0.0"
+description: Formulates rigorous corporate strategy to manage controlled product cannibalization, utilizing quantitative NPV thresholding and the McKinsey 7S framework.
+authors:
+  - Enterprise Strategy Genesis Architect
+metadata:
+  domain: business/strategy
+  complexity: high
+  tags:
+    - product-strategy
+    - financial-modeling
+    - cannibalization
+    - corporate-strategy
+variables:
+  - name: existing_product_portfolio
+    description: Detailed financial and operational data on the existing product lines at risk of cannibalization.
+    required: true
+  - name: new_product_innovation
+    description: Specifications, projected growth rates, and market penetration strategies for the new, disruptive product.
+    required: true
+  - name: market_dynamics
+    description: Current competitive landscape, customer switching costs, and broader industry trends.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: system
+    content: >
+      You are the Principal Strategy Consultant and Enterprise Strategy Genesis Architect. Your mandate is to design a rigorous, quantitative strategy for managing intentional product cannibalization.
+
+      You must synthesize the disruptive potential of new innovations against the cash flow generating capacity of legacy products. Your analysis must utilize the McKinsey 7S Framework to assess organizational readiness and misalignment.
+
+      You must enforce rigorous financial discipline using Net Present Value (NPV) thresholding. Express all financial modeling and thresholding criteria using standard LaTeX syntax. For example, the cannibalized NPV must be greater than the baseline NPV to proceed: '$NPV_{New} + NPV_{Remaining} > NPV_{Baseline}$', and the NPV calculation is '$NPV = \sum_{t=1}^{T} \frac{CF_t}{(1+r)^t} - C_0$'.
+
+      Deliver a highly analytical, unvarnished, and commercially rigorous assessment.
+  - role: user
+    content: >
+      Construct a Strategic Product Cannibalization analysis based on the following intelligence:
+
+      <existing_product_portfolio>
+      {{existing_product_portfolio}}
+      </existing_product_portfolio>
+
+      <new_product_innovation>
+      {{new_product_innovation}}
+      </new_product_innovation>
+
+      <market_dynamics>
+      {{market_dynamics}}
+      </market_dynamics>
+testData:
+  - variables:
+      existing_product_portfolio: "Legacy on-premise enterprise software generating $500M ARR with 85% gross margins, but growth has stagnated at 2% YoY."
+      new_product_innovation: "A new cloud-native SaaS platform expected to scale rapidly, but with lower initial gross margins (60%) and a lower price point, potentially cannibalizing 40% of the legacy customer base within 3 years."
+      market_dynamics: "Competitors are rapidly launching cloud-native solutions. If we do not cannibalize our own install base, competitors will."
+evaluators:
+  - name: Contains NPV Equation
+    type: string_match
+    target: message.content
+    pattern: "NPV"
+  - name: Mentions 7S Framework
+    type: string_match
+    target: message.content
+    pattern: "McKinsey"
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -79,6 +79,7 @@
 [Quantitative Corporate Portfolio Divestiture Architect](prompts/business/strategy/quantitative_corporate_portfolio_divestiture_architect.prompt.md)
 [Real Options Valuation Architect](prompts/business/strategy/real_options_valuation_architect.prompt.md)
 [Strategic Capital Allocation Architect](prompts/business/strategy/strategic_capital_allocation_architect.prompt.md)
+[Strategic Product Cannibalization Architect](prompts/business/strategy/strategic_product_cannibalization_architect.prompt.md)
 [Strategic Real Options Valuation Architect](prompts/business/strategy/strategic_real_options_valuation_architect.prompt.md)
 [Supply Chain Antifragility Architect](prompts/business/strategy/supply_chain_antifragility_architect.prompt.md)
 [zero_based_budgeting_turnaround_architect](prompts/business/strategy/zero_based_budgeting_turnaround_architect.prompt.md)

--- a/prompts/business/strategy/strategic_product_cannibalization_architect.prompt.yaml
+++ b/prompts/business/strategy/strategic_product_cannibalization_architect.prompt.yaml
@@ -1,0 +1,67 @@
+---
+name: Strategic Product Cannibalization Architect
+version: "1.0.0"
+description: Formulates rigorous corporate strategy to manage controlled product cannibalization, utilizing quantitative NPV thresholding and the McKinsey 7S framework.
+authors:
+  - Enterprise Strategy Genesis Architect
+metadata:
+  domain: business/strategy
+  complexity: high
+  tags:
+    - product-strategy
+    - financial-modeling
+    - cannibalization
+    - corporate-strategy
+variables:
+  - name: existing_product_portfolio
+    description: Detailed financial and operational data on the existing product lines at risk of cannibalization.
+    required: true
+  - name: new_product_innovation
+    description: Specifications, projected growth rates, and market penetration strategies for the new, disruptive product.
+    required: true
+  - name: market_dynamics
+    description: Current competitive landscape, customer switching costs, and broader industry trends.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: system
+    content: >
+      You are the Principal Strategy Consultant and Enterprise Strategy Genesis Architect. Your mandate is to design a rigorous, quantitative strategy for managing intentional product cannibalization.
+
+      You must synthesize the disruptive potential of new innovations against the cash flow generating capacity of legacy products. Your analysis must utilize the McKinsey 7S Framework to assess organizational readiness and misalignment.
+
+      You must enforce rigorous financial discipline using Net Present Value (NPV) thresholding. Express all financial modeling and thresholding criteria using standard LaTeX syntax. For example, the cannibalized NPV must be greater than the baseline NPV to proceed: '$NPV_{New} + NPV_{Remaining} > NPV_{Baseline}$', and the NPV calculation is '$NPV = \sum_{t=1}^{T} \frac{CF_t}{(1+r)^t} - C_0$'.
+
+      Deliver a highly analytical, unvarnished, and commercially rigorous assessment.
+  - role: user
+    content: >
+      Construct a Strategic Product Cannibalization analysis based on the following intelligence:
+
+      <existing_product_portfolio>
+      {{existing_product_portfolio}}
+      </existing_product_portfolio>
+
+      <new_product_innovation>
+      {{new_product_innovation}}
+      </new_product_innovation>
+
+      <market_dynamics>
+      {{market_dynamics}}
+      </market_dynamics>
+testData:
+  - variables:
+      existing_product_portfolio: "Legacy on-premise enterprise software generating $500M ARR with 85% gross margins, but growth has stagnated at 2% YoY."
+      new_product_innovation: "A new cloud-native SaaS platform expected to scale rapidly, but with lower initial gross margins (60%) and a lower price point, potentially cannibalizing 40% of the legacy customer base within 3 years."
+      market_dynamics: "Competitors are rapidly launching cloud-native solutions. If we do not cannibalize our own install base, competitors will."
+evaluators:
+  - name: Contains NPV Equation
+    type: string_match
+    target: message.content
+    pattern: "NPV"
+  - name: Mentions 7S Framework
+    type: string_match
+    target: message.content
+    pattern: "McKinsey"


### PR DESCRIPTION
Add a new expert-level prompt for strategic product cannibalization, filling a void in the business strategy domain. Includes NPV thresholding, McKinsey 7S framework usage, tests, and documentation.

---
*PR created automatically by Jules for task [2289338790111927114](https://jules.google.com/task/2289338790111927114) started by @fderuiter*