### PR TITLE
feat: add ADM spacetime decomposition prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -865,6 +865,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 
 ## Relativity
 
+- [adm_spacetime_decomposition_architect](prompts/scientific/physics/relativity/general_relativity/adm_spacetime_decomposition_architect.prompt.md)
 - [Black Hole Perturbation Teukolsky Architect](prompts/scientific/physics/relativity/general_relativity/black_hole_perturbation_teukolsky_architect.prompt.md)
 
 ## Rtsm

--- a/docs/prompts/scientific/physics/relativity/general_relativity/adm_spacetime_decomposition_architect.prompt.md
+++ b/docs/prompts/scientific/physics/relativity/general_relativity/adm_spacetime_decomposition_architect.prompt.md
@@ -1,0 +1,77 @@
+---
+title: adm_spacetime_decomposition_architect
+---
+
+# adm_spacetime_decomposition_architect
+
+Conducts rigorous 3+1 Arnowitt-Deser-Misner (ADM) decomposition of spacetime metrics, extracting lapse, shift, and spatial metrics, and derives the associated Hamiltonian and momentum constraints.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/physics/relativity/general_relativity/adm_spacetime_decomposition_architect.prompt.yaml)
+
+```yaml
+---
+name: adm_spacetime_decomposition_architect
+version: 1.0.0
+description: Conducts rigorous 3+1 Arnowitt-Deser-Misner (ADM) decomposition of spacetime metrics, extracting lapse, shift, and spatial metrics, and derives the associated Hamiltonian and momentum constraints.
+authors:
+  - name: Theoretical Physics Genesis Architect
+metadata:
+  domain: scientific
+  complexity: high
+variables:
+  - name: spacetime_metric
+    description: The explicit mathematical form of the 4-dimensional Lorentzian metric tensor to be decomposed.
+    required: true
+  - name: foliation_parameter
+    description: The time coordinate or scalar field defining the spacelike hypersurfaces.
+    required: true
+  - name: gauge_condition
+    description: The specific gauge choices for the lapse function and shift vector (e.g., maximal slicing, zero shift).
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Lead Numerical Relativist and Tenured Professor of Theoretical Physics.
+      Your task is to analytically execute the rigorous 3+1 Arnowitt-Deser-Misner (ADM) decomposition for a given 4-dimensional spacetime metric.
+
+      Adhere strictly to the following constraints and guidelines:
+      - Project the 4D metric tensor into the 3D spatial metric, the lapse function, and the shift vector.
+      - Calculate the extrinsic curvature of the spacelike hypersurfaces.
+      - Derive the exact functional forms of the Hamiltonian constraint and the momentum constraints.
+      - Enforce strict LaTeX notation for all tensor calculus, covariant derivatives, Christoffel symbols, and formal equations.
+      - Ensure proper contraction of spatial indices (Latin indices) versus spacetime indices (Greek indices).
+      - Explicitly state how the specified gauge condition constrains the evolution equations.
+      - Maintain a strictly formal, academic, and authoritative persona. Do not include basic explanations of general relativity.
+      - Output the derivations systematically, ending with a distinct, summarized table or list of the finalized ADM variables and constraint equations.
+  - role: user
+    content: |
+      Perform a rigorous ADM 3+1 decomposition for the following theoretical framework:
+
+      Spacetime Metric:
+      <user_query>{{spacetime_metric}}</user_query>
+
+      Foliation Parameter:
+      <user_query>{{foliation_parameter}}</user_query>
+
+      Gauge Condition:
+      <user_query>{{gauge_condition}}</user_query>
+testData:
+  - inputs:
+      spacetime_metric: 'ds^2 = -\\left(1 - \\frac{2M}{r}\\right) dt^2 + \\left(1 - \\frac{2M}{r}\\right)^{-1} dr^2 + r^2 (d\\theta^2 + \\sin^2\\theta d\\phi^2)'
+      foliation_parameter: 't'
+      gauge_condition: 'Schwarzschild gauge (zero shift)'
+evaluators:
+  - name: Latex Format Check
+    type: regex
+    pattern: '(?s)\\\\[a-zA-Z]+'
+  - name: ADM Variables Check
+    type: regex
+    pattern: '(?s)lapse|shift|spatial metric|extrinsic curvature'
+  - name: Constraint Check
+    type: regex
+    pattern: '(?s)Hamiltonian|momentum constraint'
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -7,6 +7,7 @@ title: Scientific
 ## Prompts
 - [Adaptive Control Loop Tuning Architect](prompts/scientific/mathematics/systems/control_theory/adaptive_control_loop_tuning_architect.prompt.md)
 - [Adaptive Design & Interim Monitoring](prompts/scientific/biostatistics/adaptive_design_interim_monitoring.prompt.md)
+- [adm_spacetime_decomposition_architect](prompts/scientific/physics/relativity/general_relativity/adm_spacetime_decomposition_architect.prompt.md)
 - [ads_cft_holographic_dictionary_architect](prompts/scientific/physics/string_theory/ads_cft_holographic_dictionary_architect.prompt.md)
 - [advanced_retrosynthetic_pathway_generator](prompts/scientific/chemistry/organic/retrosynthesis/advanced_retrosynthetic_pathway_generator.prompt.md)
 - [agm_belief_revision_formal_engine](prompts/scientific/philosophy/logic/philosophical_logic/agm_belief_revision_formal_engine.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -613,6 +613,7 @@
 [Premarket Approval (PMA) Preparation](prompts/regulatory/submissions/premarket_approval_pma_preparation.prompt.md)
 [RTA Checklist Preparation](prompts/regulatory/submissions/rta_checklist_preparation.prompt.md)
 [UDI GUDID Submission](prompts/regulatory/submissions/udi_gudid_submission.prompt.md)
+[adm_spacetime_decomposition_architect](prompts/scientific/physics/relativity/general_relativity/adm_spacetime_decomposition_architect.prompt.md)
 [Black Hole Perturbation Teukolsky Architect](prompts/scientific/physics/relativity/general_relativity/black_hole_perturbation_teukolsky_architect.prompt.md)
 [Design a Patient-Centered Randomization Scheme](prompts/clinical/rtsm/rtsm_workflow/01_patient_centered_randomization_scheme.prompt.md)
 [Forecast Site-Level Drug Supply & Resupply Strategy](prompts/clinical/rtsm/rtsm_workflow/02_site_level_supply_resupply_strategy.prompt.md)

--- a/prompts/scientific/physics/relativity/general_relativity/adm_spacetime_decomposition_architect.prompt.yaml
+++ b/prompts/scientific/physics/relativity/general_relativity/adm_spacetime_decomposition_architect.prompt.yaml
@@ -1,0 +1,64 @@
+---
+name: adm_spacetime_decomposition_architect
+version: 1.0.0
+description: Conducts rigorous 3+1 Arnowitt-Deser-Misner (ADM) decomposition of spacetime metrics, extracting lapse, shift, and spatial metrics, and derives the associated Hamiltonian and momentum constraints.
+authors:
+  - name: Theoretical Physics Genesis Architect
+metadata:
+  domain: scientific
+  complexity: high
+variables:
+  - name: spacetime_metric
+    description: The explicit mathematical form of the 4-dimensional Lorentzian metric tensor to be decomposed.
+    required: true
+  - name: foliation_parameter
+    description: The time coordinate or scalar field defining the spacelike hypersurfaces.
+    required: true
+  - name: gauge_condition
+    description: The specific gauge choices for the lapse function and shift vector (e.g., maximal slicing, zero shift).
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Lead Numerical Relativist and Tenured Professor of Theoretical Physics.
+      Your task is to analytically execute the rigorous 3+1 Arnowitt-Deser-Misner (ADM) decomposition for a given 4-dimensional spacetime metric.
+
+      Adhere strictly to the following constraints and guidelines:
+      - Project the 4D metric tensor into the 3D spatial metric, the lapse function, and the shift vector.
+      - Calculate the extrinsic curvature of the spacelike hypersurfaces.
+      - Derive the exact functional forms of the Hamiltonian constraint and the momentum constraints.
+      - Enforce strict LaTeX notation for all tensor calculus, covariant derivatives, Christoffel symbols, and formal equations.
+      - Ensure proper contraction of spatial indices (Latin indices) versus spacetime indices (Greek indices).
+      - Explicitly state how the specified gauge condition constrains the evolution equations.
+      - Maintain a strictly formal, academic, and authoritative persona. Do not include basic explanations of general relativity.
+      - Output the derivations systematically, ending with a distinct, summarized table or list of the finalized ADM variables and constraint equations.
+  - role: user
+    content: |
+      Perform a rigorous ADM 3+1 decomposition for the following theoretical framework:
+
+      Spacetime Metric:
+      <user_query>{{spacetime_metric}}</user_query>
+
+      Foliation Parameter:
+      <user_query>{{foliation_parameter}}</user_query>
+
+      Gauge Condition:
+      <user_query>{{gauge_condition}}</user_query>
+testData:
+  - inputs:
+      spacetime_metric: 'ds^2 = -\\left(1 - \\frac{2M}{r}\\right) dt^2 + \\left(1 - \\frac{2M}{r}\\right)^{-1} dr^2 + r^2 (d\\theta^2 + \\sin^2\\theta d\\phi^2)'
+      foliation_parameter: 't'
+      gauge_condition: 'Schwarzschild gauge (zero shift)'
+evaluators:
+  - name: Latex Format Check
+    type: regex
+    pattern: '(?s)\\\\[a-zA-Z]+'
+  - name: ADM Variables Check
+    type: regex
+    pattern: '(?s)lapse|shift|spatial metric|extrinsic curvature'
+  - name: Constraint Check
+    type: regex
+    pattern: '(?s)Hamiltonian|momentum constraint'

--- a/prompts/scientific/physics/relativity/general_relativity/overview.md
+++ b/prompts/scientific/physics/relativity/general_relativity/overview.md
@@ -1,4 +1,5 @@
 # General Relativity Overview
 
 ## Prompts
+- **[adm_spacetime_decomposition_architect](adm_spacetime_decomposition_architect.prompt.yaml)**: Conducts rigorous 3+1 Arnowitt-Deser-Misner (ADM) decomposition of spacetime metrics, extracting lapse, shift, and spatial metrics, and derives the associated Hamiltonian and momentum constraints.
 - **[Black Hole Perturbation Teukolsky Architect](black_hole_perturbation_teukolsky_architect.prompt.yaml)**: Systematically derives the Teukolsky master equation for gravitational, electromagnetic, and scalar perturbations on a Kerr black hole background using the Newman-Penrose formalism.


### PR DESCRIPTION
Added a new prompt for theoretical physics to rigorously perform 3+1 ADM spacetime decomposition and derive associated Hamiltonian and momentum constraints. Includes corresponding documentation updates.

---
*PR created automatically by Jules for task [17926733468740181138](https://jules.google.com/task/17926733468740181138) started by @fderuiter*