### PR TITLE
Fix: Suppress MkDocs 2.0 warning to fix strict build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build MkDocs
-        run: mkdocs build --clean --strict
+        run: export NO_MKDOCS_2_WARNING=1 && mkdocs build --clean --strict
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
The `mkdocs build --strict` command was failing due to a new deprecation warning from the Material for MkDocs theme regarding MkDocs 2.0. This fix exports the `NO_MKDOCS_2_WARNING=1` environment variable before the build command runs, which suppresses this specific warning and allows the build to succeed in strict mode.

---
*PR created automatically by Jules for task [15299210788839418558](https://jules.google.com/task/15299210788839418558) started by @fderuiter*