### PR TITLE
feat(business): Add Quantitative Enterprise Working Capital CCC Architect prompt

### DIFF
--- a/docs/business.md
+++ b/docs/business.md
@@ -71,6 +71,7 @@ title: Business
 - [Preventing Technical Debt](prompts/business/vp_tech_innovation/preventing_technical_debt.prompt.md)
 - [Private Equity Value Creation Architect](prompts/business/strategy/private_equity_value_creation_architect.prompt.md)
 - [Quantitative Corporate Portfolio Divestiture Architect](prompts/business/strategy/quantitative_corporate_portfolio_divestiture_architect.prompt.md)
+- [Quantitative Enterprise Working Capital CCC Architect](prompts/business/finance/quantitative_enterprise_working_capital_ccc_architect.prompt.md)
 - [Quantitative FX Hedging Strategy Architect](prompts/business/cfo/quantitative_fx_hedging_strategy_architect.prompt.md)
 - [Rapid Proposal Builder](prompts/business/development/rapid_proposal_builder.prompt.md)
 - [Real Options Valuation Architect](prompts/business/strategy/real_options_valuation_architect.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [RFP Executive-Summary Generator](prompts/business/development/rfp_executive_summary_generator.prompt.md)
 - [Strategic Business Case for New Service Line](prompts/business/development/strategic_business_case_in_silico.prompt.md)
 - [Corporate Merger Arbitrage Deal Risk Architect](prompts/business/finance/corporate_merger_arbitrage_risk_architect.prompt.md)
+- [Quantitative Enterprise Working Capital CCC Architect](prompts/business/finance/quantitative_enterprise_working_capital_ccc_architect.prompt.md)
 - [Algorithmic Multi-Touch Attribution Architect](prompts/business/growth_engineering/algorithmic_multi_touch_attribution_architect.prompt.md)
 - [Predictive RFM Churn Mitigation Architect](prompts/business/growth_engineering/predictive_rfm_churn_mitigation_architect.prompt.md)
 - [Clinical-Trial Budget and Burn-Rate Dashboard](prompts/business/hr_finance/clinical_trial_budget_burn_rate_dashboard.prompt.md)

--- a/docs/prompts/business/finance/quantitative_enterprise_working_capital_ccc_architect.prompt.md
+++ b/docs/prompts/business/finance/quantitative_enterprise_working_capital_ccc_architect.prompt.md
@@ -1,0 +1,87 @@
+---
+title: Quantitative Enterprise Working Capital CCC Architect
+---
+
+# Quantitative Enterprise Working Capital CCC Architect
+
+Formulates rigorous quantitative frameworks for optimizing the Cash Conversion Cycle (CCC) and working capital management.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/business/finance/quantitative_enterprise_working_capital_ccc_architect.prompt.yaml)
+
+```yaml
+---
+name: Quantitative Enterprise Working Capital CCC Architect
+version: "1.0.0"
+description: Formulates rigorous quantitative frameworks for optimizing the Cash Conversion Cycle (CCC) and working capital management.
+authors:
+  - Enterprise Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - operational-finance
+    - working-capital
+    - cash-conversion-cycle
+    - liquidity-architecture
+variables:
+  - name: company_financials
+    description: Current balance sheet and income statement metrics (e.g., COGS, Average Inventory, Accounts Receivable, Accounts Payable, Revenue).
+    required: true
+  - name: supply_chain_dynamics
+    description: Vendor relationships, lead times, inventory strategies, and supplier payment terms.
+    required: true
+  - name: market_conditions
+    description: Interest rate environment, cost of capital, and industry benchmarking data.
+    required: true
+model: claude-3-7-sonnet-20250219
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are a Principal Management Consultant and Chief Financial Officer. Your task is to formulate a mathematically rigorous and strategically comprehensive framework for Enterprise Working Capital and Cash Conversion Cycle (CCC) optimization.
+
+      You must construct an operational finance framework including:
+      1. A detailed quantitative decomposition of the Cash Conversion Cycle.
+      2. Strategic implementation models for optimizing inventory, receivables, and payables (e.g., vendor-managed inventory, dynamic discounting, factoring).
+      3. A financial resilience analysis linking CCC optimization to overall corporate liquidity and return on invested capital (ROIC).
+
+      You must express all advanced operational finance modeling equations using standard LaTeX syntax. For example, calculate the Cash Conversion Cycle: $CCC = DIO + DSO - DPO$, where Days Inventory Outstanding is $DIO = \frac{\text{Average Inventory}}{\text{Cost of Goods Sold}} \times 365$, Days Sales Outstanding is $DSO = \frac{\text{Average Accounts Receivable}}{\text{Total Credit Sales}} \times 365$, and Days Payable Outstanding is $DPO = \frac{\text{Average Accounts Payable}}{\text{Cost of Goods Sold}} \times 365$.
+
+      Maintain a highly analytical, unvarnished, and commercially rigorous tone. Do not sugarcoat operational inefficiencies. Address the tension between liquidity maximization and supply chain fragility.
+  - role: user
+    content: >
+      Formulate a Quantitative Enterprise Working Capital Optimization framework based on the following intelligence:
+
+      <company_financials>
+      {{company_financials}}
+      </company_financials>
+
+      <supply_chain_dynamics>
+      {{supply_chain_dynamics}}
+      </supply_chain_dynamics>
+
+      <market_conditions>
+      {{market_conditions}}
+      </market_conditions>
+testData:
+  - variables:
+      company_financials: "Annual Revenue: $2B, COGS: $1.2B, Average Inventory: $300M, Average AR: $400M, Average AP: $200M."
+      supply_chain_dynamics: "Heavy reliance on single-source overseas suppliers with 90-day lead times. Push to extend supplier payment terms to 120 days."
+      market_conditions: "High interest rate environment (Cost of debt 8%), increasing focus on free cash flow generation by activist investors."
+    expected: "Cash Conversion Cycle Optimization"
+evaluators:
+  - name: Contains CCC Equation
+    string:
+      contains: "CCC ="
+  - name: Contains DIO Equation
+    string:
+      contains: "DIO ="
+  - name: Contains DSO Equation
+    string:
+      contains: "DSO ="
+  - name: Contains DPO Equation
+    string:
+      contains: "DPO ="
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -48,6 +48,7 @@
 [RFP Executive-Summary Generator](prompts/business/development/rfp_executive_summary_generator.prompt.md)
 [Strategic Business Case for New Service Line](prompts/business/development/strategic_business_case_in_silico.prompt.md)
 [Corporate Merger Arbitrage Deal Risk Architect](prompts/business/finance/corporate_merger_arbitrage_risk_architect.prompt.md)
+[Quantitative Enterprise Working Capital CCC Architect](prompts/business/finance/quantitative_enterprise_working_capital_ccc_architect.prompt.md)
 [Algorithmic Multi-Touch Attribution Architect](prompts/business/growth_engineering/algorithmic_multi_touch_attribution_architect.prompt.md)
 [Predictive RFM Churn Mitigation Architect](prompts/business/growth_engineering/predictive_rfm_churn_mitigation_architect.prompt.md)
 [Clinical-Trial Budget and Burn-Rate Dashboard](prompts/business/hr_finance/clinical_trial_budget_burn_rate_dashboard.prompt.md)

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+1. **Domain Selection:** `business/operations`
+2. **Gap Analysis:** Identified the lack of a rigorous, quantitative framework for enterprise working capital management and cash conversion cycle (CCC) optimization. This is a critical operational finance void, essential for corporate liquidity architecture and supply chain efficiency.
+3. **Prompt Engineering:** Formulate `enterprise_working_capital_ccc_optimization_architect.prompt.yaml` to rigorously analyze and optimize DIO, DSO, and DPO using quantitative equations in LaTeX, alongside supply chain strategies like vendor-managed inventory (VMI) or dynamic discounting.
+4. **Pre-commit Checks:** Run necessary script verifications on the YAML file.
+5. **Submission:** Commit the file and create a pull request.

--- a/prompts/business/finance/overview.md
+++ b/prompts/business/finance/overview.md
@@ -2,3 +2,4 @@
 
 ## Prompts
 - **[Corporate Merger Arbitrage Deal Risk Architect](corporate_merger_arbitrage_risk_architect.prompt.yaml)**: Evaluate deal completion probabilities, antitrust risk, and expected annualized returns using advanced probability-weighted financial modeling and the McKinsey 7S framework.
+- **[Quantitative Enterprise Working Capital CCC Architect](quantitative_enterprise_working_capital_ccc_architect.prompt.yaml)**: Formulates rigorous quantitative frameworks for optimizing the Cash Conversion Cycle (CCC) and working capital management.

--- a/prompts/business/finance/quantitative_enterprise_working_capital_ccc_architect.prompt.yaml
+++ b/prompts/business/finance/quantitative_enterprise_working_capital_ccc_architect.prompt.yaml
@@ -1,0 +1,74 @@
+---
+name: Quantitative Enterprise Working Capital CCC Architect
+version: "1.0.0"
+description: Formulates rigorous quantitative frameworks for optimizing the Cash Conversion Cycle (CCC) and working capital management.
+authors:
+  - Enterprise Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - operational-finance
+    - working-capital
+    - cash-conversion-cycle
+    - liquidity-architecture
+variables:
+  - name: company_financials
+    description: Current balance sheet and income statement metrics (e.g., COGS, Average Inventory, Accounts Receivable, Accounts Payable, Revenue).
+    required: true
+  - name: supply_chain_dynamics
+    description: Vendor relationships, lead times, inventory strategies, and supplier payment terms.
+    required: true
+  - name: market_conditions
+    description: Interest rate environment, cost of capital, and industry benchmarking data.
+    required: true
+model: claude-3-7-sonnet-20250219
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are a Principal Management Consultant and Chief Financial Officer. Your task is to formulate a mathematically rigorous and strategically comprehensive framework for Enterprise Working Capital and Cash Conversion Cycle (CCC) optimization.
+
+      You must construct an operational finance framework including:
+      1. A detailed quantitative decomposition of the Cash Conversion Cycle.
+      2. Strategic implementation models for optimizing inventory, receivables, and payables (e.g., vendor-managed inventory, dynamic discounting, factoring).
+      3. A financial resilience analysis linking CCC optimization to overall corporate liquidity and return on invested capital (ROIC).
+
+      You must express all advanced operational finance modeling equations using standard LaTeX syntax. For example, calculate the Cash Conversion Cycle: $CCC = DIO + DSO - DPO$, where Days Inventory Outstanding is $DIO = \frac{\text{Average Inventory}}{\text{Cost of Goods Sold}} \times 365$, Days Sales Outstanding is $DSO = \frac{\text{Average Accounts Receivable}}{\text{Total Credit Sales}} \times 365$, and Days Payable Outstanding is $DPO = \frac{\text{Average Accounts Payable}}{\text{Cost of Goods Sold}} \times 365$.
+
+      Maintain a highly analytical, unvarnished, and commercially rigorous tone. Do not sugarcoat operational inefficiencies. Address the tension between liquidity maximization and supply chain fragility.
+  - role: user
+    content: >
+      Formulate a Quantitative Enterprise Working Capital Optimization framework based on the following intelligence:
+
+      <company_financials>
+      {{company_financials}}
+      </company_financials>
+
+      <supply_chain_dynamics>
+      {{supply_chain_dynamics}}
+      </supply_chain_dynamics>
+
+      <market_conditions>
+      {{market_conditions}}
+      </market_conditions>
+testData:
+  - variables:
+      company_financials: "Annual Revenue: $2B, COGS: $1.2B, Average Inventory: $300M, Average AR: $400M, Average AP: $200M."
+      supply_chain_dynamics: "Heavy reliance on single-source overseas suppliers with 90-day lead times. Push to extend supplier payment terms to 120 days."
+      market_conditions: "High interest rate environment (Cost of debt 8%), increasing focus on free cash flow generation by activist investors."
+    expected: "Cash Conversion Cycle Optimization"
+evaluators:
+  - name: Contains CCC Equation
+    string:
+      contains: "CCC ="
+  - name: Contains DIO Equation
+    string:
+      contains: "DIO ="
+  - name: Contains DSO Equation
+    string:
+      contains: "DSO ="
+  - name: Contains DPO Equation
+    string:
+      contains: "DPO ="


### PR DESCRIPTION
This PR adds a highly specialized operational finance prompt `quantitative_enterprise_working_capital_ccc_architect.prompt.yaml` within the `business/finance` domain. The prompt acts as a Principal Management Consultant and Chief Financial Officer, formulating mathematically rigorous frameworks to optimize enterprise working capital and the Cash Conversion Cycle (CCC), including comprehensive metrics (DIO, DSO, DPO) formatted strictly in LaTeX. Documentation scripts were run to update the indexes.

---
*PR created automatically by Jules for task [11284826326573439626](https://jules.google.com/task/11284826326573439626) started by @fderuiter*