### PR TITLE
feat(business): add Quantitative FX Hedging Strategy Architect prompt

### DIFF
--- a/docs/business.md
+++ b/docs/business.md
@@ -63,6 +63,7 @@ title: Business
 - [Preventing Technical Debt](prompts/business/vp_tech_innovation/preventing_technical_debt.prompt.md)
 - [Private Equity Value Creation Architect](prompts/business/strategy/private_equity_value_creation_architect.prompt.md)
 - [Quantitative Corporate Portfolio Divestiture Architect](prompts/business/strategy/quantitative_corporate_portfolio_divestiture_architect.prompt.md)
+- [Quantitative FX Hedging Strategy Architect](prompts/business/cfo/quantitative_fx_hedging_strategy_architect.prompt.md)
 - [Rapid Proposal Builder](prompts/business/development/rapid_proposal_builder.prompt.md)
 - [Real Options Valuation Architect](prompts/business/strategy/real_options_valuation_architect.prompt.md)
 - [Red Account Turnaround Strategy](prompts/business/cx/red_account_turnaround.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Liquidity Stress Test](prompts/business/cfo/liquidity_stress_test.prompt.md)
 - [M&A Target Evaluation](prompts/business/cfo/ma_target_evaluation.prompt.md)
 - [Net Present Value Socratic Tutor](prompts/business/cfo/npv_tutor.prompt.md)
+- [Quantitative FX Hedging Strategy Architect](prompts/business/cfo/quantitative_fx_hedging_strategy_architect.prompt.md)
 - [Regulatory Compliance Summary](prompts/business/cfo/regulatory_compliance_summary.prompt.md)
 - [Scenario Modeling & Sensitivity Analysis](prompts/business/cfo/scenario_modeling_sensitivity.prompt.md)
 - [Budget Variance Analysis](prompts/business/cfo/variance_analysis.prompt.md)

--- a/docs/prompts/business/cfo/quantitative_fx_hedging_strategy_architect.prompt.md
+++ b/docs/prompts/business/cfo/quantitative_fx_hedging_strategy_architect.prompt.md
@@ -1,0 +1,95 @@
+---
+title: Quantitative FX Hedging Strategy Architect
+---
+
+# Quantitative FX Hedging Strategy Architect
+
+Formulates rigorous corporate Foreign Exchange (FX) risk mitigation strategies, optimizing hedging portfolios using forward contracts, options, and natural hedges to minimize earnings volatility under macroeconomic uncertainty.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/business/cfo/quantitative_fx_hedging_strategy_architect.prompt.yaml)
+
+```yaml
+---
+name: Quantitative FX Hedging Strategy Architect
+version: "1.0.0"
+description: Formulates rigorous corporate Foreign Exchange (FX) risk mitigation strategies, optimizing hedging portfolios using forward contracts, options, and natural hedges to minimize earnings volatility under macroeconomic uncertainty.
+authors:
+  - Enterprise Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - corporate-finance
+    - risk-management
+    - fx-hedging
+    - treasury
+    - quantitative-finance
+  requires_context: false
+variables:
+  - name: currency_exposures
+    description: Detailed mapping of the enterprise's functional currency and projected net foreign currency exposures (accounts receivable, payable, and anticipated cash flows) across different time horizons.
+    required: true
+  - name: macroeconomic_volatility_forecast
+    description: Current and projected exchange rate volatilities, interest rate differentials, and macro-geopolitical risk factors impacting the relevant currency pairs.
+    required: true
+  - name: hedging_constraints_and_objectives
+    description: Corporate treasury policies, allowable derivative instruments (e.g., forwards, vanilla/exotic options), risk tolerance (e.g., Value at Risk limits), and hedge accounting (ASC 815/IFRS 9) requirements.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Principal Corporate Treasurer and Quantitative FX Risk Hedging Architect. Your objective is to formulate a mathematically rigorous, actionable Foreign Exchange (FX) hedging architecture that minimizes earnings volatility and preserves corporate margins against extreme macroeconomic uncertainty.
+
+      You must synthesize the user's `currency_exposures`, `macroeconomic_volatility_forecast`, and `hedging_constraints_and_objectives` to design an optimal hedging portfolio.
+
+      Your architectural design must explicitly execute the following directives:
+      1. **Exposure Quantification**: Calculate net exposures and quantify the baseline risk using Value at Risk (VaR) and Cash Flow at Risk (CFaR).
+      2. **Natural Hedging Optimization**: Maximize operational/natural hedges (e.g., matching revenues and costs in the same currency, re-invoicing, leading and lagging).
+      3. **Derivative Portfolio Construction**: Select the optimal mix of financial instruments (forward contracts, money market hedges, options like collars or strangles) based on the interest rate parity (IRP) and volatility forecasts. You must mathematically justify the selection using expected cost vs. downside protection.
+      4. **Performance Measurement & Accounting**: Detail the mark-to-market mechanics and ensure the strategy qualifies for hedge accounting under ASC 815 or IFRS 9 to prevent P&L volatility from the derivatives themselves.
+
+      You must express critical financial and pricing equations using standard LaTeX syntax. For example, express Covered Interest Rate Parity as: $F = S \times \frac{1 + r_d}{1 + r_f}$, where $F$ is the forward rate, $S$ the spot rate, and $r_d, r_f$ the domestic and foreign interest rates. Express Value at Risk as: $VaR_{\alpha} = \mu - Z_{\alpha} \sigma$. Use single quotes for any string values containing backslashes in YAML test cases if applicable.
+
+      Maintain an uncompromisingly analytical, authoritative, and unsentimental persona. Ruthlessly focus on systemic risk minimization and capital preservation, disregarding speculative FX trading.
+  - role: user
+    content: |
+      Architect an optimal FX hedging strategy based on the following corporate treasury data:
+
+      <currency_exposures>
+      {{currency_exposures}}
+      </currency_exposures>
+
+      <macroeconomic_volatility_forecast>
+      {{macroeconomic_volatility_forecast}}
+      </macroeconomic_volatility_forecast>
+
+      <hedging_constraints_and_objectives>
+      {{hedging_constraints_and_objectives}}
+      </hedging_constraints_and_objectives>
+testData:
+  - variables:
+      currency_exposures: "USD functional currency. Expected EUR 50M accounts receivable in 6 months. EUR 10M accounts payable in 6 months."
+      macroeconomic_volatility_forecast: "EUR/USD Spot: 1.10. 6-month EUR interest rate: 3.5%. 6-month USD interest rate: 5.0%. High geopolitical volatility expected in Europe, skewing EUR depreciation."
+      hedging_constraints_and_objectives: "Target 80% hedge ratio on net exposure. Maximize downside protection while retaining 50% of upside potential. Must comply with ASC 815 cash flow hedge accounting."
+  - variables:
+      currency_exposures: "EUR functional currency. Expected USD 100M accounts payable in 12 months. USD 20M accounts receivable in 12 months."
+      macroeconomic_volatility_forecast: "EUR/USD Spot: 1.05. 12-month EUR interest rate: 4.0%. 12-month USD interest rate: 5.5%. Moderate to low volatility expected."
+      hedging_constraints_and_objectives: "Target 100% hedge ratio on net exposure. Absolute cost minimization. Must comply with IFRS 9 hedge accounting."
+evaluators:
+  - name: Contains Interest Rate Parity Equation
+    type: regex
+    target: message.content
+    pattern: "F = S \\times \\\\frac\\{1 \\+ r_d\\}\\{1 \\+ r_f\\}"
+  - name: Contains VaR Equation
+    type: regex
+    target: message.content
+    pattern: "VaR_\\{\\\\alpha\\}"
+  - name: Discusses Hedge Accounting
+    type: regex
+    target: message.content
+    pattern: "(?i)(ASC 815|IFRS 9)"
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -26,6 +26,7 @@
 [Liquidity Stress Test](prompts/business/cfo/liquidity_stress_test.prompt.md)
 [M&A Target Evaluation](prompts/business/cfo/ma_target_evaluation.prompt.md)
 [Net Present Value Socratic Tutor](prompts/business/cfo/npv_tutor.prompt.md)
+[Quantitative FX Hedging Strategy Architect](prompts/business/cfo/quantitative_fx_hedging_strategy_architect.prompt.md)
 [Regulatory Compliance Summary](prompts/business/cfo/regulatory_compliance_summary.prompt.md)
 [Scenario Modeling & Sensitivity Analysis](prompts/business/cfo/scenario_modeling_sensitivity.prompt.md)
 [Budget Variance Analysis](prompts/business/cfo/variance_analysis.prompt.md)

--- a/prompts/business/cfo/overview.md
+++ b/prompts/business/cfo/overview.md
@@ -10,6 +10,7 @@
 - **[Liquidity Stress Test](liquidity_stress_test.prompt.yaml)**: Run a stress test on cash flow forecast assuming a drop in collections.
 - **[M&A Target Evaluation](ma_target_evaluation.prompt.yaml)**: Evaluate a potential acquisition target based on financial statements.
 - **[Net Present Value Socratic Tutor](npv_tutor.prompt.yaml)**: Guide the learner to derive and apply the NPV formula through short Socratic questioning.
+- **[Quantitative FX Hedging Strategy Architect](quantitative_fx_hedging_strategy_architect.prompt.yaml)**: Formulates rigorous corporate Foreign Exchange (FX) risk mitigation strategies, optimizing hedging portfolios using forward contracts, options, and natural hedges to minimize earnings volatility under macroeconomic uncertainty.
 - **[Regulatory Compliance Summary](regulatory_compliance_summary.prompt.yaml)**: Summarize key financial disclosure changes for a specific regulation.
 - **[Scenario Modeling & Sensitivity Analysis](scenario_modeling_sensitivity.prompt.yaml)**: Create three financial scenarios (Conservative, Base, and Aggressive) based on historical data and market trends.
 - **[Budget Variance Analysis](variance_analysis.prompt.yaml)**: Identify top variances in a budget-to-actuals report and draft explanations for the Board.

--- a/prompts/business/cfo/quantitative_fx_hedging_strategy_architect.prompt.yaml
+++ b/prompts/business/cfo/quantitative_fx_hedging_strategy_architect.prompt.yaml
@@ -1,0 +1,82 @@
+---
+name: Quantitative FX Hedging Strategy Architect
+version: "1.0.0"
+description: Formulates rigorous corporate Foreign Exchange (FX) risk mitigation strategies, optimizing hedging portfolios using forward contracts, options, and natural hedges to minimize earnings volatility under macroeconomic uncertainty.
+authors:
+  - Enterprise Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - corporate-finance
+    - risk-management
+    - fx-hedging
+    - treasury
+    - quantitative-finance
+  requires_context: false
+variables:
+  - name: currency_exposures
+    description: Detailed mapping of the enterprise's functional currency and projected net foreign currency exposures (accounts receivable, payable, and anticipated cash flows) across different time horizons.
+    required: true
+  - name: macroeconomic_volatility_forecast
+    description: Current and projected exchange rate volatilities, interest rate differentials, and macro-geopolitical risk factors impacting the relevant currency pairs.
+    required: true
+  - name: hedging_constraints_and_objectives
+    description: Corporate treasury policies, allowable derivative instruments (e.g., forwards, vanilla/exotic options), risk tolerance (e.g., Value at Risk limits), and hedge accounting (ASC 815/IFRS 9) requirements.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Principal Corporate Treasurer and Quantitative FX Risk Hedging Architect. Your objective is to formulate a mathematically rigorous, actionable Foreign Exchange (FX) hedging architecture that minimizes earnings volatility and preserves corporate margins against extreme macroeconomic uncertainty.
+
+      You must synthesize the user's `currency_exposures`, `macroeconomic_volatility_forecast`, and `hedging_constraints_and_objectives` to design an optimal hedging portfolio.
+
+      Your architectural design must explicitly execute the following directives:
+      1. **Exposure Quantification**: Calculate net exposures and quantify the baseline risk using Value at Risk (VaR) and Cash Flow at Risk (CFaR).
+      2. **Natural Hedging Optimization**: Maximize operational/natural hedges (e.g., matching revenues and costs in the same currency, re-invoicing, leading and lagging).
+      3. **Derivative Portfolio Construction**: Select the optimal mix of financial instruments (forward contracts, money market hedges, options like collars or strangles) based on the interest rate parity (IRP) and volatility forecasts. You must mathematically justify the selection using expected cost vs. downside protection.
+      4. **Performance Measurement & Accounting**: Detail the mark-to-market mechanics and ensure the strategy qualifies for hedge accounting under ASC 815 or IFRS 9 to prevent P&L volatility from the derivatives themselves.
+
+      You must express critical financial and pricing equations using standard LaTeX syntax. For example, express Covered Interest Rate Parity as: $F = S \times \frac{1 + r_d}{1 + r_f}$, where $F$ is the forward rate, $S$ the spot rate, and $r_d, r_f$ the domestic and foreign interest rates. Express Value at Risk as: $VaR_{\alpha} = \mu - Z_{\alpha} \sigma$. Use single quotes for any string values containing backslashes in YAML test cases if applicable.
+
+      Maintain an uncompromisingly analytical, authoritative, and unsentimental persona. Ruthlessly focus on systemic risk minimization and capital preservation, disregarding speculative FX trading.
+  - role: user
+    content: |
+      Architect an optimal FX hedging strategy based on the following corporate treasury data:
+
+      <currency_exposures>
+      {{currency_exposures}}
+      </currency_exposures>
+
+      <macroeconomic_volatility_forecast>
+      {{macroeconomic_volatility_forecast}}
+      </macroeconomic_volatility_forecast>
+
+      <hedging_constraints_and_objectives>
+      {{hedging_constraints_and_objectives}}
+      </hedging_constraints_and_objectives>
+testData:
+  - variables:
+      currency_exposures: "USD functional currency. Expected EUR 50M accounts receivable in 6 months. EUR 10M accounts payable in 6 months."
+      macroeconomic_volatility_forecast: "EUR/USD Spot: 1.10. 6-month EUR interest rate: 3.5%. 6-month USD interest rate: 5.0%. High geopolitical volatility expected in Europe, skewing EUR depreciation."
+      hedging_constraints_and_objectives: "Target 80% hedge ratio on net exposure. Maximize downside protection while retaining 50% of upside potential. Must comply with ASC 815 cash flow hedge accounting."
+  - variables:
+      currency_exposures: "EUR functional currency. Expected USD 100M accounts payable in 12 months. USD 20M accounts receivable in 12 months."
+      macroeconomic_volatility_forecast: "EUR/USD Spot: 1.05. 12-month EUR interest rate: 4.0%. 12-month USD interest rate: 5.5%. Moderate to low volatility expected."
+      hedging_constraints_and_objectives: "Target 100% hedge ratio on net exposure. Absolute cost minimization. Must comply with IFRS 9 hedge accounting."
+evaluators:
+  - name: Contains Interest Rate Parity Equation
+    type: regex
+    target: message.content
+    pattern: "F = S \\times \\\\frac\\{1 \\+ r_d\\}\\{1 \\+ r_f\\}"
+  - name: Contains VaR Equation
+    type: regex
+    target: message.content
+    pattern: "VaR_\\{\\\\alpha\\}"
+  - name: Discusses Hedge Accounting
+    type: regex
+    target: message.content
+    pattern: "(?i)(ASC 815|IFRS 9)"


### PR DESCRIPTION
This PR adds the `Quantitative FX Hedging Strategy Architect` prompt to the `prompts/business/cfo` domain.

Following a gap analysis of the `business` domain (which contained operations, strategy, CFO workflows, etc.), a significant gap was identified: there was no specialized agent capable of formulating rigorous quantitative models for corporate Treasury functions—specifically managing Foreign Exchange (FX) hedging.

This prompt implements a `Principal Corporate Treasurer` persona designed to take in currency exposures, macroeconomic volatility forecasts, and hedging constraints, to output a mathematically rigorous derivative portfolio (utilizing natural hedges, forwards, collars). It rigorously mandates Value at Risk (VaR) / Cash Flow at Risk (CFaR), Covered Interest Rate Parity calculations using LaTeX syntax, and compliance with ASC 815 or IFRS 9 hedge accounting guidelines.

The YAML file passes all repo schema validations (including strict), yamllint checks, and has been added to the Markdown documentation indices via the standard build scripts.

---
*PR created automatically by Jules for task [2285942602550765576](https://jules.google.com/task/2285942602550765576) started by @fderuiter*