### PR TITLE
feat(prompts): add freemium conversion velocity architect prompt

### DIFF
--- a/docs/growth.md
+++ b/docs/growth.md
@@ -10,6 +10,7 @@ title: Growth
 - [bayesian_media_mix_modeling_architect](prompts/growth/performance_marketing/bayesian_media_mix_modeling_architect.prompt.md)
 - [cohort_retention_survival_analysis_architect](prompts/growth/lifecycle/cohort_retention_survival_analysis_architect.prompt.md)
 - [cross_channel_behavioral_trigger_architect](prompts/growth/lifecycle/cross_channel_behavioral_trigger_architect.prompt.md)
+- [freemium_conversion_velocity_architect](prompts/growth/product_marketing/freemium_conversion_velocity_architect.prompt.md)
 - [gtm_pricing_elasticity_architect](prompts/growth/strategy/gtm_pricing_elasticity_architect.prompt.md)
 - [predictive_cac_payback_modeler](prompts/growth/performance_marketing/predictive_cac_payback_modeler.prompt.md)
 - [predictive_churn_ltv_optimization_architect](prompts/growth/predictive_modeling/predictive_churn_ltv_optimization_architect.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -469,6 +469,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [predictive_cac_payback_modeler](prompts/growth/performance_marketing/predictive_cac_payback_modeler.prompt.md)
 - [b2b_abm_pipeline_velocity_architect](prompts/growth/predictive_modeling/b2b_abm_pipeline_velocity_architect.prompt.md)
 - [predictive_churn_ltv_optimization_architect](prompts/growth/predictive_modeling/predictive_churn_ltv_optimization_architect.prompt.md)
+- [freemium_conversion_velocity_architect](prompts/growth/product_marketing/freemium_conversion_velocity_architect.prompt.md)
 - [product_led_growth_k_factor_architect](prompts/growth/product_marketing/product_led_growth_k_factor_architect.prompt.md)
 - [gtm_pricing_elasticity_architect](prompts/growth/strategy/gtm_pricing_elasticity_architect.prompt.md)
 

--- a/docs/prompts/growth/product_marketing/freemium_conversion_velocity_architect.prompt.md
+++ b/docs/prompts/growth/product_marketing/freemium_conversion_velocity_architect.prompt.md
@@ -1,0 +1,79 @@
+---
+title: freemium_conversion_velocity_architect
+---
+
+# freemium_conversion_velocity_architect
+
+Mathematically models and optimizes Freemium-to-Paid conversion velocity using user telemetry, addressing product friction and monetization failures.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/growth/product_marketing/freemium_conversion_velocity_architect.prompt.yaml)
+
+```yaml
+---
+name: freemium_conversion_velocity_architect
+version: 1.0.0
+description: Mathematically models and optimizes Freemium-to-Paid conversion velocity using user telemetry, addressing product friction and monetization failures.
+authors:
+  - Growth Strategy Genesis Architect
+metadata:
+  domain: growth/product_marketing
+  complexity: high
+variables:
+  - name: user_telemetry
+    description: Behavioral data covering free tier usage, feature adoption rates, and drop-off points.
+  - name: monetization_metrics
+    description: Current Free-to-Paid conversion rate, trial length, and upgrade trigger performance.
+  - name: financial_parameters
+    description: Current ARPU, Churn Rate, Gross Margin, and Blended CAC.
+model: gpt-4o
+modelParameters:
+  temperature: 0.15
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the Principal Product Marketing Director and Lead Growth Architect for a tier-one enterprise SaaS organization. You deliver unvarnished, commercially rigorous assessments of product friction, monetization failures, and feature-level adoption, operating without sugarcoating brutal market realities.
+
+      Your objective is to systematically model and accelerate Freemium-to-Paid conversion velocity, prescribing precise interventions that eliminate friction and maximize upgrade revenue.
+
+      Strict Execution Guidelines:
+      1. Growth Framework Integration: You must anchor your strategic synthesis in the AARRR (Acquisition, Activation, Retention, Referral, Revenue) funnel, specifically aggressively optimizing the Activation to Revenue conversion vectors to engineer seamless upgrade paths.
+      2. Financial Modeling Rigor: You must strictly use LaTeX for all advanced marketing metrics and financial modeling.
+         - You must calculate and define Customer Lifetime Value explicitly as: $LTV = \frac{ARPU \times \text{Gross Margin}}{\text{Churn Rate}}$
+         - You must calculate and define Return on Ad Spend explicitly as: $ROAS = \frac{\text{Revenue}}{\text{Cost}}$
+         - You must calculate and define Freemium Conversion Velocity explicitly as: $V_c = \frac{\text{Total Conversions}}{\text{Time to Convert (Days)}}$
+      3. Actionable Output: Formulate a rigorous conversion velocity model and prescribe a precise, feature-level intervention matrix mapping usage friction points to high-leverage product changes that natively trigger upgrade prompts within the user's natural workflow.
+  - role: user
+    content: |
+      Execute a critical gap analysis and develop a Freemium-to-Paid conversion velocity optimization workflow for the following enterprise SaaS profile.
+
+      <user_telemetry>
+      {{user_telemetry}}
+      </user_telemetry>
+
+      <monetization_metrics>
+      {{monetization_metrics}}
+      </monetization_metrics>
+
+      <financial_parameters>
+      {{financial_parameters}}
+      </financial_parameters>
+testData:
+  - variables:
+      user_telemetry: "Users engage heavily with core features (Day 7 active: 70%), but advanced reporting features (gated) are only discovered by 12% of the free user base. 45% drop off immediately after hitting a hard paywall without context."
+      monetization_metrics: "Current Free-to-Paid conversion rate is 2.1%. Average time to convert is 42 days."
+      financial_parameters: "ARPU: $1200, Churn Rate: 4.2%, Gross Margin: 80%, Blended CAC: $850."
+    expected: "A comprehensive conversion optimization architecture mapping feature-level interventions to surface contextual upgrade triggers before hard paywalls, integrating AARRR constraints, and featuring exact LaTeX financial equations for Conversion Velocity ($V_c$), LTV, and ROAS."
+  - variables:
+      user_telemetry: "Insufficient or corrupted data: 'Null' values for all feature adoption metrics."
+      monetization_metrics: "N/A"
+      financial_parameters: "ARPU: N/A, Churn Rate: N/A, Gross Margin: N/A, Blended CAC: N/A."
+    expected: "An unvarnished assessment stating the telemetry is insufficient to model conversion velocity, refusing to hallucinate baseline metrics, while outlining the required mathematical framework (AARRR, LTV, ROAS, V_c in LaTeX) needed once valid usage data is secured."
+evaluators:
+  - "Output must explicitly contain the AARRR funnel framework applied to the data."
+  - "Output must contain the exact LaTeX formula for LTV: $LTV = \\frac{ARPU \\times \\text{Gross Margin}}{\\text{Churn Rate}}$"
+  - "Output must contain the exact LaTeX formula for ROAS: $ROAS = \\frac{\\text{Revenue}}{\\text{Cost}}$"
+  - "Output must contain the exact LaTeX formula for Conversion Velocity: $V_c = \\frac{\\text{Total Conversions}}{\\text{Time to Convert (Days)}}$"
+  - "Output must prescribe a specific, feature-level intervention matrix to optimize upgrade triggers or rigorously reject invalid data."
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -310,6 +310,7 @@
 [predictive_cac_payback_modeler](prompts/growth/performance_marketing/predictive_cac_payback_modeler.prompt.md)
 [b2b_abm_pipeline_velocity_architect](prompts/growth/predictive_modeling/b2b_abm_pipeline_velocity_architect.prompt.md)
 [predictive_churn_ltv_optimization_architect](prompts/growth/predictive_modeling/predictive_churn_ltv_optimization_architect.prompt.md)
+[freemium_conversion_velocity_architect](prompts/growth/product_marketing/freemium_conversion_velocity_architect.prompt.md)
 [product_led_growth_k_factor_architect](prompts/growth/product_marketing/product_led_growth_k_factor_architect.prompt.md)
 [gtm_pricing_elasticity_architect](prompts/growth/strategy/gtm_pricing_elasticity_architect.prompt.md)
 [Imaging Charter Draft](prompts/clinical/imaging/imaging_workflow/01_imaging_charter_draft.prompt.md)

--- a/prompts/growth/product_marketing/freemium_conversion_velocity_architect.prompt.yaml
+++ b/prompts/growth/product_marketing/freemium_conversion_velocity_architect.prompt.yaml
@@ -1,0 +1,66 @@
+---
+name: freemium_conversion_velocity_architect
+version: 1.0.0
+description: Mathematically models and optimizes Freemium-to-Paid conversion velocity using user telemetry, addressing product friction and monetization failures.
+authors:
+  - Growth Strategy Genesis Architect
+metadata:
+  domain: growth/product_marketing
+  complexity: high
+variables:
+  - name: user_telemetry
+    description: Behavioral data covering free tier usage, feature adoption rates, and drop-off points.
+  - name: monetization_metrics
+    description: Current Free-to-Paid conversion rate, trial length, and upgrade trigger performance.
+  - name: financial_parameters
+    description: Current ARPU, Churn Rate, Gross Margin, and Blended CAC.
+model: gpt-4o
+modelParameters:
+  temperature: 0.15
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the Principal Product Marketing Director and Lead Growth Architect for a tier-one enterprise SaaS organization. You deliver unvarnished, commercially rigorous assessments of product friction, monetization failures, and feature-level adoption, operating without sugarcoating brutal market realities.
+
+      Your objective is to systematically model and accelerate Freemium-to-Paid conversion velocity, prescribing precise interventions that eliminate friction and maximize upgrade revenue.
+
+      Strict Execution Guidelines:
+      1. Growth Framework Integration: You must anchor your strategic synthesis in the AARRR (Acquisition, Activation, Retention, Referral, Revenue) funnel, specifically aggressively optimizing the Activation to Revenue conversion vectors to engineer seamless upgrade paths.
+      2. Financial Modeling Rigor: You must strictly use LaTeX for all advanced marketing metrics and financial modeling.
+         - You must calculate and define Customer Lifetime Value explicitly as: $LTV = \frac{ARPU \times \text{Gross Margin}}{\text{Churn Rate}}$
+         - You must calculate and define Return on Ad Spend explicitly as: $ROAS = \frac{\text{Revenue}}{\text{Cost}}$
+         - You must calculate and define Freemium Conversion Velocity explicitly as: $V_c = \frac{\text{Total Conversions}}{\text{Time to Convert (Days)}}$
+      3. Actionable Output: Formulate a rigorous conversion velocity model and prescribe a precise, feature-level intervention matrix mapping usage friction points to high-leverage product changes that natively trigger upgrade prompts within the user's natural workflow.
+  - role: user
+    content: |
+      Execute a critical gap analysis and develop a Freemium-to-Paid conversion velocity optimization workflow for the following enterprise SaaS profile.
+
+      <user_telemetry>
+      {{user_telemetry}}
+      </user_telemetry>
+
+      <monetization_metrics>
+      {{monetization_metrics}}
+      </monetization_metrics>
+
+      <financial_parameters>
+      {{financial_parameters}}
+      </financial_parameters>
+testData:
+  - variables:
+      user_telemetry: "Users engage heavily with core features (Day 7 active: 70%), but advanced reporting features (gated) are only discovered by 12% of the free user base. 45% drop off immediately after hitting a hard paywall without context."
+      monetization_metrics: "Current Free-to-Paid conversion rate is 2.1%. Average time to convert is 42 days."
+      financial_parameters: "ARPU: $1200, Churn Rate: 4.2%, Gross Margin: 80%, Blended CAC: $850."
+    expected: "A comprehensive conversion optimization architecture mapping feature-level interventions to surface contextual upgrade triggers before hard paywalls, integrating AARRR constraints, and featuring exact LaTeX financial equations for Conversion Velocity ($V_c$), LTV, and ROAS."
+  - variables:
+      user_telemetry: "Insufficient or corrupted data: 'Null' values for all feature adoption metrics."
+      monetization_metrics: "N/A"
+      financial_parameters: "ARPU: N/A, Churn Rate: N/A, Gross Margin: N/A, Blended CAC: N/A."
+    expected: "An unvarnished assessment stating the telemetry is insufficient to model conversion velocity, refusing to hallucinate baseline metrics, while outlining the required mathematical framework (AARRR, LTV, ROAS, V_c in LaTeX) needed once valid usage data is secured."
+evaluators:
+  - "Output must explicitly contain the AARRR funnel framework applied to the data."
+  - "Output must contain the exact LaTeX formula for LTV: $LTV = \\frac{ARPU \\times \\text{Gross Margin}}{\\text{Churn Rate}}$"
+  - "Output must contain the exact LaTeX formula for ROAS: $ROAS = \\frac{\\text{Revenue}}{\\text{Cost}}$"
+  - "Output must contain the exact LaTeX formula for Conversion Velocity: $V_c = \\frac{\\text{Total Conversions}}{\\text{Time to Convert (Days)}}$"
+  - "Output must prescribe a specific, feature-level intervention matrix to optimize upgrade triggers or rigorously reject invalid data."

--- a/prompts/growth/product_marketing/overview.md
+++ b/prompts/growth/product_marketing/overview.md
@@ -1,4 +1,5 @@
 # Product Marketing Overview
 
 ## Prompts
+- **[freemium_conversion_velocity_architect](freemium_conversion_velocity_architect.prompt.yaml)**: Mathematically models and optimizes Freemium-to-Paid conversion velocity using user telemetry, addressing product friction and monetization failures.
 - **[product_led_growth_k_factor_architect](product_led_growth_k_factor_architect.prompt.yaml)**: Formulates advanced Product-Led Growth (PLG) viral loop architectures, modeling K-Factor optimization and intrinsic referral mechanics to mathematically accelerate organic acquisition.


### PR DESCRIPTION
Adds a new high-complexity prompt template `freemium_conversion_velocity_architect` under `growth/product_marketing`. The prompt uses the Principal Growth Architect persona to mathematically model Freemium-to-Paid conversion velocity and prescribe feature-level interventions for enterprise SaaS. Includes full test data, strict LaTeX formatting requirements, and documentation updates.

---
*PR created automatically by Jules for task [11690079417316031512](https://jules.google.com/task/11690079417316031512) started by @fderuiter*