### PR TITLE
🧱 Mason: [Architecture] Add evaluators to BFT consensus prompt

### DIFF
--- a/docs/prompts/technical/architecture/byzantine_fault_tolerant_consensus_architect.prompt.md
+++ b/docs/prompts/technical/architecture/byzantine_fault_tolerant_consensus_architect.prompt.md
@@ -104,6 +104,18 @@ testData:
       - name: Refusal JSON
         type: regex
         pattern: '\{"error": "unsafe"\}'
-evaluators: []
+evaluators:
+  - name: Consensus Protocol Header
+    type: regex
+    pattern: "(?i)Consensus Protocol"
+  - name: Cryptographic Primitives Header
+    type: regex
+    pattern: "(?i)Cryptographic Primitives"
+  - name: View Change Header
+    type: regex
+    pattern: "(?i)View Change"
+  - name: Network Protocol Header
+    type: regex
+    pattern: "(?i)Network Protocol"
 
 ```

--- a/prompts/technical/architecture/byzantine_fault_tolerant_consensus_architect.prompt.yaml
+++ b/prompts/technical/architecture/byzantine_fault_tolerant_consensus_architect.prompt.yaml
@@ -93,4 +93,16 @@ testData:
       - name: Refusal JSON
         type: regex
         pattern: '\{"error": "unsafe"\}'
-evaluators: []
+evaluators:
+  - name: Consensus Protocol Header
+    type: regex
+    pattern: "(?i)Consensus Protocol"
+  - name: Cryptographic Primitives Header
+    type: regex
+    pattern: "(?i)Cryptographic Primitives"
+  - name: View Change Header
+    type: regex
+    pattern: "(?i)View Change"
+  - name: Network Protocol Header
+    type: regex
+    pattern: "(?i)Network Protocol"


### PR DESCRIPTION
💡 **What:** Added global regex evaluators to the `byzantine_fault_tolerant_consensus_architect.prompt.yaml` file.
🎯 **Why:** To ensure the output rigorously contains all mandated structural components (e.g., Consensus Protocol, Cryptographic Primitives) and eliminate schema validation warnings about missing evaluators.
📊 **Impact:** Improved test reliability and schema strictness, ensuring downstream LLM execution actually adheres to the architectural framework requested.

---
*PR created automatically by Jules for task [10720646481651183299](https://jules.google.com/task/10720646481651183299) started by @fderuiter*