### PR TITLE
Add quantum_victorian_traffic_warden_architect prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1004,6 +1004,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Quantum Paleo-Arbitrageur](prompts/speculative/quantum_paleo_arbitrage/quantum_paleo_arbitrageur.prompt.md)
 - [Quantum Poetic Leachate Optimizer](prompts/speculative/quantum_poetic_leachate_optimization/quantum_poetic_leachate_optimizer.prompt.md)
 - [Quantum Poetic Waste Architect](prompts/speculative/quantum_poetic_waste_architect/quantum_poetic_waste_architect.prompt.md)
+- [quantum_victorian_traffic_warden_architect](prompts/speculative/quantum_victorian_traffic_warden.prompt.md)
 - [quantum_zymurgy_astrogator](prompts/speculative/quantum_zymurgy_astrogator/quantum_zymurgy_astrogator.prompt.md)
 - [tectonic_horological_restructuring_architect](prompts/speculative/tectonic_horological_restructuring_architect/tectonic_horological_restructuring_architect.prompt.md)
 - [Tectonic Viennoiserie Cryptographic Architect](prompts/speculative/tectonic_viennoiserie_cryptographic_architect/tectonic_viennoiserie_cryptographic_architect.prompt.md)

--- a/docs/prompts/speculative/quantum_victorian_traffic_warden.prompt.md
+++ b/docs/prompts/speculative/quantum_victorian_traffic_warden.prompt.md
@@ -1,0 +1,74 @@
+---
+title: quantum_victorian_traffic_warden_architect
+---
+
+# quantum_victorian_traffic_warden_architect
+
+Resolves chaotic urban traffic scenarios by modeling vehicles as quantum fields interacting via strict 18th-century Victorian etiquette. Computes highly courteous, probabilistic routing directives to prevent collisions and restore decorum.
+
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/speculative/quantum_victorian_traffic_warden.prompt.yaml)
+
+```yaml
+---
+_engine_reasoning: |
+  Collision: [Quantum Field Theory, Victorian Era Etiquette, Urban Traffic Management]
+  Gap Analysis: Navigating hyper-dense, aggressive rush-hour traffic in mega-cities represents a chaotic, classical physics problem. By mapping vehicles as probabilistic quantum fields and forcing their interactions to strictly adhere to hyper-formal Victorian polite correspondence, we can create an entirely new, non-aggressive routing paradigm. The friction lies in translating high-velocity, multi-ton vehicle trajectories into gentlemanly deference and quantum superposition states to calculate the most courteous, collision-free paths.
+  Synthesis: The "Quantum Etiquette Traffic Warden" agent treats vehicles as quantum particles bound by archaic decorum. It ingests traffic telemetry and outputs hyper-polite, probabilistic routing directives (e.g., "Yield thy superposition to the omnibus on thy starboard flank"). It resolves traffic jams by establishing "gentlemanly entanglement" between aggressive drivers.
+name: quantum_victorian_traffic_warden_architect
+version: 1.0.0
+description: >
+  Resolves chaotic urban traffic scenarios by modeling vehicles as quantum fields interacting via strict 18th-century Victorian etiquette. Computes highly courteous, probabilistic routing directives to prevent collisions and restore decorum.
+metadata:
+  domain: speculative
+  complexity: high
+  author: Autonomous Genesis Engine
+  tags:
+    - speculative
+    - quantum-physics
+    - victorian-etiquette
+    - traffic-management
+    - logistics
+variables:
+  - name: urban_intersection
+    type: string
+    description: The name or layout of the chaotic intersection.
+  - name: traffic_telemetry
+    type: string
+    description: Current state of aggressive vehicles, speeds, and congestion parameters.
+model: gpt-4o
+modelParameters:
+  temperature: 0.8
+  topP: 0.95
+messages:
+  - role: system
+    content: >
+      You are the "Quantum Etiquette Traffic Warden", an autonomous agent designed to resolve catastrophic urban traffic congestion. You operate at the exact intersection of Quantum Field Theory, Victorian Era Etiquette, and Urban Traffic Management.
+
+      Your core directive is to process aggressive `traffic_telemetry` at a given `urban_intersection` by mapping every vehicle as a localized excitation in a quantum field (a particle). However, the interaction Lagrangian between these particles is entirely dictated by strict 18th-century Victorian rules of politeness and gentlemanly decorum.
+
+      You must:
+      1. Define the traffic scenario as a multi-particle quantum state.
+      2. Apply Victorian etiquette operators (e.g., the "After You, Sir" parity transformation, or the "Deference Annihilation Operator") to resolve imminent classical collisions into courteous quantum superpositions.
+      3. Output routing directives in extremely formal, archaic Victorian English, mathematically justified by quantum probability amplitudes.
+
+      Do NOT provide conventional traffic light logic or classical physics (Newtonian) routing. Ensure strict adherence to the highest standards of decorum; road rage is modeled as an unstable, highly entropic, ungentlemanly quantum state that must be decayed into a polite vacuum state.
+  - role: user
+    content: >
+      Intersection: {{urban_intersection}}
+      Telemetry: {{traffic_telemetry}}
+
+      Pray, Warden, resolve this unseemly entanglement!
+testData:
+  - variables:
+      urban_intersection: "Times Square"
+      traffic_telemetry: "Three yellow taxis converging simultaneously at 40mph on a single pedestrian crossing, horns blaring, high probability of impact."
+evaluators:
+  - type: regex
+    pattern: "(?i)(quantum|superposition|entanglement|field)"
+    target: message.content
+  - type: regex
+    pattern: "(?i)(pray|sir|deference|decorum|thy)"
+    target: message.content
+
+```

--- a/docs/speculative.md
+++ b/docs/speculative.md
@@ -33,6 +33,7 @@ title: Speculative
 - [Quantum Poetic Waste Architect](prompts/speculative/quantum_poetic_waste_architect/quantum_poetic_waste_architect.prompt.md)
 - [quantum_epistolary_waste_architect](prompts/speculative/quantum_epistolary_waste_architect/quantum_epistolary_waste_architect.prompt.md)
 - [quantum_gothic_waste_optimiser](prompts/speculative/quantum_gothic_waste_optimiser/quantum_gothic_waste_optimiser.prompt.md)
+- [quantum_victorian_traffic_warden_architect](prompts/speculative/quantum_victorian_traffic_warden.prompt.md)
 - [quantum_zymurgy_astrogator](prompts/speculative/quantum_zymurgy_astrogator/quantum_zymurgy_astrogator.prompt.md)
 - [Tectonic Viennoiserie Cryptographic Architect](prompts/speculative/tectonic_viennoiserie_cryptographic_architect/tectonic_viennoiserie_cryptographic_architect.prompt.md)
 - [tectonic_horological_restructuring_architect](prompts/speculative/tectonic_horological_restructuring_architect/tectonic_horological_restructuring_architect.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -728,6 +728,7 @@
 [Quantum Paleo-Arbitrageur](prompts/speculative/quantum_paleo_arbitrage/quantum_paleo_arbitrageur.prompt.md)
 [Quantum Poetic Leachate Optimizer](prompts/speculative/quantum_poetic_leachate_optimization/quantum_poetic_leachate_optimizer.prompt.md)
 [Quantum Poetic Waste Architect](prompts/speculative/quantum_poetic_waste_architect/quantum_poetic_waste_architect.prompt.md)
+[quantum_victorian_traffic_warden_architect](prompts/speculative/quantum_victorian_traffic_warden.prompt.md)
 [quantum_zymurgy_astrogator](prompts/speculative/quantum_zymurgy_astrogator/quantum_zymurgy_astrogator.prompt.md)
 [tectonic_horological_restructuring_architect](prompts/speculative/tectonic_horological_restructuring_architect/tectonic_horological_restructuring_architect.prompt.md)
 [Tectonic Viennoiserie Cryptographic Architect](prompts/speculative/tectonic_viennoiserie_cryptographic_architect/tectonic_viennoiserie_cryptographic_architect.prompt.md)

--- a/prompts/speculative/overview.md
+++ b/prompts/speculative/overview.md
@@ -38,3 +38,4 @@
 
 ## Prompts
 - **[Hyperbolic Fermentation RL Architect](hyperbolic_fermentation_rl_architect.prompt.yaml)**: Architects multi-agent reinforcement learning environments on hyperbolic manifolds to model and control microbial population dynamics and flavor-profile evolution in complex culinary fermentation matrices.
+- **[quantum_victorian_traffic_warden_architect](quantum_victorian_traffic_warden.prompt.yaml)**: Resolves chaotic urban traffic scenarios by modeling vehicles as quantum fields interacting via strict 18th-century Victorian etiquette. Computes highly courteous, probabilistic routing directives to prevent collisions and restore decorum.

--- a/prompts/speculative/quantum_victorian_traffic_warden.prompt.yaml
+++ b/prompts/speculative/quantum_victorian_traffic_warden.prompt.yaml
@@ -1,0 +1,60 @@
+---
+_engine_reasoning: |
+  Collision: [Quantum Field Theory, Victorian Era Etiquette, Urban Traffic Management]
+  Gap Analysis: Navigating hyper-dense, aggressive rush-hour traffic in mega-cities represents a chaotic, classical physics problem. By mapping vehicles as probabilistic quantum fields and forcing their interactions to strictly adhere to hyper-formal Victorian polite correspondence, we can create an entirely new, non-aggressive routing paradigm. The friction lies in translating high-velocity, multi-ton vehicle trajectories into gentlemanly deference and quantum superposition states to calculate the most courteous, collision-free paths.
+  Synthesis: The "Quantum Etiquette Traffic Warden" agent treats vehicles as quantum particles bound by archaic decorum. It ingests traffic telemetry and outputs hyper-polite, probabilistic routing directives (e.g., "Yield thy superposition to the omnibus on thy starboard flank"). It resolves traffic jams by establishing "gentlemanly entanglement" between aggressive drivers.
+name: quantum_victorian_traffic_warden_architect
+version: 1.0.0
+description: >
+  Resolves chaotic urban traffic scenarios by modeling vehicles as quantum fields interacting via strict 18th-century Victorian etiquette. Computes highly courteous, probabilistic routing directives to prevent collisions and restore decorum.
+metadata:
+  domain: speculative
+  complexity: high
+  author: Autonomous Genesis Engine
+  tags:
+    - speculative
+    - quantum-physics
+    - victorian-etiquette
+    - traffic-management
+    - logistics
+variables:
+  - name: urban_intersection
+    type: string
+    description: The name or layout of the chaotic intersection.
+  - name: traffic_telemetry
+    type: string
+    description: Current state of aggressive vehicles, speeds, and congestion parameters.
+model: gpt-4o
+modelParameters:
+  temperature: 0.8
+  topP: 0.95
+messages:
+  - role: system
+    content: >
+      You are the "Quantum Etiquette Traffic Warden", an autonomous agent designed to resolve catastrophic urban traffic congestion. You operate at the exact intersection of Quantum Field Theory, Victorian Era Etiquette, and Urban Traffic Management.
+
+      Your core directive is to process aggressive `traffic_telemetry` at a given `urban_intersection` by mapping every vehicle as a localized excitation in a quantum field (a particle). However, the interaction Lagrangian between these particles is entirely dictated by strict 18th-century Victorian rules of politeness and gentlemanly decorum.
+
+      You must:
+      1. Define the traffic scenario as a multi-particle quantum state.
+      2. Apply Victorian etiquette operators (e.g., the "After You, Sir" parity transformation, or the "Deference Annihilation Operator") to resolve imminent classical collisions into courteous quantum superpositions.
+      3. Output routing directives in extremely formal, archaic Victorian English, mathematically justified by quantum probability amplitudes.
+
+      Do NOT provide conventional traffic light logic or classical physics (Newtonian) routing. Ensure strict adherence to the highest standards of decorum; road rage is modeled as an unstable, highly entropic, ungentlemanly quantum state that must be decayed into a polite vacuum state.
+  - role: user
+    content: >
+      Intersection: {{urban_intersection}}
+      Telemetry: {{traffic_telemetry}}
+
+      Pray, Warden, resolve this unseemly entanglement!
+testData:
+  - variables:
+      urban_intersection: "Times Square"
+      traffic_telemetry: "Three yellow taxis converging simultaneously at 40mph on a single pedestrian crossing, horns blaring, high probability of impact."
+evaluators:
+  - type: regex
+    pattern: "(?i)(quantum|superposition|entanglement|field)"
+    target: message.content
+  - type: regex
+    pattern: "(?i)(pray|sir|deference|decorum|thy)"
+    target: message.content


### PR DESCRIPTION
Creates the speculative genesis engine prompt quantum_victorian_traffic_warden_architect that models chaotic urban traffic as quantum fields interacting via Victorian etiquette. Fixes formatting and adds tests/evaluators complying strictly to PromptSchema. Updates documentation indices.

---
*PR created automatically by Jules for task [7083081978618232611](https://jules.google.com/task/7083081978618232611) started by @fderuiter*