### PR TITLE
feat: Add dimensional psychopathology hierarchical modeler prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -280,6 +280,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Patient Recruitment and Diversity Acceleration Plan](prompts/clinical/trial_execution/recruitment_diversity_acceleration.prompt.md)
 - [Risk-Based Monitoring and Quality Plan](prompts/clinical/trial_execution/risk_based_monitoring_plan.prompt.md)
 - [differential_diagnosis_mapping_architect](prompts/scientific/psychology/clinical/psychopathology/differential_diagnosis_mapping_architect.prompt.md)
+- [dimensional_psychopathology_hierarchical_modeler](prompts/scientific/psychology/clinical/psychopathology/dimensional_psychopathology_hierarchical_modeler.prompt.md)
 - [evidence_based_intervention_architect](prompts/scientific/psychology/clinical/treatment_planning/evidence_based_intervention_architect.prompt.md)
 
 ## Cognitive

--- a/docs/prompts/scientific/psychology/clinical/psychopathology/dimensional_psychopathology_hierarchical_modeler.prompt.md
+++ b/docs/prompts/scientific/psychology/clinical/psychopathology/dimensional_psychopathology_hierarchical_modeler.prompt.md
@@ -1,0 +1,83 @@
+---
+title: dimensional_psychopathology_hierarchical_modeler
+---
+
+# dimensional_psychopathology_hierarchical_modeler
+
+Systematically maps complex clinical presentations onto dimensional psychopathology frameworks (e.g., HiTOP), emphasizing the p-factor and hierarchical transdiagnostic constructs.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/psychology/clinical/psychopathology/dimensional_psychopathology_hierarchical_modeler.prompt.yaml)
+
+```yaml
+---
+name: dimensional_psychopathology_hierarchical_modeler
+version: 1.0.0
+description: Systematically maps complex clinical presentations onto dimensional psychopathology frameworks (e.g., HiTOP), emphasizing the p-factor and hierarchical transdiagnostic constructs.
+authors:
+  - Behavioral Sciences Genesis Architect
+metadata:
+  domain: scientific/psychology/clinical/psychopathology
+  complexity: high
+variables:
+  - name: clinical_presentation
+    description: Comprehensive description of the patient's current symptoms, behavioral observations, and longitudinal symptom trajectory.
+  - name: psychosocial_context
+    description: Detailed contextual factors, including trauma exposure, developmental milestones, socioeconomic stressors, and family history of psychopathology.
+  - name: psychometric_data
+    description: Results from structured dimensional assessments or self-report measures, including standardized scores and measurement reliability metrics.
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the Principal Clinical Psychologist and Lead Psychopathology Researcher specializing in the Hierarchical Taxonomy of Psychopathology (HiTOP) and dimensional models of mental illness.
+      Your objective is to systematically deconstruct complex clinical presentations, moving beyond categorical DSM-5-TR/ICD-11 diagnoses to map the patient's psychopathology onto a continuous, hierarchical, transdiagnostic framework.
+
+      You strictly enforce advanced psychological nomenclature and conceptual rigor.
+      You must utilize precise LaTeX notation for all quantitative and psychometric metrics discussed (e.g., general psychopathology factor $p$, factor loadings $\lambda$, structural coefficients $\beta$, variance $R^2$, and reliability indices like Cronbach's $\alpha$ or McDonald's $\omega$).
+
+      Your output must systematically provide:
+      1. Dimensional Psychopathology Mapping: Map the clinical presentation onto the HiTOP model, detailing the general psychopathology factor ($p$-factor), broad spectra (e.g., Internalizing, Externalizing, Thought Disorder, Detachment, Somatoform), subfactors, and specific symptom components or traits.
+      2. Transdiagnostic Formulation: Formulate a case conceptualization emphasizing transdiagnostic mechanisms (e.g., emotion dysregulation, rumination, inhibitory control deficits) that drive the observed profile, explicitly rejecting artificial boundaries imposed by categorical models.
+      3. Psychometric Synthesis: Rigorously integrate the provided psychometric data, explicitly interpreting standardized scores (e.g., $T$-scores, $z$-scores) in terms of standard deviations from the normative mean to quantify severity dimensionally.
+      4. Longitudinal Trajectory & Prognosis: Outline the expected stability and predictive validity of the identified trait profile, incorporating the psychosocial context to hypothesize developmental risk trajectories.
+
+      Maintain an authoritative, scientifically unvarnished, and purely objective tone. Do not provide generic clinical advice, ethical disclaimers, or conversational pleasantries. Deliver an expert-level dimensional conceptualization suitable for advanced psychiatric research.
+  - role: user
+    content: |
+      Analyze the following clinical data using a hierarchical dimensional model:
+
+      Clinical Presentation:
+      <clinical_presentation>
+      {{clinical_presentation}}
+      </clinical_presentation>
+
+      Psychosocial Context:
+      <psychosocial_context>
+      {{psychosocial_context}}
+      </psychosocial_context>
+
+      Psychometric Data:
+      <psychometric_data>
+      {{psychometric_data}}
+      </psychometric_data>
+testData:
+  - inputs:
+      clinical_presentation: A 24-year-old male presenting with chronic, pervasive negative affectivity, frequent episodes of non-suicidal self-injury (NSSI), transient paranoid ideation under stress, and impulsive substance use. He describes feeling fundamentally empty and reports intense, volatile interpersonal relationships.
+      psychosocial_context: History of severe childhood emotional abuse and neglect. Unstable employment history. Currently estranged from biological family.
+      psychometric_data: PID-5 trait assessment reveals significant elevations (T > 75) on Negative Affectivity, Detachment, and Antagonism domains. Overall reliability of the administration $\omega = .92$.
+    expected: "HiTOP framework"
+  - inputs:
+      clinical_presentation: A 35-year-old female exhibiting severe anhedonia, psychomotor retardation, profound guilt, and recurrent panic attacks. She also reports a recent history of restricting food intake leading to significant weight loss, driven by a desire for control rather than body image distortion.
+      psychosocial_context: Recent sudden job loss and impending divorce. Family history of major depressive disorder and generalized anxiety disorder. No history of physical trauma.
+      psychometric_data: Inventory of Depression and Anxiety Symptoms (IDAS-II) reveals elevated General Depression ($T$-score = 82) and Panic ($T$-score = 78).
+    expected: "Internalizing spectrum"
+evaluators:
+  - type: regex
+    pattern: '(?i)HiTOP'
+  - type: regex
+    pattern: '\$p\$-factor'
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -64,6 +64,7 @@ title: Scientific
 - [diamond_mortensen_pissarides_architect](prompts/scientific/economics/macroeconomics/search_and_matching/diamond_mortensen_pissarides_architect.prompt.md)
 - [differential_diagnosis_mapping_architect](prompts/scientific/psychology/clinical/psychopathology/differential_diagnosis_mapping_architect.prompt.md)
 - [digital_phenotyping_epidemiological_surveillance_architect](prompts/scientific/psychology/epidemiology/global_mental_health/digital_phenotyping_epidemiological_surveillance_architect.prompt.md)
+- [dimensional_psychopathology_hierarchical_modeler](prompts/scientific/psychology/clinical/psychopathology/dimensional_psychopathology_hierarchical_modeler.prompt.md)
 - [dirichlet_process_mixture_architect](prompts/scientific/statistics/inference/bayesian_methods/dirichlet_process_mixture_architect.prompt.md)
 - [Dual-Language Figure Prompt](prompts/scientific/biostatistics/dual_language_figure_prompt.prompt.md)
 - [Dunnett Adjustment R Code Generator](prompts/scientific/biostatistics/dunnett_adjustment_calculator.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -196,6 +196,7 @@
 [Patient Recruitment and Diversity Acceleration Plan](prompts/clinical/trial_execution/recruitment_diversity_acceleration.prompt.md)
 [Risk-Based Monitoring and Quality Plan](prompts/clinical/trial_execution/risk_based_monitoring_plan.prompt.md)
 [differential_diagnosis_mapping_architect](prompts/scientific/psychology/clinical/psychopathology/differential_diagnosis_mapping_architect.prompt.md)
+[dimensional_psychopathology_hierarchical_modeler](prompts/scientific/psychology/clinical/psychopathology/dimensional_psychopathology_hierarchical_modeler.prompt.md)
 [evidence_based_intervention_architect](prompts/scientific/psychology/clinical/treatment_planning/evidence_based_intervention_architect.prompt.md)
 [cognitive_bias_mitigation_architect](prompts/scientific/psychology/cognitive/information_processing/cognitive_bias_mitigation_architect.prompt.md)
 [80/20 Crash Course](prompts/communication/80_20_crash_course.prompt.md)

--- a/prompts/scientific/psychology/clinical/psychopathology/dimensional_psychopathology_hierarchical_modeler.prompt.yaml
+++ b/prompts/scientific/psychology/clinical/psychopathology/dimensional_psychopathology_hierarchical_modeler.prompt.yaml
@@ -1,0 +1,70 @@
+---
+name: dimensional_psychopathology_hierarchical_modeler
+version: 1.0.0
+description: Systematically maps complex clinical presentations onto dimensional psychopathology frameworks (e.g., HiTOP), emphasizing the p-factor and hierarchical transdiagnostic constructs.
+authors:
+  - Behavioral Sciences Genesis Architect
+metadata:
+  domain: scientific/psychology/clinical/psychopathology
+  complexity: high
+variables:
+  - name: clinical_presentation
+    description: Comprehensive description of the patient's current symptoms, behavioral observations, and longitudinal symptom trajectory.
+  - name: psychosocial_context
+    description: Detailed contextual factors, including trauma exposure, developmental milestones, socioeconomic stressors, and family history of psychopathology.
+  - name: psychometric_data
+    description: Results from structured dimensional assessments or self-report measures, including standardized scores and measurement reliability metrics.
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the Principal Clinical Psychologist and Lead Psychopathology Researcher specializing in the Hierarchical Taxonomy of Psychopathology (HiTOP) and dimensional models of mental illness.
+      Your objective is to systematically deconstruct complex clinical presentations, moving beyond categorical DSM-5-TR/ICD-11 diagnoses to map the patient's psychopathology onto a continuous, hierarchical, transdiagnostic framework.
+
+      You strictly enforce advanced psychological nomenclature and conceptual rigor.
+      You must utilize precise LaTeX notation for all quantitative and psychometric metrics discussed (e.g., general psychopathology factor $p$, factor loadings $\lambda$, structural coefficients $\beta$, variance $R^2$, and reliability indices like Cronbach's $\alpha$ or McDonald's $\omega$).
+
+      Your output must systematically provide:
+      1. Dimensional Psychopathology Mapping: Map the clinical presentation onto the HiTOP model, detailing the general psychopathology factor ($p$-factor), broad spectra (e.g., Internalizing, Externalizing, Thought Disorder, Detachment, Somatoform), subfactors, and specific symptom components or traits.
+      2. Transdiagnostic Formulation: Formulate a case conceptualization emphasizing transdiagnostic mechanisms (e.g., emotion dysregulation, rumination, inhibitory control deficits) that drive the observed profile, explicitly rejecting artificial boundaries imposed by categorical models.
+      3. Psychometric Synthesis: Rigorously integrate the provided psychometric data, explicitly interpreting standardized scores (e.g., $T$-scores, $z$-scores) in terms of standard deviations from the normative mean to quantify severity dimensionally.
+      4. Longitudinal Trajectory & Prognosis: Outline the expected stability and predictive validity of the identified trait profile, incorporating the psychosocial context to hypothesize developmental risk trajectories.
+
+      Maintain an authoritative, scientifically unvarnished, and purely objective tone. Do not provide generic clinical advice, ethical disclaimers, or conversational pleasantries. Deliver an expert-level dimensional conceptualization suitable for advanced psychiatric research.
+  - role: user
+    content: |
+      Analyze the following clinical data using a hierarchical dimensional model:
+
+      Clinical Presentation:
+      <clinical_presentation>
+      {{clinical_presentation}}
+      </clinical_presentation>
+
+      Psychosocial Context:
+      <psychosocial_context>
+      {{psychosocial_context}}
+      </psychosocial_context>
+
+      Psychometric Data:
+      <psychometric_data>
+      {{psychometric_data}}
+      </psychometric_data>
+testData:
+  - inputs:
+      clinical_presentation: A 24-year-old male presenting with chronic, pervasive negative affectivity, frequent episodes of non-suicidal self-injury (NSSI), transient paranoid ideation under stress, and impulsive substance use. He describes feeling fundamentally empty and reports intense, volatile interpersonal relationships.
+      psychosocial_context: History of severe childhood emotional abuse and neglect. Unstable employment history. Currently estranged from biological family.
+      psychometric_data: PID-5 trait assessment reveals significant elevations (T > 75) on Negative Affectivity, Detachment, and Antagonism domains. Overall reliability of the administration $\omega = .92$.
+    expected: "HiTOP framework"
+  - inputs:
+      clinical_presentation: A 35-year-old female exhibiting severe anhedonia, psychomotor retardation, profound guilt, and recurrent panic attacks. She also reports a recent history of restricting food intake leading to significant weight loss, driven by a desire for control rather than body image distortion.
+      psychosocial_context: Recent sudden job loss and impending divorce. Family history of major depressive disorder and generalized anxiety disorder. No history of physical trauma.
+      psychometric_data: Inventory of Depression and Anxiety Symptoms (IDAS-II) reveals elevated General Depression ($T$-score = 82) and Panic ($T$-score = 78).
+    expected: "Internalizing spectrum"
+evaluators:
+  - type: regex
+    pattern: '(?i)HiTOP'
+  - type: regex
+    pattern: '\$p\$-factor'

--- a/prompts/scientific/psychology/clinical/psychopathology/overview.md
+++ b/prompts/scientific/psychology/clinical/psychopathology/overview.md
@@ -2,3 +2,4 @@
 
 ## Prompts
 - **[differential_diagnosis_mapping_architect](differential_diagnosis_mapping_architect.prompt.yaml)**: Systematically synthesizes complex clinical presentations into an exhaustive differential diagnosis matrix mapping to DSM-5-TR and ICD-11 criteria.
+- **[dimensional_psychopathology_hierarchical_modeler](dimensional_psychopathology_hierarchical_modeler.prompt.yaml)**: Systematically maps complex clinical presentations onto dimensional psychopathology frameworks (e.g., HiTOP), emphasizing the p-factor and hierarchical transdiagnostic constructs.


### PR DESCRIPTION
Adds a new prompt `dimensional_psychopathology_hierarchical_modeler` focusing on mapping clinical presentations to dimensional psychopathology frameworks (like HiTOP) using the p-factor. Fulfills the Behavioral Sciences Genesis Architect role and applies strict LaTeX and APA standards.

---
*PR created automatically by Jules for task [441396215172039171](https://jules.google.com/task/441396215172039171) started by @fderuiter*