### PR TITLE
🧹 chore: remove unused import re in migrate_prompts.py

### DIFF
--- a/tools/scripts/migrate_prompts.py
+++ b/tools/scripts/migrate_prompts.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 try:


### PR DESCRIPTION
🎯 **What:** Removed the unused import `re` from `tools/scripts/migrate_prompts.py`.
💡 **Why:** This improves code health by removing dead code, which enhances maintainability and readability.
✅ **Verification:** I verified the change by reading the file and ensuring it's syntactically correct through compilation. I also attempted to run the full test suite, though it was blocked by environment issues.
✨ **Result:** A cleaner and more maintainable `migrate_prompts.py` script.

---
*PR created automatically by Jules for task [9278699495203275377](https://jules.google.com/task/9278699495203275377) started by @fderuiter*