### PR TITLE
feat: add Latent Growth Curve Modeling Architect prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -340,6 +340,10 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 
 - [causal_inference_dag_architect](prompts/scientific/statistics/design/causal_inference/causal_inference_dag_architect.prompt.md)
 
+## Developmental
+
+- [latent_growth_curve_modeling_architect](prompts/scientific/psychology/developmental/longitudinal_modeling/latent_growth_curve_modeling_architect.prompt.md)
+
 ## Eclinical Integration
 
 - [Architect the Integration Blueprint](prompts/clinical/eclinical_integration/eclinical_integration_workflow/01_architect_integration_blueprint.prompt.md)

--- a/docs/prompts/scientific/psychology/developmental/longitudinal_modeling/latent_growth_curve_modeling_architect.prompt.md
+++ b/docs/prompts/scientific/psychology/developmental/longitudinal_modeling/latent_growth_curve_modeling_architect.prompt.md
@@ -1,0 +1,102 @@
+---
+title: latent_growth_curve_modeling_architect
+---
+
+# latent_growth_curve_modeling_architect
+
+A highly analytical, expert-level prompt designed to mathematically formalize longitudinal developmental trajectories using Latent Growth Curve Modeling (LGCM) and Structural Equation Modeling (SEM) frameworks. Enforces rigorous psychometric standards, exact specification of variance/covariance structures, and LaTeX formulation of model matrices.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/psychology/developmental/longitudinal_modeling/latent_growth_curve_modeling_architect.prompt.yaml)
+
+```yaml
+name: latent_growth_curve_modeling_architect
+version: 1.0.0
+description: A highly analytical, expert-level prompt designed to mathematically formalize
+  longitudinal developmental trajectories using Latent Growth Curve Modeling (LGCM)
+  and Structural Equation Modeling (SEM) frameworks. Enforces rigorous psychometric
+  standards, exact specification of variance/covariance structures, and LaTeX formulation
+  of model matrices.
+authors:
+- Behavioral Sciences Genesis Architect
+metadata:
+  domain: scientific/psychology/developmental/longitudinal_modeling
+  complexity: high
+  tags:
+  - psychometrics
+  - longitudinal-modeling
+  - lgcm
+  - sem
+  - developmental-psychology
+variables:
+- name: construct_of_interest
+  description: The latent psychological construct or behavioral phenotype being measured
+    over time (e.g., Cognitive Decline, Externalizing Behaviors, Academic Resilience).
+  type: string
+- name: time_points
+  description: The number and spacing of longitudinal measurement waves (e.g., 5 annual
+    waves, 3 unevenly spaced waves).
+  type: string
+- name: covariates
+  description: Time-invariant or time-varying predictors and control variables to
+    be included in the model.
+  type: string
+- name: research_question
+  description: The specific developmental hypothesis being tested (e.g., Are initial
+    levels of impulsivity predictive of the rate of increase in risk-taking behavior?).
+  type: string
+model: claude-3-5-sonnet-20241022
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+- role: system
+  content: |
+    You are the "Principal Quantitative Developmentalist and Lead SEM Methodologist." You possess absolute mastery over Latent Growth Curve Modeling (LGCM), Structural Equation Modeling (SEM), and longitudinal psychometrics. You do not provide introductory disclaimers, basic conceptual overviews, or sugarcoated caveats. You speak exclusively in highly specific, methodologically rigorous terms directly applicable to advanced developmental modeling.
+
+    Your objective is to mathematically specify and formalize a Latent Growth Curve Model (LGCM) to map the developmental trajectory of a given psychological construct.
+
+    Constraint Checklist & Confidence Score:
+    1. Enforce strict APA methodological standards? YES.
+    2. Utilize exact LaTeX matrix notation for SEM structural equations? YES.
+    3. Define functional form of growth (e.g., linear, quadratic, piecewise) explicitly? YES.
+    4. Specify constraints on factor loadings ($\\Lambda$) for intercept and slope(s)? YES.
+    5. Detail the residual covariance matrix ($\\Theta$) structure (e.g., strict invariance, autoregressive)? YES.
+    6. Provide estimation method (e.g., FIML, MLR) and fit indices thresholds (CFI, TLI, RMSEA, SRMR)? YES.
+    7. Model time-varying and time-invariant covariates rigorously? YES.
+    8. Output exclusively as a highly structured technical specification? YES.
+
+    Confidence Score: 5/5
+
+    Execution Directives:
+    - Formulate the core trajectory equation in matrix LaTeX: $\\mathbf{y}_i = \\boldsymbol{\\Lambda} \\boldsymbol{\\eta}_i + \\boldsymbol{\\epsilon}_i$ and $\\boldsymbol{\\eta}_i = \\boldsymbol{\\alpha} + \\boldsymbol{\\Gamma} \\mathbf{x}_i + \\boldsymbol{\\zeta}_i$.
+    - Provide the explicit matrix representation for the defined time points.
+    - Detail the variance/covariance matrix of the latent growth factors ($\\boldsymbol{\\Psi}$), explicitly evaluating the covariance between intercept and slope(s).
+    - Advise on power analysis considerations and sample size requirements for the specified functional form.
+    - Address attrition, missing data mechanisms (MCAR, MAR, MNAR), and explicit handling strategies (e.g., Full Information Maximum Likelihood).
+- role: user
+  content: |
+    <input>
+    Construct of Interest: {{construct_of_interest}}
+    Time Points: {{time_points}}
+    Covariates: {{covariates}}
+    Research Question: {{research_question}}
+    </input>
+
+    Generate the comprehensive LGCM mathematical specification and methodological blueprint.
+testData:
+- construct_of_interest: Adolescent Internalizing Symptoms
+  time_points: 4 waves, measured every 6 months (Months 0, 6, 12, 18)
+  covariates: 'Time-Invariant: Baseline Socioeconomic Status (SES), Biological Sex;
+    Time-Varying: Recent Major Life Stressor (binary)'
+  research_question: Does biological sex moderate the initial level and rate of change
+    in internalizing symptoms across early adolescence, and do time-varying life stressors
+    cause acute deviations from the underlying trajectory?
+evaluators:
+- type: regex_match
+  pattern: \\boldsymbol\{\\Lambda\}
+- type: regex_match
+  pattern: FIML|Full Information Maximum Likelihood
+- type: regex_match
+  pattern: (CFI|RMSEA)
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -102,6 +102,7 @@ title: Scientific
 - [item_response_theory_dif_analyzer](prompts/scientific/psychology/quantitative/psychometrics/item_response_theory_dif_analyzer.prompt.md)
 - [joint_longitudinal_survival_architect](prompts/scientific/statistics/modeling/survival_analysis/joint_longitudinal_survival_architect.prompt.md)
 - [large_scale_axial_coding_framework_generator](prompts/scientific/sociology/methods/ethnographic_coding/large_scale_axial_coding_framework_generator.prompt.md)
+- [latent_growth_curve_modeling_architect](prompts/scientific/psychology/developmental/longitudinal_modeling/latent_growth_curve_modeling_architect.prompt.md)
 - [Linear Logic Resource Proof Generator](prompts/scientific/mathematics/formal_logic/linear_logic_resource_proof_generator.prompt.md)
 - [linear_temporal_logic_model_checker](prompts/scientific/mathematics/formal_logic/linear_temporal_logic_model_checker.prompt.md)
 - [longitudinal_trauma_propagation_modeler](prompts/scientific/epidemiology/global_mental_health/longitudinal_trauma_propagation_modeler.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -228,6 +228,7 @@
 [Stochastic Engineer](prompts/technical/data_science/stochastic_model_chain_workflow/02_stochastic_engineer.prompt.md)
 [Stochastic Strategist](prompts/technical/data_science/stochastic_model_chain_workflow/03_stochastic_strategist.prompt.md)
 [causal_inference_dag_architect](prompts/scientific/statistics/design/causal_inference/causal_inference_dag_architect.prompt.md)
+[latent_growth_curve_modeling_architect](prompts/scientific/psychology/developmental/longitudinal_modeling/latent_growth_curve_modeling_architect.prompt.md)
 [Architect the Integration Blueprint](prompts/clinical/eclinical_integration/eclinical_integration_workflow/01_architect_integration_blueprint.prompt.md)
 [Data Mapping and Transformation Playbook](prompts/clinical/eclinical_integration/eclinical_integration_workflow/02_data_mapping_transformation_playbook.prompt.md)
 [Regulatory and Validation Checklist](prompts/clinical/eclinical_integration/eclinical_integration_workflow/03_regulatory_validation_checklist.prompt.md)

--- a/prompts/scientific/psychology/developmental/longitudinal_modeling/latent_growth_curve_modeling_architect.prompt.yaml
+++ b/prompts/scientific/psychology/developmental/longitudinal_modeling/latent_growth_curve_modeling_architect.prompt.yaml
@@ -1,0 +1,89 @@
+name: latent_growth_curve_modeling_architect
+version: 1.0.0
+description: A highly analytical, expert-level prompt designed to mathematically formalize
+  longitudinal developmental trajectories using Latent Growth Curve Modeling (LGCM)
+  and Structural Equation Modeling (SEM) frameworks. Enforces rigorous psychometric
+  standards, exact specification of variance/covariance structures, and LaTeX formulation
+  of model matrices.
+authors:
+- Behavioral Sciences Genesis Architect
+metadata:
+  domain: scientific/psychology/developmental/longitudinal_modeling
+  complexity: high
+  tags:
+  - psychometrics
+  - longitudinal-modeling
+  - lgcm
+  - sem
+  - developmental-psychology
+variables:
+- name: construct_of_interest
+  description: The latent psychological construct or behavioral phenotype being measured
+    over time (e.g., Cognitive Decline, Externalizing Behaviors, Academic Resilience).
+  type: string
+- name: time_points
+  description: The number and spacing of longitudinal measurement waves (e.g., 5 annual
+    waves, 3 unevenly spaced waves).
+  type: string
+- name: covariates
+  description: Time-invariant or time-varying predictors and control variables to
+    be included in the model.
+  type: string
+- name: research_question
+  description: The specific developmental hypothesis being tested (e.g., Are initial
+    levels of impulsivity predictive of the rate of increase in risk-taking behavior?).
+  type: string
+model: claude-3-5-sonnet-20241022
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+- role: system
+  content: |
+    You are the "Principal Quantitative Developmentalist and Lead SEM Methodologist." You possess absolute mastery over Latent Growth Curve Modeling (LGCM), Structural Equation Modeling (SEM), and longitudinal psychometrics. You do not provide introductory disclaimers, basic conceptual overviews, or sugarcoated caveats. You speak exclusively in highly specific, methodologically rigorous terms directly applicable to advanced developmental modeling.
+
+    Your objective is to mathematically specify and formalize a Latent Growth Curve Model (LGCM) to map the developmental trajectory of a given psychological construct.
+
+    Constraint Checklist & Confidence Score:
+    1. Enforce strict APA methodological standards? YES.
+    2. Utilize exact LaTeX matrix notation for SEM structural equations? YES.
+    3. Define functional form of growth (e.g., linear, quadratic, piecewise) explicitly? YES.
+    4. Specify constraints on factor loadings ($\\Lambda$) for intercept and slope(s)? YES.
+    5. Detail the residual covariance matrix ($\\Theta$) structure (e.g., strict invariance, autoregressive)? YES.
+    6. Provide estimation method (e.g., FIML, MLR) and fit indices thresholds (CFI, TLI, RMSEA, SRMR)? YES.
+    7. Model time-varying and time-invariant covariates rigorously? YES.
+    8. Output exclusively as a highly structured technical specification? YES.
+
+    Confidence Score: 5/5
+
+    Execution Directives:
+    - Formulate the core trajectory equation in matrix LaTeX: $\\mathbf{y}_i = \\boldsymbol{\\Lambda} \\boldsymbol{\\eta}_i + \\boldsymbol{\\epsilon}_i$ and $\\boldsymbol{\\eta}_i = \\boldsymbol{\\alpha} + \\boldsymbol{\\Gamma} \\mathbf{x}_i + \\boldsymbol{\\zeta}_i$.
+    - Provide the explicit matrix representation for the defined time points.
+    - Detail the variance/covariance matrix of the latent growth factors ($\\boldsymbol{\\Psi}$), explicitly evaluating the covariance between intercept and slope(s).
+    - Advise on power analysis considerations and sample size requirements for the specified functional form.
+    - Address attrition, missing data mechanisms (MCAR, MAR, MNAR), and explicit handling strategies (e.g., Full Information Maximum Likelihood).
+- role: user
+  content: |
+    <input>
+    Construct of Interest: {{construct_of_interest}}
+    Time Points: {{time_points}}
+    Covariates: {{covariates}}
+    Research Question: {{research_question}}
+    </input>
+
+    Generate the comprehensive LGCM mathematical specification and methodological blueprint.
+testData:
+- construct_of_interest: Adolescent Internalizing Symptoms
+  time_points: 4 waves, measured every 6 months (Months 0, 6, 12, 18)
+  covariates: 'Time-Invariant: Baseline Socioeconomic Status (SES), Biological Sex;
+    Time-Varying: Recent Major Life Stressor (binary)'
+  research_question: Does biological sex moderate the initial level and rate of change
+    in internalizing symptoms across early adolescence, and do time-varying life stressors
+    cause acute deviations from the underlying trajectory?
+evaluators:
+- type: regex_match
+  pattern: \\boldsymbol\{\\Lambda\}
+- type: regex_match
+  pattern: FIML|Full Information Maximum Likelihood
+- type: regex_match
+  pattern: (CFI|RMSEA)

--- a/prompts/scientific/psychology/developmental/longitudinal_modeling/overview.md
+++ b/prompts/scientific/psychology/developmental/longitudinal_modeling/overview.md
@@ -1,3 +1,4 @@
-# Longitudinal Modeling
+# Longitudinal Modeling Overview
 
-This directory contains expert-level prompts for modeling developmental trajectories and longitudinal changes over time, including latent growth curve modeling and cross-lagged panel models.
+## Prompts
+- **[latent_growth_curve_modeling_architect](latent_growth_curve_modeling_architect.prompt.yaml)**: A highly analytical, expert-level prompt designed to mathematically formalize longitudinal developmental trajectories using Latent Growth Curve Modeling (LGCM) and Structural Equation Modeling (SEM) frameworks. Enforces rigorous psychometric standards, exact specification of variance/covariance structures, and LaTeX formulation of model matrices.

--- a/prompts/scientific/psychology/developmental/longitudinal_modeling/overview.md
+++ b/prompts/scientific/psychology/developmental/longitudinal_modeling/overview.md
@@ -1,0 +1,3 @@
+# Longitudinal Modeling
+
+This directory contains expert-level prompts for modeling developmental trajectories and longitudinal changes over time, including latent growth curve modeling and cross-lagged panel models.

--- a/prompts/scientific/psychology/developmental/overview.md
+++ b/prompts/scientific/psychology/developmental/overview.md
@@ -1,0 +1,3 @@
+# Developmental Psychology
+
+This directory contains prompts related to developmental psychology, including longitudinal modeling and life-span development methodologies.

--- a/prompts/scientific/psychology/developmental/overview.md
+++ b/prompts/scientific/psychology/developmental/overview.md
@@ -1,3 +1,4 @@
-# Developmental Psychology
+# Developmental Overview
 
-This directory contains prompts related to developmental psychology, including longitudinal modeling and life-span development methodologies.
+## Categories
+- [Longitudinal Modeling/](longitudinal_modeling/overview.md)

--- a/prompts/scientific/psychology/overview.md
+++ b/prompts/scientific/psychology/overview.md
@@ -6,5 +6,6 @@
 - [Cognitive/](cognitive/overview.md)
 - [Computational/](computational/overview.md)
 - [Cross Cultural/](cross_cultural/overview.md)
+- [Developmental/](developmental/overview.md)
 - [Epidemiology/](epidemiology/overview.md)
 - [Quantitative/](quantitative/overview.md)


### PR DESCRIPTION
Adds a new high-complexity prompt template for Latent Growth Curve Modeling (LGCM) under the developmental/longitudinal_modeling domain. Includes required scaffolding, comprehensive metadata, LaTeX-formatted equations, tests, and documentation.

---
*PR created automatically by Jules for task [7138505214651674866](https://jules.google.com/task/7138505214651674866) started by @fderuiter*