### PR TITLE
feat: Add GTM pricing elasticity architect

### DIFF
--- a/docs/business.md
+++ b/docs/business.md
@@ -49,6 +49,7 @@ title: Business
 - [Global Regulatory and Tax Matrix for Site Payments](prompts/business/payment/global_regulatory_tax_matrix.prompt.md)
 - [Global Supply Chain Resilience Architect](prompts/business/operations/supply_chain/global_supply_chain_resilience_architect.prompt.md)
 - [global_supply_chain_geopolitical_duress_architect](prompts/business/operations/supply_chain/global_supply_chain_geopolitical_duress_architect.prompt.md)
+- [GTM Pricing Elasticity Architect](prompts/business/growth_engineering/gtm_pricing_elasticity_architect.prompt.md)
 - [Hostile Takeover Defense Matrix Architect](prompts/business/strategy/hostile_takeover_defense_matrix.prompt.md)
 - [Hype vs. Reality Analysis](prompts/business/vp_tech_innovation/hype_vs_reality_analysis.prompt.md)
 - [Investigator-Site Payment Forecast](prompts/business/payment/investigator_site_payment_forecast.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,6 +121,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Quantitative Enterprise Working Capital CCC Architect](prompts/business/finance/quantitative_enterprise_working_capital_ccc_architect.prompt.md)
 - [Quantitative M&A Accretion Dilution Architect](prompts/business/finance/quantitative_ma_accretion_dilution_architect.prompt.md)
 - [Algorithmic Multi-Touch Attribution Architect](prompts/business/growth_engineering/algorithmic_multi_touch_attribution_architect.prompt.md)
+- [GTM Pricing Elasticity Architect](prompts/business/growth_engineering/gtm_pricing_elasticity_architect.prompt.md)
 - [Predictive RFM Churn Mitigation Architect](prompts/business/growth_engineering/predictive_rfm_churn_mitigation_architect.prompt.md)
 - [Clinical-Trial Budget and Burn-Rate Dashboard](prompts/business/hr_finance/clinical_trial_budget_burn_rate_dashboard.prompt.md)
 - [GCP and GDPR Training Compliance Risk Report](prompts/business/hr_finance/gcp_gdpr_compliance_training_risk_report.prompt.md)

--- a/docs/prompts/business/growth_engineering/gtm_pricing_elasticity_architect.prompt.md
+++ b/docs/prompts/business/growth_engineering/gtm_pricing_elasticity_architect.prompt.md
@@ -1,0 +1,92 @@
+---
+title: GTM Pricing Elasticity Architect
+---
+
+# GTM Pricing Elasticity Architect
+
+Constructs deeply rigorous Go-To-Market (GTM) pricing elasticity matrices, modeling price sensitivity, optimal revenue maximization points, and willingness-to-pay using advanced econometric frameworks.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/business/growth_engineering/gtm_pricing_elasticity_architect.prompt.yaml)
+
+```yaml
+---
+name: GTM Pricing Elasticity Architect
+version: "1.0.0"
+description: Constructs deeply rigorous Go-To-Market (GTM) pricing elasticity matrices, modeling price sensitivity, optimal revenue maximization points, and willingness-to-pay using advanced econometric frameworks.
+authors:
+  - Growth Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - growth-engineering
+    - product-marketing
+    - pricing-strategy
+    - go-to-market
+    - financial-modeling
+variables:
+  - name: product_value_proposition
+    description: Detailed breakdown of the core enterprise SaaS product, including unique value metrics, competitive differentiation, and feature gating.
+    required: true
+  - name: target_market_segments
+    description: Definitions of the targeted customer cohorts, including firmographics, current software spend, and alternative solutions.
+    required: true
+  - name: financial_constraints
+    description: Required Gross Margins, Customer Acquisition Costs (CAC), and overall target Return on Ad Spend (ROAS) constraints.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Principal Growth Architect and Chief Marketing Officer. Your directive is to formulate a deeply rigorous Go-To-Market (GTM) pricing elasticity matrix for complex enterprise SaaS products.
+
+      You must discard superficial tiering (e.g., 'Bronze/Silver/Gold') without empirical backing. Instead, architect a robust pricing strategy based on price elasticity of demand (PED) and willingness-to-pay (WTP) analyses.
+
+      Your output must meticulously detail:
+      1. A rigorous econometric framework for defining the optimal price point that maximizes total revenue, factoring in potential churn and market saturation.
+      2. The strict mapping of this pricing model across the AARRR (Acquisition, Activation, Retention, Referral, Revenue) funnel, demonstrating how pricing tiers influence acquisition velocity versus long-term retention.
+      3. A commercial assessment outlining how changes in pricing impact Customer Lifetime Value (LTV) and Customer Acquisition Cost (CAC) payback periods.
+
+      You must strictly use LaTeX for all advanced marketing metrics and financial modeling. You must calculate and present equations for Price Elasticity of Demand ($E_d = \frac{\% \Delta Q}{\% \Delta P}$), Customer Lifetime Value ($LTV = \frac{ARPU \times \text{Gross Margin}}{\text{Churn Rate}}$), Customer Acquisition Cost ($CAC = \frac{\text{Total Marketing Costs}}{\text{Acquired Customers}}$), and Return on Ad Spend ($ROAS = \frac{\text{Revenue}}{\text{Cost}}$).
+
+      Do not sugarcoat the brutal realities of feature commoditization, price wars, or customer acquisition costs. Do not use conversational pleasantries. Provide the unvarnished strategic architecture directly.
+  - role: user
+    content: |
+      Engineer a Go-To-Market pricing elasticity architecture based on the following parameters:
+
+      <product_value_proposition>
+      {{product_value_proposition}}
+      </product_value_proposition>
+
+      <target_market_segments>
+      {{target_market_segments}}
+      </target_market_segments>
+
+      <financial_constraints>
+      {{financial_constraints}}
+      </financial_constraints>
+testData:
+  - inputs:
+      product_value_proposition: "Enterprise AI workflow automation platform. Reduces manual data entry by 80%. High switching costs once integrated."
+      target_market_segments: "Mid-market to Enterprise (500-5000 employees). Current spend on legacy solutions is $50k/year."
+      financial_constraints: "Target Gross Margin > 80%. Target CAC payback < 9 months."
+    expected: "GTM Pricing Elasticity Matrix and AARRR integration."
+  - inputs:
+      product_value_proposition: "Developer-focused API for real-time video processing. Usage-based consumption."
+      target_market_segments: "B2B Startups and scale-ups. High sensitivity to baseline costs but scales with their success."
+      financial_constraints: "Must maintain 70% Gross Margin at high volume. LTV:CAC must be > 4:1."
+    expected: "Usage-based Elasticity Modeling and LTV/CAC calculus."
+evaluators:
+  - name: Contains LTV Equation
+    string:
+      contains: "LTV ="
+  - name: Contains Price Elasticity Equation
+    string:
+      contains: "E_d"
+  - name: Enforces AARRR Funnel
+    string:
+      contains: "AARRR"
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -52,6 +52,7 @@
 [Quantitative Enterprise Working Capital CCC Architect](prompts/business/finance/quantitative_enterprise_working_capital_ccc_architect.prompt.md)
 [Quantitative M&A Accretion Dilution Architect](prompts/business/finance/quantitative_ma_accretion_dilution_architect.prompt.md)
 [Algorithmic Multi-Touch Attribution Architect](prompts/business/growth_engineering/algorithmic_multi_touch_attribution_architect.prompt.md)
+[GTM Pricing Elasticity Architect](prompts/business/growth_engineering/gtm_pricing_elasticity_architect.prompt.md)
 [Predictive RFM Churn Mitigation Architect](prompts/business/growth_engineering/predictive_rfm_churn_mitigation_architect.prompt.md)
 [Clinical-Trial Budget and Burn-Rate Dashboard](prompts/business/hr_finance/clinical_trial_budget_burn_rate_dashboard.prompt.md)
 [GCP and GDPR Training Compliance Risk Report](prompts/business/hr_finance/gcp_gdpr_compliance_training_risk_report.prompt.md)

--- a/prompts/business/growth_engineering/gtm_pricing_elasticity_architect.prompt.yaml
+++ b/prompts/business/growth_engineering/gtm_pricing_elasticity_architect.prompt.yaml
@@ -1,0 +1,79 @@
+---
+name: GTM Pricing Elasticity Architect
+version: "1.0.0"
+description: Constructs deeply rigorous Go-To-Market (GTM) pricing elasticity matrices, modeling price sensitivity, optimal revenue maximization points, and willingness-to-pay using advanced econometric frameworks.
+authors:
+  - Growth Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - growth-engineering
+    - product-marketing
+    - pricing-strategy
+    - go-to-market
+    - financial-modeling
+variables:
+  - name: product_value_proposition
+    description: Detailed breakdown of the core enterprise SaaS product, including unique value metrics, competitive differentiation, and feature gating.
+    required: true
+  - name: target_market_segments
+    description: Definitions of the targeted customer cohorts, including firmographics, current software spend, and alternative solutions.
+    required: true
+  - name: financial_constraints
+    description: Required Gross Margins, Customer Acquisition Costs (CAC), and overall target Return on Ad Spend (ROAS) constraints.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Principal Growth Architect and Chief Marketing Officer. Your directive is to formulate a deeply rigorous Go-To-Market (GTM) pricing elasticity matrix for complex enterprise SaaS products.
+
+      You must discard superficial tiering (e.g., 'Bronze/Silver/Gold') without empirical backing. Instead, architect a robust pricing strategy based on price elasticity of demand (PED) and willingness-to-pay (WTP) analyses.
+
+      Your output must meticulously detail:
+      1. A rigorous econometric framework for defining the optimal price point that maximizes total revenue, factoring in potential churn and market saturation.
+      2. The strict mapping of this pricing model across the AARRR (Acquisition, Activation, Retention, Referral, Revenue) funnel, demonstrating how pricing tiers influence acquisition velocity versus long-term retention.
+      3. A commercial assessment outlining how changes in pricing impact Customer Lifetime Value (LTV) and Customer Acquisition Cost (CAC) payback periods.
+
+      You must strictly use LaTeX for all advanced marketing metrics and financial modeling. You must calculate and present equations for Price Elasticity of Demand ($E_d = \frac{\% \Delta Q}{\% \Delta P}$), Customer Lifetime Value ($LTV = \frac{ARPU \times \text{Gross Margin}}{\text{Churn Rate}}$), Customer Acquisition Cost ($CAC = \frac{\text{Total Marketing Costs}}{\text{Acquired Customers}}$), and Return on Ad Spend ($ROAS = \frac{\text{Revenue}}{\text{Cost}}$).
+
+      Do not sugarcoat the brutal realities of feature commoditization, price wars, or customer acquisition costs. Do not use conversational pleasantries. Provide the unvarnished strategic architecture directly.
+  - role: user
+    content: |
+      Engineer a Go-To-Market pricing elasticity architecture based on the following parameters:
+
+      <product_value_proposition>
+      {{product_value_proposition}}
+      </product_value_proposition>
+
+      <target_market_segments>
+      {{target_market_segments}}
+      </target_market_segments>
+
+      <financial_constraints>
+      {{financial_constraints}}
+      </financial_constraints>
+testData:
+  - inputs:
+      product_value_proposition: "Enterprise AI workflow automation platform. Reduces manual data entry by 80%. High switching costs once integrated."
+      target_market_segments: "Mid-market to Enterprise (500-5000 employees). Current spend on legacy solutions is $50k/year."
+      financial_constraints: "Target Gross Margin > 80%. Target CAC payback < 9 months."
+    expected: "GTM Pricing Elasticity Matrix and AARRR integration."
+  - inputs:
+      product_value_proposition: "Developer-focused API for real-time video processing. Usage-based consumption."
+      target_market_segments: "B2B Startups and scale-ups. High sensitivity to baseline costs but scales with their success."
+      financial_constraints: "Must maintain 70% Gross Margin at high volume. LTV:CAC must be > 4:1."
+    expected: "Usage-based Elasticity Modeling and LTV/CAC calculus."
+evaluators:
+  - name: Contains LTV Equation
+    string:
+      contains: "LTV ="
+  - name: Contains Price Elasticity Equation
+    string:
+      contains: "E_d"
+  - name: Enforces AARRR Funnel
+    string:
+      contains: "AARRR"

--- a/prompts/business/growth_engineering/overview.md
+++ b/prompts/business/growth_engineering/overview.md
@@ -2,4 +2,5 @@
 
 ## Prompts
 - **[Algorithmic Multi-Touch Attribution Architect](algorithmic_multi_touch_attribution_architect.prompt.yaml)**: Constructs highly rigorous, algorithmic multi-touch attribution (MTA) models using Markov chains and Shapley values, mapping fractional credit across the AARRR funnel for enterprise performance marketing.
+- **[GTM Pricing Elasticity Architect](gtm_pricing_elasticity_architect.prompt.yaml)**: Constructs deeply rigorous Go-To-Market (GTM) pricing elasticity matrices, modeling price sensitivity, optimal revenue maximization points, and willingness-to-pay using advanced econometric frameworks.
 - **[Predictive RFM Churn Mitigation Architect](predictive_rfm_churn_mitigation_architect.prompt.yaml)**: Constructs deeply rigorous, predictive churn mitigation workflows using advanced Recency-Frequency-Monetary (RFM) analysis and the AARRR funnel for enterprise growth strategy.


### PR DESCRIPTION
Adds a new expert-level prompt for generating Go-To-Market pricing elasticity matrices, modeling price sensitivity and optimal revenue points using advanced econometrics.

---
*PR created automatically by Jules for task [9269465168270347158](https://jules.google.com/task/9269465168270347158) started by @fderuiter*