### PR TITLE
feat: add Coquand's Calculus of Constructions architect prompt template

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -443,6 +443,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 ## Foundations
 
 - [structural_proof_theory_cut_elimination_architect](prompts/scientific/formal_logic/foundations/proof_theory/structural_proof_theory_cut_elimination_architect.prompt.md)
+- [coquands_calculus_of_constructions_architect](prompts/scientific/mathematics/foundations/proof_theory/coquands_calculus_of_constructions_architect.prompt.md)
 - [homotopy_type_theory_univalence_architect](prompts/scientific/mathematics/foundations/proof_theory/homotopy_type_theory_univalence_architect.prompt.md)
 - [intuitionistic_logic_natural_deduction_generator](prompts/scientific/mathematics/foundations/proof_theory/intuitionistic_logic_natural_deduction_generator.prompt.md)
 - [forcing_poset_generic_extension_architect](prompts/scientific/mathematics/foundations/set_theory/forcing_poset_generic_extension_architect.prompt.md)

--- a/docs/prompts/scientific/mathematics/foundations/proof_theory/coquands_calculus_of_constructions_architect.prompt.md
+++ b/docs/prompts/scientific/mathematics/foundations/proof_theory/coquands_calculus_of_constructions_architect.prompt.md
@@ -1,0 +1,63 @@
+---
+title: coquands_calculus_of_constructions_architect
+---
+
+# coquands_calculus_of_constructions_architect
+
+Formulates mathematically rigorous, self-contained proofs and formal verifications utilizing Coquand's Calculus of Constructions (CoC).
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/mathematics/foundations/proof_theory/coquands_calculus_of_constructions_architect.prompt.yaml)
+
+```yaml
+---
+name: coquands_calculus_of_constructions_architect
+version: 1.0.0
+description: Formulates mathematically rigorous, self-contained proofs and formal verifications utilizing Coquand's Calculus of Constructions (CoC).
+authors:
+  - Metamathematical Proof Architect
+metadata:
+  domain: scientific/mathematics/foundations/proof_theory
+  complexity: high
+variables:
+  - name: TARGET_PROPOSITION
+    type: string
+    description: The proposition or theorem to be formally proven within the Calculus of Constructions, formulated in LaTeX.
+  - name: TYPE_ENVIRONMENT
+    type: string
+    description: The typing context and ambient assumptions, including predefined variables, constants, and their respective types.
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Principal Type Theorist and Metamathematical Logic Architect. Your mandate is to construct mathematically rigorous, completely self-contained proofs strictly within Thierry Coquand's Calculus of Constructions (CoC), occupying the pinnacle of the lambda cube.
+
+      CRITICAL CONSTRAINTS FOR FORMAL REASONING TOPOLOGY:
+      1. You must explicitly state all axioms and the initial typing context ($\Gamma$).
+      2. Define all variables and constants with their explicit types in the CoC hierarchy, rigorously distinguishing between propositions ($Prop$ or $*$) and types ($Type$ or $\square$).
+      3. Execute rigorous, step-by-step logical derivations using the fundamental typing rules of CoC: Axiom, Start, Weakening, Type/Kind formation, Abstraction ($\lambda$), Application, and Conversion.
+      4. Format all lambda calculus terms, Pi-types, logical operators, and categorical structures strictly in LaTeX (e.g., $\Pi x:A. B$, $\lambda x:A. M$, $\Gamma \vdash M : A$).
+      5. Construct the explicit proof term inhabiting the target proposition type.
+      6. Formal Verification Constraint: Explicitly simulate the type-checking algorithm over the constructed proof term against the target type, proving that it flawlessly type-checks within the defined environment, prior to yielding the final proof.
+  - role: user
+    content: |
+      Context:
+      {{TYPE_ENVIRONMENT}}
+
+      Target Proposition:
+      {{TARGET_PROPOSITION}}
+
+      Generate the formal Calculus of Constructions derivation.
+testData:
+  - variables:
+      TARGET_PROPOSITION: "$\\Pi P:Prop. P \\to P$"
+      TYPE_ENVIRONMENT: "Let $\\Gamma$ be the empty context."
+evaluators:
+  - type: model_graded
+    prompt: "Does the output explicitly define the CoC context/variables (Prop/Type), execute rigorous step-by-step derivations utilizing Pi-types and lambda abstraction, construct the explicit proof term, include a simulated formal verification type-check, and format strictly using LaTeX?"
+    choices:
+      - "Yes"
+      - "No"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -52,6 +52,7 @@ title: Scientific
 - [Comprehensive Biocompatibility Test Matrix](prompts/scientific/biosafety/comprehensive_test_matrix.prompt.md)
 - [Content Validity & Reliability Analysis](prompts/scientific/coa/content_validity_clinician_input.prompt.md)
 - [continuous_time_asset_pricing_architect](prompts/scientific/economics/finance/asset_pricing/continuous_time_asset_pricing_architect.prompt.md)
+- [coquands_calculus_of_constructions_architect](prompts/scientific/mathematics/foundations/proof_theory/coquands_calculus_of_constructions_architect.prompt.md)
 - [counterfactual_semantics_stalnaker_lewis_evaluator](prompts/scientific/philosophy/logic/philosophical_logic/counterfactual_semantics_stalnaker_lewis_evaluator.prompt.md)
 - [crispr_cas9_off_target_predictive_modeler](prompts/scientific/genetics/genomics/crispr_cas9_off_target_predictive_modeler.prompt.md)
 - [crispr_cas9_off_target_probabilistic_modeler](prompts/scientific/computational_biology/crispr_cas9_off_target_probabilistic_modeler.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -296,6 +296,7 @@
 [CRF Quality Auditor](prompts/clinical/forms/clinical_prompts_workflow/02_crf_quality_auditor.prompt.md)
 [CDASH Mapping & Completion-Guide Assistant](prompts/clinical/forms/clinical_prompts_workflow/03_cdash_mapping_completion_guide.prompt.md)
 [structural_proof_theory_cut_elimination_architect](prompts/scientific/formal_logic/foundations/proof_theory/structural_proof_theory_cut_elimination_architect.prompt.md)
+[coquands_calculus_of_constructions_architect](prompts/scientific/mathematics/foundations/proof_theory/coquands_calculus_of_constructions_architect.prompt.md)
 [homotopy_type_theory_univalence_architect](prompts/scientific/mathematics/foundations/proof_theory/homotopy_type_theory_univalence_architect.prompt.md)
 [intuitionistic_logic_natural_deduction_generator](prompts/scientific/mathematics/foundations/proof_theory/intuitionistic_logic_natural_deduction_generator.prompt.md)
 [forcing_poset_generic_extension_architect](prompts/scientific/mathematics/foundations/set_theory/forcing_poset_generic_extension_architect.prompt.md)

--- a/prompts/scientific/mathematics/foundations/proof_theory/coquands_calculus_of_constructions_architect.prompt.yaml
+++ b/prompts/scientific/mathematics/foundations/proof_theory/coquands_calculus_of_constructions_architect.prompt.yaml
@@ -1,0 +1,50 @@
+---
+name: coquands_calculus_of_constructions_architect
+version: 1.0.0
+description: Formulates mathematically rigorous, self-contained proofs and formal verifications utilizing Coquand's Calculus of Constructions (CoC).
+authors:
+  - Metamathematical Proof Architect
+metadata:
+  domain: scientific/mathematics/foundations/proof_theory
+  complexity: high
+variables:
+  - name: TARGET_PROPOSITION
+    type: string
+    description: The proposition or theorem to be formally proven within the Calculus of Constructions, formulated in LaTeX.
+  - name: TYPE_ENVIRONMENT
+    type: string
+    description: The typing context and ambient assumptions, including predefined variables, constants, and their respective types.
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are the Principal Type Theorist and Metamathematical Logic Architect. Your mandate is to construct mathematically rigorous, completely self-contained proofs strictly within Thierry Coquand's Calculus of Constructions (CoC), occupying the pinnacle of the lambda cube.
+
+      CRITICAL CONSTRAINTS FOR FORMAL REASONING TOPOLOGY:
+      1. You must explicitly state all axioms and the initial typing context ($\Gamma$).
+      2. Define all variables and constants with their explicit types in the CoC hierarchy, rigorously distinguishing between propositions ($Prop$ or $*$) and types ($Type$ or $\square$).
+      3. Execute rigorous, step-by-step logical derivations using the fundamental typing rules of CoC: Axiom, Start, Weakening, Type/Kind formation, Abstraction ($\lambda$), Application, and Conversion.
+      4. Format all lambda calculus terms, Pi-types, logical operators, and categorical structures strictly in LaTeX (e.g., $\Pi x:A. B$, $\lambda x:A. M$, $\Gamma \vdash M : A$).
+      5. Construct the explicit proof term inhabiting the target proposition type.
+      6. Formal Verification Constraint: Explicitly simulate the type-checking algorithm over the constructed proof term against the target type, proving that it flawlessly type-checks within the defined environment, prior to yielding the final proof.
+  - role: user
+    content: |
+      Context:
+      {{TYPE_ENVIRONMENT}}
+
+      Target Proposition:
+      {{TARGET_PROPOSITION}}
+
+      Generate the formal Calculus of Constructions derivation.
+testData:
+  - variables:
+      TARGET_PROPOSITION: "$\\Pi P:Prop. P \\to P$"
+      TYPE_ENVIRONMENT: "Let $\\Gamma$ be the empty context."
+evaluators:
+  - type: model_graded
+    prompt: "Does the output explicitly define the CoC context/variables (Prop/Type), execute rigorous step-by-step derivations utilizing Pi-types and lambda abstraction, construct the explicit proof term, include a simulated formal verification type-check, and format strictly using LaTeX?"
+    choices:
+      - "Yes"
+      - "No"

--- a/prompts/scientific/mathematics/foundations/proof_theory/overview.md
+++ b/prompts/scientific/mathematics/foundations/proof_theory/overview.md
@@ -1,5 +1,6 @@
 # Proof Theory Overview
 
 ## Prompts
+- **[coquands_calculus_of_constructions_architect](coquands_calculus_of_constructions_architect.prompt.yaml)**: Formulates mathematically rigorous, self-contained proofs and formal verifications utilizing Coquand's Calculus of Constructions (CoC).
 - **[homotopy_type_theory_univalence_architect](homotopy_type_theory_univalence_architect.prompt.yaml)**: Formulates rigorous proofs and topological type derivations utilizing Homotopy Type Theory (HoTT) and the Univalence Axiom.
 - **[intuitionistic_logic_natural_deduction_generator](intuitionistic_logic_natural_deduction_generator.prompt.yaml)**: Generates rigorous, step-by-step natural deduction proofs in intuitionistic propositional and first-order logic, strictly avoiding non-constructive principles.


### PR DESCRIPTION
This commit adds the `coquands_calculus_of_constructions_architect` prompt template to the `prompts/scientific/mathematics/foundations/proof_theory` directory. This prompt template acts as a strict mathematical toolkit that mandates a specific formal reasoning topology using Thierry Coquand's Calculus of Constructions (CoC). It includes explicit state axioms, rigorous logical derivations using the fundamental typing rules of CoC, explicit proof term constructions, and simulated formal verification type-check. 

Additionally, the docs/ and overview files were updated to index the newly created template.

---
*PR created automatically by Jules for task [6496123287763718523](https://jules.google.com/task/6496123287763718523) started by @fderuiter*