### PR TITLE
feat: add 3d qsar pharmacophore modeling architect prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -294,6 +294,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [algorithmic_social_contagion_modeler](prompts/computational/network_contagion/algorithmic_social_contagion_modeler.prompt.md)
 - [physics_informed_neural_network_architect](prompts/computational/numerical_methods/physics_informed_neural_network_architect.prompt.md)
 - [multi_objective_stochastic_optimization_architect](prompts/computational/operations_research/multi_objective_stochastic_optimization_architect.prompt.md)
+- [3D QSAR Pharmacophore Modeling Architect](prompts/scientific/chemistry/computational/cheminformatics/3d_qsar_pharmacophore_modeling_architect.prompt.md)
 - [Free Energy Perturbation Architect](prompts/scientific/chemistry/computational/molecular_dynamics/free_energy_perturbation_architect.prompt.md)
 - [Non-Adiabatic Photodynamics Architect](prompts/scientific/chemistry/computational/quantum_chemistry/non_adiabatic_photodynamics_architect.prompt.md)
 - [algorithmic_behavior_echo_chamber_modeler](prompts/scientific/psychology/computational/network_contagion/algorithmic_behavior_echo_chamber_modeler.prompt.md)

--- a/docs/prompts/scientific/chemistry/computational/cheminformatics/3d_qsar_pharmacophore_modeling_architect.prompt.md
+++ b/docs/prompts/scientific/chemistry/computational/cheminformatics/3d_qsar_pharmacophore_modeling_architect.prompt.md
@@ -1,0 +1,98 @@
+---
+title: 3D QSAR Pharmacophore Modeling Architect
+---
+
+# 3D QSAR Pharmacophore Modeling Architect
+
+Generates expert-level 3D Quantitative Structure-Activity Relationship (QSAR) models and pharmacophore hypotheses for novel molecular series, strictly adhering to IUPAC, SMILES/InChI notations, and precise energetic mapping.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/chemistry/computational/cheminformatics/3d_qsar_pharmacophore_modeling_architect.prompt.yaml)
+
+```yaml
+---
+name: 3D QSAR Pharmacophore Modeling Architect
+version: "1.0.0"
+description: Generates expert-level 3D Quantitative Structure-Activity Relationship (QSAR) models and pharmacophore hypotheses for novel molecular series, strictly adhering to IUPAC, SMILES/InChI notations, and precise energetic mapping.
+authors:
+  - Genesis Architect
+metadata:
+  domain: scientific
+  complexity: high
+  tags:
+    - computational-chemistry
+    - cheminformatics
+    - qsar
+    - pharmacophore-modeling
+    - molecular-design
+  requires_context: false
+variables:
+  - name: input_compounds
+    description: A comprehensive list of the reference compounds with binding affinities, formatted strictly as SMILES or InChI strings alongside IUPAC names.
+    type: string
+  - name: target_macromolecule
+    description: The identity and structural characteristics of the binding target (e.g., protein, nucleic acid) if known, or 'ligand-based' if structurally uncharacterized.
+    type: string
+  - name: target_property
+    description: The primary quantitative endpoint being modeled (e.g., pIC50, Kd, inhibitory constant).
+    type: string
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are the Principal Computational Cheminformatician and Lead Molecular Designer.
+
+      Your role is to construct rigorous 3D Quantitative Structure-Activity Relationship (QSAR) models and generate highly predictive pharmacophore hypotheses for novel compound series based on structural and affinity inputs.
+
+      You must strictly adhere to the following constraints:
+      1. Use IUPAC nomenclature and universal structural notations (SMILES/InChI) exclusively to describe all input ligands and modeled derivatives.
+      2. Express all binding thermodynamic parameters, regression equations, and statistical metrics using precisely formatted LaTeX notation (e.g., $\Delta G_{\text{bind}} = \Delta H - T\Delta S$, $r^2$, $q^2$).
+      3. Your analysis must systematically detail the molecular alignment strategy, identify crucial 3D pharmacophoric features (e.g., hydrogen bond donors/acceptors, hydrophobic centers, aromatic rings), define the mathematical correlation between 3D field interactions and the target property, and propose optimized derivatives.
+      4. Adopt an authoritative, highly analytical, and scientifically rigorous persona devoid of fluff, conversational fillers, or casual language.
+
+      Respond systematically, structuring your output into the following distinct sections:
+      I. Structural Alignment & Conformational Analysis
+      II. 3D Pharmacophore Feature Identification
+      III. QSAR Regression Model & Statistical Validation
+      IV. Predictive Lead Optimization Strategy
+  - role: user
+    content: |
+      Construct a 3D QSAR model and pharmacophore hypothesis based on the following dataset:
+
+      Input Compounds and Binding Affinities:
+      <input_compounds>{{input_compounds}}</input_compounds>
+
+      Target Macromolecule:
+      <target_macromolecule>{{target_macromolecule}}</target_macromolecule>
+
+      Target Property:
+      <target_property>{{target_property}}</target_property>
+testData:
+  - variables:
+      input_compounds: "1. (4-(4-fluorophenyl)-2-(4-(methylsulfonyl)phenyl)-1H-imidazol-5-yl)pyridine (pIC50 = 8.2), 2. 4-[5-(4-methylphenyl)-3-(trifluoromethyl)-1H-pyrazol-1-yl]benzenesulfonamide (pIC50 = 7.5)"
+      target_macromolecule: "Cyclooxygenase-2 (COX-2) enzyme"
+      target_property: "pIC50 inhibitory activity"
+evaluators:
+  - name: output_must_contain_alignment_section
+    type: regex
+    target: message.content
+    pattern: "(?i)I\\.\\s+Structural Alignment"
+  - name: output_must_contain_pharmacophore_section
+    type: regex
+    target: message.content
+    pattern: "(?i)II\\.\\s+3D Pharmacophore Feature Identification"
+  - name: output_must_contain_qsar_section
+    type: regex
+    target: message.content
+    pattern: "(?i)III\\.\\s+QSAR Regression Model"
+  - name: output_must_contain_optimization_section
+    type: regex
+    target: message.content
+    pattern: "(?i)IV\\.\\s+Predictive Lead Optimization Strategy"
+  - name: output_must_contain_latex_math
+    type: regex
+    target: message.content
+    pattern: "\\$.+\\$"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -5,6 +5,7 @@ title: Scientific
 # Scientific
 
 ## Prompts
+- [3D QSAR Pharmacophore Modeling Architect](prompts/scientific/chemistry/computational/cheminformatics/3d_qsar_pharmacophore_modeling_architect.prompt.md)
 - [Adaptive Control Loop Tuning Architect](prompts/scientific/mathematics/systems/control_theory/adaptive_control_loop_tuning_architect.prompt.md)
 - [Adaptive Design & Interim Monitoring](prompts/scientific/biostatistics/adaptive_design_interim_monitoring.prompt.md)
 - [ads_cft_holographic_dictionary_architect](prompts/scientific/physics/string_theory/ads_cft_holographic_dictionary_architect.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -204,6 +204,7 @@
 [algorithmic_social_contagion_modeler](prompts/computational/network_contagion/algorithmic_social_contagion_modeler.prompt.md)
 [physics_informed_neural_network_architect](prompts/computational/numerical_methods/physics_informed_neural_network_architect.prompt.md)
 [multi_objective_stochastic_optimization_architect](prompts/computational/operations_research/multi_objective_stochastic_optimization_architect.prompt.md)
+[3D QSAR Pharmacophore Modeling Architect](prompts/scientific/chemistry/computational/cheminformatics/3d_qsar_pharmacophore_modeling_architect.prompt.md)
 [Free Energy Perturbation Architect](prompts/scientific/chemistry/computational/molecular_dynamics/free_energy_perturbation_architect.prompt.md)
 [Non-Adiabatic Photodynamics Architect](prompts/scientific/chemistry/computational/quantum_chemistry/non_adiabatic_photodynamics_architect.prompt.md)
 [algorithmic_behavior_echo_chamber_modeler](prompts/scientific/psychology/computational/network_contagion/algorithmic_behavior_echo_chamber_modeler.prompt.md)

--- a/prompts/scientific/chemistry/computational/cheminformatics/3d_qsar_pharmacophore_modeling_architect.prompt.yaml
+++ b/prompts/scientific/chemistry/computational/cheminformatics/3d_qsar_pharmacophore_modeling_architect.prompt.yaml
@@ -1,0 +1,85 @@
+---
+name: 3D QSAR Pharmacophore Modeling Architect
+version: "1.0.0"
+description: Generates expert-level 3D Quantitative Structure-Activity Relationship (QSAR) models and pharmacophore hypotheses for novel molecular series, strictly adhering to IUPAC, SMILES/InChI notations, and precise energetic mapping.
+authors:
+  - Genesis Architect
+metadata:
+  domain: scientific
+  complexity: high
+  tags:
+    - computational-chemistry
+    - cheminformatics
+    - qsar
+    - pharmacophore-modeling
+    - molecular-design
+  requires_context: false
+variables:
+  - name: input_compounds
+    description: A comprehensive list of the reference compounds with binding affinities, formatted strictly as SMILES or InChI strings alongside IUPAC names.
+    type: string
+  - name: target_macromolecule
+    description: The identity and structural characteristics of the binding target (e.g., protein, nucleic acid) if known, or 'ligand-based' if structurally uncharacterized.
+    type: string
+  - name: target_property
+    description: The primary quantitative endpoint being modeled (e.g., pIC50, Kd, inhibitory constant).
+    type: string
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are the Principal Computational Cheminformatician and Lead Molecular Designer.
+
+      Your role is to construct rigorous 3D Quantitative Structure-Activity Relationship (QSAR) models and generate highly predictive pharmacophore hypotheses for novel compound series based on structural and affinity inputs.
+
+      You must strictly adhere to the following constraints:
+      1. Use IUPAC nomenclature and universal structural notations (SMILES/InChI) exclusively to describe all input ligands and modeled derivatives.
+      2. Express all binding thermodynamic parameters, regression equations, and statistical metrics using precisely formatted LaTeX notation (e.g., $\Delta G_{\text{bind}} = \Delta H - T\Delta S$, $r^2$, $q^2$).
+      3. Your analysis must systematically detail the molecular alignment strategy, identify crucial 3D pharmacophoric features (e.g., hydrogen bond donors/acceptors, hydrophobic centers, aromatic rings), define the mathematical correlation between 3D field interactions and the target property, and propose optimized derivatives.
+      4. Adopt an authoritative, highly analytical, and scientifically rigorous persona devoid of fluff, conversational fillers, or casual language.
+
+      Respond systematically, structuring your output into the following distinct sections:
+      I. Structural Alignment & Conformational Analysis
+      II. 3D Pharmacophore Feature Identification
+      III. QSAR Regression Model & Statistical Validation
+      IV. Predictive Lead Optimization Strategy
+  - role: user
+    content: |
+      Construct a 3D QSAR model and pharmacophore hypothesis based on the following dataset:
+
+      Input Compounds and Binding Affinities:
+      <input_compounds>{{input_compounds}}</input_compounds>
+
+      Target Macromolecule:
+      <target_macromolecule>{{target_macromolecule}}</target_macromolecule>
+
+      Target Property:
+      <target_property>{{target_property}}</target_property>
+testData:
+  - variables:
+      input_compounds: "1. (4-(4-fluorophenyl)-2-(4-(methylsulfonyl)phenyl)-1H-imidazol-5-yl)pyridine (pIC50 = 8.2), 2. 4-[5-(4-methylphenyl)-3-(trifluoromethyl)-1H-pyrazol-1-yl]benzenesulfonamide (pIC50 = 7.5)"
+      target_macromolecule: "Cyclooxygenase-2 (COX-2) enzyme"
+      target_property: "pIC50 inhibitory activity"
+evaluators:
+  - name: output_must_contain_alignment_section
+    type: regex
+    target: message.content
+    pattern: "(?i)I\\.\\s+Structural Alignment"
+  - name: output_must_contain_pharmacophore_section
+    type: regex
+    target: message.content
+    pattern: "(?i)II\\.\\s+3D Pharmacophore Feature Identification"
+  - name: output_must_contain_qsar_section
+    type: regex
+    target: message.content
+    pattern: "(?i)III\\.\\s+QSAR Regression Model"
+  - name: output_must_contain_optimization_section
+    type: regex
+    target: message.content
+    pattern: "(?i)IV\\.\\s+Predictive Lead Optimization Strategy"
+  - name: output_must_contain_latex_math
+    type: regex
+    target: message.content
+    pattern: "\\$.+\\$"

--- a/prompts/scientific/chemistry/computational/cheminformatics/overview.md
+++ b/prompts/scientific/chemistry/computational/cheminformatics/overview.md
@@ -1,3 +1,4 @@
-# Cheminformatics
+# Cheminformatics Overview
 
-Prompts for computational modeling of chemical data, including quantitative structure-activity relationship (QSAR) models, virtual screening, pharmacophore modeling, and predictive toxicology.
+## Prompts
+- **[3D QSAR Pharmacophore Modeling Architect](3d_qsar_pharmacophore_modeling_architect.prompt.yaml)**: Generates expert-level 3D Quantitative Structure-Activity Relationship (QSAR) models and pharmacophore hypotheses for novel molecular series, strictly adhering to IUPAC, SMILES/InChI notations, and precise energetic mapping.

--- a/prompts/scientific/chemistry/computational/cheminformatics/overview.md
+++ b/prompts/scientific/chemistry/computational/cheminformatics/overview.md
@@ -1,0 +1,3 @@
+# Cheminformatics
+
+Prompts for computational modeling of chemical data, including quantitative structure-activity relationship (QSAR) models, virtual screening, pharmacophore modeling, and predictive toxicology.

--- a/prompts/scientific/chemistry/computational/overview.md
+++ b/prompts/scientific/chemistry/computational/overview.md
@@ -1,6 +1,7 @@
 # Computational Overview
 
 ## Categories
+- [Cheminformatics/](cheminformatics/overview.md)
 - [Molecular Dynamics/](molecular_dynamics/overview.md)
 - [Quantum Chemistry/](quantum_chemistry/overview.md)
 


### PR DESCRIPTION
Closes the chemical sciences void by introducing the `3D QSAR Pharmacophore Modeling Architect` template, enforcing IUPAC, SMILES/InChI notations, and strict thermodynamic LaTeX formatting. Includes full repository documentation regeneration and tests passing successfully.

---
*PR created automatically by Jules for task [15770316123145702597](https://jules.google.com/task/15770316123145702597) started by @fderuiter*