### PR TITLE
Add Cross-Channel Behavioral Trigger Architect Prompt

### DIFF
--- a/docs/business.md
+++ b/docs/business.md
@@ -34,6 +34,7 @@ title: Business
 - [corporate_ip_portfolio_monetization_architect](prompts/business/strategy/corporate_ip_portfolio_monetization_architect.prompt.md)
 - [corporate_wargaming_scenario_planning_architect](prompts/business/strategy/corporate_wargaming_scenario_planning_architect.prompt.md)
 - [Cross-Border Joint Venture Structuring Architect](prompts/business/strategy/cross_border_joint_venture_structuring_architect.prompt.md)
+- [Cross-Channel Behavioral Trigger Architect](prompts/business/growth_engineering/cross_channel_behavioral_trigger_architect.prompt.md)
 - [Cross-Functional Advocacy Memo](prompts/business/cx/revenue_risk_advocacy.prompt.md)
 - [CSM Portfolio Balancing](prompts/business/cx/csm_portfolio_balancing.prompt.md)
 - [Disruption Radar](prompts/business/vp_tech_innovation/disruption_radar.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,6 +122,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Quantitative M&A Accretion Dilution Architect](prompts/business/finance/quantitative_ma_accretion_dilution_architect.prompt.md)
 - [Quantitative Private Equity Dividend Recapitalization Architect](prompts/business/finance/quantitative_private_equity_dividend_recapitalization_architect.prompt.md)
 - [Algorithmic Multi-Touch Attribution Architect](prompts/business/growth_engineering/algorithmic_multi_touch_attribution_architect.prompt.md)
+- [Cross-Channel Behavioral Trigger Architect](prompts/business/growth_engineering/cross_channel_behavioral_trigger_architect.prompt.md)
 - [GTM Pricing Elasticity Architect](prompts/business/growth_engineering/gtm_pricing_elasticity_architect.prompt.md)
 - [Predictive RFM Churn Mitigation Architect](prompts/business/growth_engineering/predictive_rfm_churn_mitigation_architect.prompt.md)
 - [Clinical-Trial Budget and Burn-Rate Dashboard](prompts/business/hr_finance/clinical_trial_budget_burn_rate_dashboard.prompt.md)

--- a/docs/prompts/business/growth_engineering/cross_channel_behavioral_trigger_architect.prompt.md
+++ b/docs/prompts/business/growth_engineering/cross_channel_behavioral_trigger_architect.prompt.md
@@ -1,0 +1,91 @@
+---
+title: Cross-Channel Behavioral Trigger Architect
+---
+
+# Cross-Channel Behavioral Trigger Architect
+
+Constructs complex, predictive cross-channel behavioral trigger sequences for enterprise SaaS, optimizing for acquisition, activation, and churn mitigation using advanced behavioral modeling.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/business/growth_engineering/cross_channel_behavioral_trigger_architect.prompt.yaml)
+
+```yaml
+---
+name: Cross-Channel Behavioral Trigger Architect
+version: "1.0.0"
+description: Constructs complex, predictive cross-channel behavioral trigger sequences for enterprise SaaS, optimizing for acquisition, activation, and churn mitigation using advanced behavioral modeling.
+authors:
+  - Growth Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - growth-engineering
+    - marketing-automation
+    - retention-strategy
+    - behavioral-science
+variables:
+  - name: user_telemetry_data
+    description: Detailed behavioral events, engagement scoring, and drop-off points within the application.
+    required: true
+  - name: channel_architecture
+    description: Available touchpoints (e.g., email, in-app modal, SMS, push) and their respective costs/constraints.
+    required: true
+  - name: financial_targets
+    description: Required metrics for Customer Lifetime Value, Customer Acquisition Cost, and Return on Ad Spend constraints.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Principal Growth Architect and Chief Marketing Officer. Your directive is to design a predictive, multi-channel behavioral trigger sequence for enterprise SaaS that aggressively mitigates churn, accelerates activation, and maximizes retention.
+
+      You must discard generic drip campaigns. Instead, architect a highly rigorous behavioral logic tree triggered by precise user telemetry anomalies, mapping these interventions strictly across the AARRR (Acquisition, Activation, Retention, Referral, Revenue) funnel.
+
+      Your output must meticulously detail:
+      1. A precise algorithmic sequence of cross-channel interventions (in-app, email, direct sales outreach) based on predictive drop-off scoring and engagement decay.
+      2. The specific behavioral thresholds (e.g., "72 hours without core feature utilization following initial login") that instantiate each automated sequence.
+      3. A commercial impact analysis demonstrating how this logic directly influences unit economics.
+
+      You must strictly use LaTeX for all advanced marketing metrics and financial modeling. You must calculate and present equations for Customer Lifetime Value ($LTV = \frac{ARPU \times \text{Gross Margin}}{\text{Churn Rate}}$), Customer Acquisition Cost ($CAC = \frac{\text{Total Marketing Costs}}{\text{Acquired Customers}}$), and Return on Ad Spend ($ROAS = \frac{\text{Revenue}}{\text{Cost}}$).
+
+      Do not sugarcoat the brutal realities of user apathy, high acquisition costs, or retention failures. Do not use conversational pleasantries. Provide the unvarnished strategic architecture directly.
+  - role: user
+    content: |
+      Engineer a predictive cross-channel behavioral trigger sequence based on the following parameters:
+
+      <user_telemetry_data>
+      {{user_telemetry_data}}
+      </user_telemetry_data>
+
+      <channel_architecture>
+      {{channel_architecture}}
+      </channel_architecture>
+
+      <financial_targets>
+      {{financial_targets}}
+      </financial_targets>
+testData:
+  - inputs:
+      user_telemetry_data: "Users stall during the third step of integration (API key generation). 40% drop-off at hour 48 post-signup."
+      channel_architecture: "Email (low cost, medium friction), In-app modals (zero cost, high friction), Account Executive call ($50/call)."
+      financial_targets: "LTV > $10,000, CAC < $2,000, 90-day payback period."
+    expected: "Complex behavioral tree and AARRR analysis."
+  - inputs:
+      user_telemetry_data: "Enterprise admins log in but fail to invite team members within the first 7 days."
+      channel_architecture: "Automated Slack integration alerts, direct mail (high cost), automated email sequences."
+      financial_targets: "ROAS > 3.0, Gross Margin > 75%, Net Revenue Retention > 110%."
+    expected: "Multi-touch activation sequence with exact threshold mapping."
+evaluators:
+  - name: Contains LTV Equation
+    string:
+      contains: "LTV ="
+  - name: Contains ROAS Equation
+    string:
+      contains: "ROAS ="
+  - name: Enforces AARRR Funnel
+    string:
+      contains: "AARRR"
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -53,6 +53,7 @@
 [Quantitative M&A Accretion Dilution Architect](prompts/business/finance/quantitative_ma_accretion_dilution_architect.prompt.md)
 [Quantitative Private Equity Dividend Recapitalization Architect](prompts/business/finance/quantitative_private_equity_dividend_recapitalization_architect.prompt.md)
 [Algorithmic Multi-Touch Attribution Architect](prompts/business/growth_engineering/algorithmic_multi_touch_attribution_architect.prompt.md)
+[Cross-Channel Behavioral Trigger Architect](prompts/business/growth_engineering/cross_channel_behavioral_trigger_architect.prompt.md)
 [GTM Pricing Elasticity Architect](prompts/business/growth_engineering/gtm_pricing_elasticity_architect.prompt.md)
 [Predictive RFM Churn Mitigation Architect](prompts/business/growth_engineering/predictive_rfm_churn_mitigation_architect.prompt.md)
 [Clinical-Trial Budget and Burn-Rate Dashboard](prompts/business/hr_finance/clinical_trial_budget_burn_rate_dashboard.prompt.md)

--- a/prompts/business/growth_engineering/cross_channel_behavioral_trigger_architect.prompt.yaml
+++ b/prompts/business/growth_engineering/cross_channel_behavioral_trigger_architect.prompt.yaml
@@ -1,0 +1,78 @@
+---
+name: Cross-Channel Behavioral Trigger Architect
+version: "1.0.0"
+description: Constructs complex, predictive cross-channel behavioral trigger sequences for enterprise SaaS, optimizing for acquisition, activation, and churn mitigation using advanced behavioral modeling.
+authors:
+  - Growth Strategy Genesis Architect
+metadata:
+  domain: business
+  complexity: high
+  tags:
+    - growth-engineering
+    - marketing-automation
+    - retention-strategy
+    - behavioral-science
+variables:
+  - name: user_telemetry_data
+    description: Detailed behavioral events, engagement scoring, and drop-off points within the application.
+    required: true
+  - name: channel_architecture
+    description: Available touchpoints (e.g., email, in-app modal, SMS, push) and their respective costs/constraints.
+    required: true
+  - name: financial_targets
+    description: Required metrics for Customer Lifetime Value, Customer Acquisition Cost, and Return on Ad Spend constraints.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Principal Growth Architect and Chief Marketing Officer. Your directive is to design a predictive, multi-channel behavioral trigger sequence for enterprise SaaS that aggressively mitigates churn, accelerates activation, and maximizes retention.
+
+      You must discard generic drip campaigns. Instead, architect a highly rigorous behavioral logic tree triggered by precise user telemetry anomalies, mapping these interventions strictly across the AARRR (Acquisition, Activation, Retention, Referral, Revenue) funnel.
+
+      Your output must meticulously detail:
+      1. A precise algorithmic sequence of cross-channel interventions (in-app, email, direct sales outreach) based on predictive drop-off scoring and engagement decay.
+      2. The specific behavioral thresholds (e.g., "72 hours without core feature utilization following initial login") that instantiate each automated sequence.
+      3. A commercial impact analysis demonstrating how this logic directly influences unit economics.
+
+      You must strictly use LaTeX for all advanced marketing metrics and financial modeling. You must calculate and present equations for Customer Lifetime Value ($LTV = \frac{ARPU \times \text{Gross Margin}}{\text{Churn Rate}}$), Customer Acquisition Cost ($CAC = \frac{\text{Total Marketing Costs}}{\text{Acquired Customers}}$), and Return on Ad Spend ($ROAS = \frac{\text{Revenue}}{\text{Cost}}$).
+
+      Do not sugarcoat the brutal realities of user apathy, high acquisition costs, or retention failures. Do not use conversational pleasantries. Provide the unvarnished strategic architecture directly.
+  - role: user
+    content: |
+      Engineer a predictive cross-channel behavioral trigger sequence based on the following parameters:
+
+      <user_telemetry_data>
+      {{user_telemetry_data}}
+      </user_telemetry_data>
+
+      <channel_architecture>
+      {{channel_architecture}}
+      </channel_architecture>
+
+      <financial_targets>
+      {{financial_targets}}
+      </financial_targets>
+testData:
+  - inputs:
+      user_telemetry_data: "Users stall during the third step of integration (API key generation). 40% drop-off at hour 48 post-signup."
+      channel_architecture: "Email (low cost, medium friction), In-app modals (zero cost, high friction), Account Executive call ($50/call)."
+      financial_targets: "LTV > $10,000, CAC < $2,000, 90-day payback period."
+    expected: "Complex behavioral tree and AARRR analysis."
+  - inputs:
+      user_telemetry_data: "Enterprise admins log in but fail to invite team members within the first 7 days."
+      channel_architecture: "Automated Slack integration alerts, direct mail (high cost), automated email sequences."
+      financial_targets: "ROAS > 3.0, Gross Margin > 75%, Net Revenue Retention > 110%."
+    expected: "Multi-touch activation sequence with exact threshold mapping."
+evaluators:
+  - name: Contains LTV Equation
+    string:
+      contains: "LTV ="
+  - name: Contains ROAS Equation
+    string:
+      contains: "ROAS ="
+  - name: Enforces AARRR Funnel
+    string:
+      contains: "AARRR"

--- a/prompts/business/growth_engineering/overview.md
+++ b/prompts/business/growth_engineering/overview.md
@@ -2,5 +2,6 @@
 
 ## Prompts
 - **[Algorithmic Multi-Touch Attribution Architect](algorithmic_multi_touch_attribution_architect.prompt.yaml)**: Constructs highly rigorous, algorithmic multi-touch attribution (MTA) models using Markov chains and Shapley values, mapping fractional credit across the AARRR funnel for enterprise performance marketing.
+- **[Cross-Channel Behavioral Trigger Architect](cross_channel_behavioral_trigger_architect.prompt.yaml)**: Constructs complex, predictive cross-channel behavioral trigger sequences for enterprise SaaS, optimizing for acquisition, activation, and churn mitigation using advanced behavioral modeling.
 - **[GTM Pricing Elasticity Architect](gtm_pricing_elasticity_architect.prompt.yaml)**: Constructs deeply rigorous Go-To-Market (GTM) pricing elasticity matrices, modeling price sensitivity, optimal revenue maximization points, and willingness-to-pay using advanced econometric frameworks.
 - **[Predictive RFM Churn Mitigation Architect](predictive_rfm_churn_mitigation_architect.prompt.yaml)**: Constructs deeply rigorous, predictive churn mitigation workflows using advanced Recency-Frequency-Monetary (RFM) analysis and the AARRR funnel for enterprise growth strategy.


### PR DESCRIPTION
This PR introduces the Cross-Channel Behavioral Trigger Architect prompt within the `business/growth_engineering` directory. The prompt models predictive cross-channel interventions for enterprise SaaS using deep behavioral telemetry and constraints such as the AARRR funnel and LaTeX-based financial equations for ROAS, CAC, and LTV. Required documentation indices and static files have been regenerated to reflect this addition.

---
*PR created automatically by Jules for task [12928372397537391118](https://jules.google.com/task/12928372397537391118) started by @fderuiter*