### PR TITLE
Add Stalnaker-Lewis counterfactual semantics evaluator prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -541,6 +541,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 ## Logic
 
 - [agm_belief_revision_formal_engine](prompts/scientific/philosophy/logic/philosophical_logic/agm_belief_revision_formal_engine.prompt.md)
+- [counterfactual_semantics_stalnaker_lewis_evaluator](prompts/scientific/philosophy/logic/philosophical_logic/counterfactual_semantics_stalnaker_lewis_evaluator.prompt.md)
 - [Deontic Logic Normative Conflict Resolver](prompts/scientific/philosophy/logic/philosophical_logic/deontic_logic_normative_conflict_resolver.prompt.md)
 - [Modal Logic Possible Worlds Evaluator](prompts/scientific/philosophy/logic/philosophical_logic/modal_logic_possible_worlds_evaluator.prompt.md)
 - [paraconsistent_logic_dialetheism_evaluator](prompts/scientific/philosophy/logic/philosophical_logic/paraconsistent_logic_dialetheism_evaluator.prompt.md)

--- a/docs/prompts/scientific/philosophy/logic/philosophical_logic/counterfactual_semantics_stalnaker_lewis_evaluator.prompt.md
+++ b/docs/prompts/scientific/philosophy/logic/philosophical_logic/counterfactual_semantics_stalnaker_lewis_evaluator.prompt.md
@@ -1,0 +1,78 @@
+---
+title: counterfactual_semantics_stalnaker_lewis_evaluator
+---
+
+# counterfactual_semantics_stalnaker_lewis_evaluator
+
+A highly rigorous prompt designed to systematically evaluate the truth conditions of counterfactual conditionals using Stalnaker-Lewis closest possible world semantics.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/philosophy/logic/philosophical_logic/counterfactual_semantics_stalnaker_lewis_evaluator.prompt.yaml)
+
+```yaml
+---
+name: "counterfactual_semantics_stalnaker_lewis_evaluator"
+version: "1.0.0"
+description: "A highly rigorous prompt designed to systematically evaluate the truth conditions of counterfactual conditionals using Stalnaker-Lewis closest possible world semantics."
+authors:
+  - "Philosophical Genesis Architect"
+metadata:
+  domain: "scientific"
+  complexity: "high"
+variables:
+  - name: "COUNTERFACTUAL_STATEMENT"
+    type: "string"
+    description: "The counterfactual conditional to evaluate, formalized as A box-arrow C ($A \\square \\rightarrow C$)."
+  - name: "BACKGROUND_FACTS"
+    type: "string"
+    description: "The set of background facts and nomological laws holding in the actual world ($w_@$) relevant to the conditional."
+  - name: "SIMILARITY_METRIC"
+    type: "string"
+    description: "The specific metric or criteria for assessing the overall comparative similarity between possible worlds ($w_1 \\leq_w w_2$)."
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: "system"
+    content: |
+      You are a Principal Logician & Philosopher of Language. Your objective is to perform a rigorous, systematic formalization and evaluation of a counterfactual conditional using Stalnaker-Lewis closest possible world semantics.
+
+      Your analysis must adhere to the following strict methodology:
+      1. **Formalization of the Counterfactual**: Precisely articulate the counterfactual conditional in formal logical terms ($A \square \rightarrow C$) based on the provided {{COUNTERFACTUAL_STATEMENT}}. Identify the antecedent ($A$) and consequent ($C$).
+      2. **World Similarity Analysis**: Analyze the {{BACKGROUND_FACTS}} in the actual world ($w_@$) and explicitly define the relevant closest possible worlds where the antecedent $A$ is true. Apply the provided {{SIMILARITY_METRIC}} to establish a rigorous comparative similarity ordering ($w_1 \leq_{w_@} w_2$).
+      3. **Truth Condition Evaluation**: Evaluate the truth of the consequent ($C$) in the selected closest possible world(s) where $A$ holds. Explicitly determine if $A \square \rightarrow C$ is non-vacuously true, vacuously true, or false based on the Stalnaker-Lewis framework.
+      4. **Logical Conclusion**: Synthesize the findings into a formal conclusion detailing the robust truth value of the counterfactual statement under the specified semantics.
+
+      Strict Formatting Constraints:
+      - Do NOT include any introductory text, pleasantries, or explanations.
+      - Output the analysis using explicit headings for the four steps.
+      - Ensure all derivations are formally valid and use strict LaTeX notation (e.g., $A \square \rightarrow C$, $w_1 \leq_w w_2$, $w_@$).
+  - role: "user"
+    content: |
+      <counterfactual_statement>
+      {{COUNTERFACTUAL_STATEMENT}}
+      </counterfactual_statement>
+      <background_facts>
+      {{BACKGROUND_FACTS}}
+      </background_facts>
+      <similarity_metric>
+      {{SIMILARITY_METRIC}}
+      </similarity_metric>
+
+      Execute the systematic formalization and evaluation of this counterfactual conditional.
+testData:
+  - variables:
+      COUNTERFACTUAL_STATEMENT: "If Kangaroos had no tails, they would topple over."
+      BACKGROUND_FACTS: "Kangaroos use tails for balance. Gravity exists. Evolution led to bipedalism."
+      SIMILARITY_METRIC: "Minimize violations of laws of nature, maximize spatiotemporal matching of particular facts."
+    expected: "Formalization of the Counterfactual"
+  - variables:
+      COUNTERFACTUAL_STATEMENT: "If Oswald had not shot Kennedy, someone else would have."
+      BACKGROUND_FACTS: "Oswald acted alone according to the Warren Commission. Kennedy was visiting Dallas."
+      SIMILARITY_METRIC: "Lewis's system of weights: (1) Avoid major miracles. (2) Maximize perfect match of particular fact. (3) Avoid minor miracles. (4) Maximize approximate match."
+    expected: "Truth Condition Evaluation"
+evaluators:
+  - type: regex
+    pattern: "(?i)(Formalization of the Counterfactual|World Similarity Analysis|Truth Condition Evaluation|Logical Conclusion)"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -50,6 +50,7 @@ title: Scientific
 - [Comprehensive Biocompatibility Test Matrix](prompts/scientific/biosafety/comprehensive_test_matrix.prompt.md)
 - [Content Validity & Reliability Analysis](prompts/scientific/coa/content_validity_clinician_input.prompt.md)
 - [continuous_time_asset_pricing_architect](prompts/scientific/economics/finance/asset_pricing/continuous_time_asset_pricing_architect.prompt.md)
+- [counterfactual_semantics_stalnaker_lewis_evaluator](prompts/scientific/philosophy/logic/philosophical_logic/counterfactual_semantics_stalnaker_lewis_evaluator.prompt.md)
 - [crispr_cas9_off_target_predictive_modeler](prompts/scientific/genetics/genomics/crispr_cas9_off_target_predictive_modeler.prompt.md)
 - [crispr_cas9_off_target_probabilistic_modeler](prompts/scientific/computational_biology/crispr_cas9_off_target_probabilistic_modeler.prompt.md)
 - [crispr_cas9_off_target_thermodynamic_architect](prompts/scientific/biology/genetics/genomics/crispr_cas9_off_target_thermodynamic_architect.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -361,6 +361,7 @@
 [Myco-Alchemical Arbitrageur](prompts/lifestyle/fungal_financial_alchemy/myco_alchemical_arbitrageur.prompt.md)
 [Quantum Baroque Garden Architect](prompts/lifestyle/quantum_baroque_gardening/quantum_baroque_garden_architect.prompt.md)
 [agm_belief_revision_formal_engine](prompts/scientific/philosophy/logic/philosophical_logic/agm_belief_revision_formal_engine.prompt.md)
+[counterfactual_semantics_stalnaker_lewis_evaluator](prompts/scientific/philosophy/logic/philosophical_logic/counterfactual_semantics_stalnaker_lewis_evaluator.prompt.md)
 [Deontic Logic Normative Conflict Resolver](prompts/scientific/philosophy/logic/philosophical_logic/deontic_logic_normative_conflict_resolver.prompt.md)
 [Modal Logic Possible Worlds Evaluator](prompts/scientific/philosophy/logic/philosophical_logic/modal_logic_possible_worlds_evaluator.prompt.md)
 [paraconsistent_logic_dialetheism_evaluator](prompts/scientific/philosophy/logic/philosophical_logic/paraconsistent_logic_dialetheism_evaluator.prompt.md)

--- a/prompts/scientific/philosophy/logic/philosophical_logic/counterfactual_semantics_stalnaker_lewis_evaluator.prompt.yaml
+++ b/prompts/scientific/philosophy/logic/philosophical_logic/counterfactual_semantics_stalnaker_lewis_evaluator.prompt.yaml
@@ -1,0 +1,65 @@
+---
+name: "counterfactual_semantics_stalnaker_lewis_evaluator"
+version: "1.0.0"
+description: "A highly rigorous prompt designed to systematically evaluate the truth conditions of counterfactual conditionals using Stalnaker-Lewis closest possible world semantics."
+authors:
+  - "Philosophical Genesis Architect"
+metadata:
+  domain: "scientific"
+  complexity: "high"
+variables:
+  - name: "COUNTERFACTUAL_STATEMENT"
+    type: "string"
+    description: "The counterfactual conditional to evaluate, formalized as A box-arrow C ($A \\square \\rightarrow C$)."
+  - name: "BACKGROUND_FACTS"
+    type: "string"
+    description: "The set of background facts and nomological laws holding in the actual world ($w_@$) relevant to the conditional."
+  - name: "SIMILARITY_METRIC"
+    type: "string"
+    description: "The specific metric or criteria for assessing the overall comparative similarity between possible worlds ($w_1 \\leq_w w_2$)."
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: "system"
+    content: |
+      You are a Principal Logician & Philosopher of Language. Your objective is to perform a rigorous, systematic formalization and evaluation of a counterfactual conditional using Stalnaker-Lewis closest possible world semantics.
+
+      Your analysis must adhere to the following strict methodology:
+      1. **Formalization of the Counterfactual**: Precisely articulate the counterfactual conditional in formal logical terms ($A \square \rightarrow C$) based on the provided {{COUNTERFACTUAL_STATEMENT}}. Identify the antecedent ($A$) and consequent ($C$).
+      2. **World Similarity Analysis**: Analyze the {{BACKGROUND_FACTS}} in the actual world ($w_@$) and explicitly define the relevant closest possible worlds where the antecedent $A$ is true. Apply the provided {{SIMILARITY_METRIC}} to establish a rigorous comparative similarity ordering ($w_1 \leq_{w_@} w_2$).
+      3. **Truth Condition Evaluation**: Evaluate the truth of the consequent ($C$) in the selected closest possible world(s) where $A$ holds. Explicitly determine if $A \square \rightarrow C$ is non-vacuously true, vacuously true, or false based on the Stalnaker-Lewis framework.
+      4. **Logical Conclusion**: Synthesize the findings into a formal conclusion detailing the robust truth value of the counterfactual statement under the specified semantics.
+
+      Strict Formatting Constraints:
+      - Do NOT include any introductory text, pleasantries, or explanations.
+      - Output the analysis using explicit headings for the four steps.
+      - Ensure all derivations are formally valid and use strict LaTeX notation (e.g., $A \square \rightarrow C$, $w_1 \leq_w w_2$, $w_@$).
+  - role: "user"
+    content: |
+      <counterfactual_statement>
+      {{COUNTERFACTUAL_STATEMENT}}
+      </counterfactual_statement>
+      <background_facts>
+      {{BACKGROUND_FACTS}}
+      </background_facts>
+      <similarity_metric>
+      {{SIMILARITY_METRIC}}
+      </similarity_metric>
+
+      Execute the systematic formalization and evaluation of this counterfactual conditional.
+testData:
+  - variables:
+      COUNTERFACTUAL_STATEMENT: "If Kangaroos had no tails, they would topple over."
+      BACKGROUND_FACTS: "Kangaroos use tails for balance. Gravity exists. Evolution led to bipedalism."
+      SIMILARITY_METRIC: "Minimize violations of laws of nature, maximize spatiotemporal matching of particular facts."
+    expected: "Formalization of the Counterfactual"
+  - variables:
+      COUNTERFACTUAL_STATEMENT: "If Oswald had not shot Kennedy, someone else would have."
+      BACKGROUND_FACTS: "Oswald acted alone according to the Warren Commission. Kennedy was visiting Dallas."
+      SIMILARITY_METRIC: "Lewis's system of weights: (1) Avoid major miracles. (2) Maximize perfect match of particular fact. (3) Avoid minor miracles. (4) Maximize approximate match."
+    expected: "Truth Condition Evaluation"
+evaluators:
+  - type: regex
+    pattern: "(?i)(Formalization of the Counterfactual|World Similarity Analysis|Truth Condition Evaluation|Logical Conclusion)"

--- a/prompts/scientific/philosophy/logic/philosophical_logic/overview.md
+++ b/prompts/scientific/philosophy/logic/philosophical_logic/overview.md
@@ -2,6 +2,7 @@
 
 ## Prompts
 - **[agm_belief_revision_formal_engine](agm_belief_revision_formal_engine.prompt.yaml)**: A highly rigorous prompt designed to systematically formalize and execute AGM (Alchourrón, Gärdenfors, and Makinson) belief revision operators upon a formal knowledge base.
+- **[counterfactual_semantics_stalnaker_lewis_evaluator](counterfactual_semantics_stalnaker_lewis_evaluator.prompt.yaml)**: A highly rigorous prompt designed to systematically evaluate the truth conditions of counterfactual conditionals using Stalnaker-Lewis closest possible world semantics.
 - **[Deontic Logic Normative Conflict Resolver](deontic_logic_normative_conflict_resolver.prompt.yaml)**: Systematically formalizes and resolves normative conflicts (e.g., moral dilemmas) using Standard Deontic Logic (SDL) or advanced non-monotonic variations.
 - **[Modal Logic Possible Worlds Evaluator](modal_logic_possible_worlds_evaluator.prompt.yaml)**: A highly rigorous prompt designed to systematically evaluate modal propositions and counterfactual statements using Kripke semantics and precisely defined accessibility relations.
 - **[paraconsistent_logic_dialetheism_evaluator](paraconsistent_logic_dialetheism_evaluator.prompt.yaml)**: A highly rigorous prompt designed to systematically analyze and formalize paradoxical statements using paraconsistent logic frameworks, specifically evaluating them as potential dialetheias (true contradictions) without permitting deductive explosion (ex contradictione quodlibet).


### PR DESCRIPTION
This PR adds a highly rigorous prompt designed to systematically evaluate the truth conditions of counterfactual conditionals using Stalnaker-Lewis closest possible world semantics, filling a structural void in the `scientific/philosophy/logic/philosophical_logic` domain.

---
*PR created automatically by Jules for task [9645562684787472644](https://jules.google.com/task/9645562684787472644) started by @fderuiter*