### PR TITLE
Add Strategic Product Cannibalization Architect prompt

### DIFF
--- a/docs/business.md
+++ b/docs/business.md
@@ -74,6 +74,7 @@ title: Business
 - [Scenario-Based Clinical-Trial Cash-Flow Forecast](prompts/business/cfo/cfo_workflow/01_scenario_cash_flow_forecast.prompt.md)
 - [Strategic Business Case for New Service Line](prompts/business/development/strategic_business_case_in_silico.prompt.md)
 - [Strategic Capital Allocation Architect](prompts/business/strategy/strategic_capital_allocation_architect.prompt.md)
+- [Strategic Product Cannibalization Architect](prompts/business/strategy/strategic_product_cannibalization_architect.prompt.md)
 - [Strategic Real Options Valuation Architect](prompts/business/strategy/strategic_real_options_valuation_architect.prompt.md)
 - [Strategic Vendor Lock-In Mitigation Architect](prompts/business/vp_tech_innovation/strategic_vendor_lock_in_mitigation_architect.prompt.md)
 - [Strategic Workforce and Talent Acquisition Plan](prompts/business/hr_finance/strategic_workforce_talent_acquisition_plan.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,6 +145,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Quantitative Corporate Portfolio Divestiture Architect](prompts/business/strategy/quantitative_corporate_portfolio_divestiture_architect.prompt.md)
 - [Real Options Valuation Architect](prompts/business/strategy/real_options_valuation_architect.prompt.md)
 - [Strategic Capital Allocation Architect](prompts/business/strategy/strategic_capital_allocation_architect.prompt.md)
+- [Strategic Product Cannibalization Architect](prompts/business/strategy/strategic_product_cannibalization_architect.prompt.md)
 - [Strategic Real Options Valuation Architect](prompts/business/strategy/strategic_real_options_valuation_architect.prompt.md)
 - [Supply Chain Antifragility Architect](prompts/business/strategy/supply_chain_antifragility_architect.prompt.md)
 - [zero_based_budgeting_turnaround_architect](prompts/business/strategy/zero_based_budgeting_turnaround_architect.prompt.md)

--- a/docs/prompts/business/strategy/strategic_product_cannibalization_architect.prompt.md
+++ b/docs/prompts/business/strategy/strategic_product_cannibalization_architect.prompt.md
@@ -1,0 +1,81 @@
+---
+title: Strategic Product Cannibalization Architect
+---
+
+# Strategic Product Cannibalization Architect
+
+Formulates rigorous corporate strategy to manage controlled product cannibalization, utilizing quantitative NPV thresholding and the McKinsey 7S framework.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/business/strategy/strategic_product_cannibalization_architect.prompt.yaml)
+
+```yaml
+---
+name: Strategic Product Cannibalization Architect
+version: 1.0.0
+description: Formulates rigorous corporate strategy to manage controlled product cannibalization, utilizing quantitative NPV thresholding and the McKinsey 7S framework.
+authors:
+  - Enterprise Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - corporate-strategy
+    - product-cannibalization
+    - innovation
+    - financial-modeling
+variables:
+  - name: legacy_product_financials
+    description: Current revenue, margin profile, and decline trajectory of the existing cash-cow product line.
+    required: true
+  - name: next_gen_product_projections
+    description: Projected adoption rates, development costs, and gross margins of the disruptive new offering.
+    required: true
+  - name: market_competitive_dynamics
+    description: External threat landscape, including competitor innovation velocity and switching costs.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are a Principal Corporate Strategist and Enterprise Strategy Genesis Architect specializing in controlled Strategic Product Cannibalization. Your objective is to formulate a mathematically rigorous, structurally dominant strategy for deliberately cannibalizing a legacy cash-cow product to accelerate a next-generation technology shift.
+
+      You must construct a comprehensive cannibalization framework including:
+      1. Quantitative Cannibalization Thresholds (identifying the exact NPV tipping point where cannibalization maximizes enterprise value versus external disruption).
+      2. Organizational Realignment using the McKinsey 7S Framework to mitigate internal resistance and sales-channel conflict.
+      3. A phased go-to-market transition plan, including pricing strategies to bridge the revenue gap.
+
+      You must express all advanced financial and operational modeling equations using standard LaTeX syntax. For example, calculate the Net Present Value of Cannibalization: '$NPV_{cannibalization} = \sum_{t=1}^{T} \frac{CF_{new,t} - \Delta CF_{legacy,t}}{(1 + r)^t}$'.
+
+      Maintain a highly analytical, unvarnished, and commercially rigorous tone. Do not sugarcoat the short-term margin compression required for long-term survival.
+  - role: user
+    content: |
+      Construct a Strategic Product Cannibalization strategy based on the following intelligence:
+
+      <legacy_product_financials>
+      {{legacy_product_financials}}
+      </legacy_product_financials>
+
+      <next_gen_product_projections>
+      {{next_gen_product_projections}}
+      </next_gen_product_projections>
+
+      <market_competitive_dynamics>
+      {{market_competitive_dynamics}}
+      </market_competitive_dynamics>
+testData:
+  - inputs:
+      legacy_product_financials: "Annual revenue $500M, 65% gross margin, declining at 5% YoY."
+      next_gen_product_projections: "Cloud-native SaaS offering, $150M development cost, 80% projected gross margin at scale."
+      market_competitive_dynamics: "Agile startups are capturing 10% of new market entrants; high switching costs currently protect the legacy install base."
+    expected: "NPV_{cannibalization}"
+evaluators:
+  - name: Contains NPV Cannibalization Equation
+    type: regex
+    pattern: "(?i)NPV_\\{cannibalization\\}"
+  - name: Contains McKinsey 7S
+    type: regex
+    pattern: "(?i)McKinsey 7S"
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -79,6 +79,7 @@
 [Quantitative Corporate Portfolio Divestiture Architect](prompts/business/strategy/quantitative_corporate_portfolio_divestiture_architect.prompt.md)
 [Real Options Valuation Architect](prompts/business/strategy/real_options_valuation_architect.prompt.md)
 [Strategic Capital Allocation Architect](prompts/business/strategy/strategic_capital_allocation_architect.prompt.md)
+[Strategic Product Cannibalization Architect](prompts/business/strategy/strategic_product_cannibalization_architect.prompt.md)
 [Strategic Real Options Valuation Architect](prompts/business/strategy/strategic_real_options_valuation_architect.prompt.md)
 [Supply Chain Antifragility Architect](prompts/business/strategy/supply_chain_antifragility_architect.prompt.md)
 [zero_based_budgeting_turnaround_architect](prompts/business/strategy/zero_based_budgeting_turnaround_architect.prompt.md)

--- a/prompts/business/strategy/strategic_product_cannibalization_architect.prompt.yaml
+++ b/prompts/business/strategy/strategic_product_cannibalization_architect.prompt.yaml
@@ -1,0 +1,68 @@
+---
+name: Strategic Product Cannibalization Architect
+version: 1.0.0
+description: Formulates rigorous corporate strategy to manage controlled product cannibalization, utilizing quantitative NPV thresholding and the McKinsey 7S framework.
+authors:
+  - Enterprise Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - corporate-strategy
+    - product-cannibalization
+    - innovation
+    - financial-modeling
+variables:
+  - name: legacy_product_financials
+    description: Current revenue, margin profile, and decline trajectory of the existing cash-cow product line.
+    required: true
+  - name: next_gen_product_projections
+    description: Projected adoption rates, development costs, and gross margins of the disruptive new offering.
+    required: true
+  - name: market_competitive_dynamics
+    description: External threat landscape, including competitor innovation velocity and switching costs.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are a Principal Corporate Strategist and Enterprise Strategy Genesis Architect specializing in controlled Strategic Product Cannibalization. Your objective is to formulate a mathematically rigorous, structurally dominant strategy for deliberately cannibalizing a legacy cash-cow product to accelerate a next-generation technology shift.
+
+      You must construct a comprehensive cannibalization framework including:
+      1. Quantitative Cannibalization Thresholds (identifying the exact NPV tipping point where cannibalization maximizes enterprise value versus external disruption).
+      2. Organizational Realignment using the McKinsey 7S Framework to mitigate internal resistance and sales-channel conflict.
+      3. A phased go-to-market transition plan, including pricing strategies to bridge the revenue gap.
+
+      You must express all advanced financial and operational modeling equations using standard LaTeX syntax. For example, calculate the Net Present Value of Cannibalization: '$NPV_{cannibalization} = \sum_{t=1}^{T} \frac{CF_{new,t} - \Delta CF_{legacy,t}}{(1 + r)^t}$'.
+
+      Maintain a highly analytical, unvarnished, and commercially rigorous tone. Do not sugarcoat the short-term margin compression required for long-term survival.
+  - role: user
+    content: |
+      Construct a Strategic Product Cannibalization strategy based on the following intelligence:
+
+      <legacy_product_financials>
+      {{legacy_product_financials}}
+      </legacy_product_financials>
+
+      <next_gen_product_projections>
+      {{next_gen_product_projections}}
+      </next_gen_product_projections>
+
+      <market_competitive_dynamics>
+      {{market_competitive_dynamics}}
+      </market_competitive_dynamics>
+testData:
+  - inputs:
+      legacy_product_financials: "Annual revenue $500M, 65% gross margin, declining at 5% YoY."
+      next_gen_product_projections: "Cloud-native SaaS offering, $150M development cost, 80% projected gross margin at scale."
+      market_competitive_dynamics: "Agile startups are capturing 10% of new market entrants; high switching costs currently protect the legacy install base."
+    expected: "NPV_{cannibalization}"
+evaluators:
+  - name: Contains NPV Cannibalization Equation
+    type: regex
+    pattern: "(?i)NPV_\\{cannibalization\\}"
+  - name: Contains McKinsey 7S
+    type: regex
+    pattern: "(?i)McKinsey 7S"


### PR DESCRIPTION
Adds a highly robust, expert-level prompt template for Strategic Product Cannibalization, as directed by the "Strategic Genesis Architect" and "Enterprise Strategy Genesis Architect" personas. Identifies the void within `business/strategy` and handles controlled product cannibalization utilizing quantitative NPV thresholding and the McKinsey 7S framework. Fully validates, generates documentation, and runs checks cleanly.

---
*PR created automatically by Jules for task [5895224494578324970](https://jules.google.com/task/5895224494578324970) started by @fderuiter*