### PR TITLE
Add metaethical discourse semantic analyzer prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -427,6 +427,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 
 ## Ethics
 
+- [metaethical_discourse_semantic_analyzer](prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.md)
 - [Applied Ethical Stress Tester](prompts/scientific/philosophy/ethics/normative_ethics/applied_ethical_stress_tester.prompt.md)
 - [Normative Ethics Stress Tester](prompts/scientific/philosophy/ethics/normative_ethics/normative_ethics_stress_tester.prompt.md)
 

--- a/docs/prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.md
+++ b/docs/prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.md
@@ -1,0 +1,67 @@
+---
+title: metaethical_discourse_semantic_analyzer
+---
+
+# metaethical_discourse_semantic_analyzer
+
+A highly rigorous prompt designed to systematically analyze and evaluate the semantic and ontological commitments of moral discourse, categorizing normative claims across metaethical frameworks (e.g., Non-Cognitivism, Moral Realism, Error Theory).
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.yaml)
+
+```yaml
+---
+name: "metaethical_discourse_semantic_analyzer"
+version: "1.0.0"
+description: "A highly rigorous prompt designed to systematically analyze and evaluate the semantic and ontological commitments of moral discourse, categorizing normative claims across metaethical frameworks (e.g., Non-Cognitivism, Moral Realism, Error Theory)."
+authors:
+  - "Philosophical Genesis Architect"
+metadata:
+  domain: "scientific"
+  complexity: "high"
+variables:
+  - name: "MORAL_PROPOSITION"
+    type: "string"
+    description: "The primary normative or moral claim under analysis."
+  - name: "TARGET_FRAMEWORK"
+    type: "string"
+    description: "The specific metaethical framework to apply (e.g., Expressivism, Cornell Realism, Mackie's Error Theory)."
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: "system"
+    content: |
+      You are the Principal Metaethicist and Lead Ontologist. Your objective is to perform a rigorous, systematic formalization and analysis of the semantic structure and ontological commitments of a moral proposition based on a specified metaethical framework.
+      Your analysis must adhere to the following strict methodology:
+      1. **Semantic Formalization**: Precisely deconstruct the {{MORAL_PROPOSITION}} into its underlying semantic components. Determine if the proposition is truth-apt (cognitive) or expresses non-cognitive attitudes (e.g., imperatives, emotions).
+      2. **Ontological Commitment Analysis**: Evaluate the proposition to identify any presumed metaphysical entities or truth-makers (e.g., mind-independent moral facts, natural properties).
+      3. **Framework Application**: Rigorously apply the {{TARGET_FRAMEWORK}} to evaluate the proposition. Formalize the implications of this framework on both the semantic and ontological status of the claim.
+      4. **Dialectical Conclusion**: Conclude on the overall status of the moral claim within the given framework, identifying any structural vulnerabilities (e.g., the Frege-Geach problem for non-cognitivism, epistemic access for non-naturalism).
+      Strict Formatting Constraints:
+      - Do NOT include any introductory text, pleasantries, or explanations.
+      - Output the analysis using explicit headings for the four steps.
+      - Ensure all logical derivations are formally valid and use strict philosophical terminology.
+  - role: "user"
+    content: |
+      <moral_proposition>
+      {{MORAL_PROPOSITION}}
+      </moral_proposition>
+      <target_framework>
+      {{TARGET_FRAMEWORK}}
+      </target_framework>
+      Execute the systematic formalization and semantic analysis of this moral proposition.
+testData:
+  - variables:
+      MORAL_PROPOSITION: "Murder is wrong."
+      TARGET_FRAMEWORK: "Ayer's Emotivism (Non-Cognitivism)"
+    expected: "Semantic Formalization"
+  - variables:
+      MORAL_PROPOSITION: "It is an objective fact that torturing innocents for fun is bad."
+      TARGET_FRAMEWORK: "Mackie's Error Theory"
+    expected: "Ontological Commitment Analysis"
+evaluators:
+  - type: regex
+    pattern: "(?i)(Semantic Formalization|Ontological Commitment Analysis|Framework Application|Dialectical Conclusion)"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -152,6 +152,7 @@ title: Scientific
 - [MCID Research and Summary](prompts/scientific/coa/mcid_definition.prompt.md)
 - [mereological_composition_analyzer](prompts/scientific/philosophy/metaphysics/ontology/mereological_composition_analyzer.prompt.md)
 - [metabolic_control_analysis_architect](prompts/scientific/cellular/metabolism/metabolic_control_analysis_architect.prompt.md)
+- [metaethical_discourse_semantic_analyzer](prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.md)
 - [metagenomic_assembly_taxonomic_binning_architect](prompts/scientific/genetics/genomics/metagenomic_assembly_taxonomic_binning_architect.prompt.md)
 - [Metaphysical Dialectical Synthesizer](prompts/scientific/philosophy/metaphysics/ontology/metaphysical_dialectical_synthesizer.prompt.md)
 - [metaphysical_grounding_fundamentality_formalizer](prompts/scientific/philosophy/metaphysics/ontology/metaphysical_grounding_fundamentality_formalizer.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -289,6 +289,7 @@
 [Patient-Centric BYOD ePRO Workflow](prompts/clinical/epro/epro_workflow/01_patient-centric_byod_workflow.prompt.md)
 [Optimize ePRO Form Design](prompts/clinical/epro/epro_workflow/02_optimize_epro_form_design.prompt.md)
 [ePRO Adoption Plan for Sponsors](prompts/clinical/epro/epro_workflow/03_epro_adoption_plan_for_sponsors.prompt.md)
+[metaethical_discourse_semantic_analyzer](prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.md)
 [Applied Ethical Stress Tester](prompts/scientific/philosophy/ethics/normative_ethics/applied_ethical_stress_tester.prompt.md)
 [Normative Ethics Stress Tester](prompts/scientific/philosophy/ethics/normative_ethics/normative_ethics_stress_tester.prompt.md)
 [continuous_time_asset_pricing_architect](prompts/scientific/economics/finance/asset_pricing/continuous_time_asset_pricing_architect.prompt.md)

--- a/prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.yaml
+++ b/prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.yaml
@@ -1,0 +1,54 @@
+---
+name: "metaethical_discourse_semantic_analyzer"
+version: "1.0.0"
+description: "A highly rigorous prompt designed to systematically analyze and evaluate the semantic and ontological commitments of moral discourse, categorizing normative claims across metaethical frameworks (e.g., Non-Cognitivism, Moral Realism, Error Theory)."
+authors:
+  - "Philosophical Genesis Architect"
+metadata:
+  domain: "scientific"
+  complexity: "high"
+variables:
+  - name: "MORAL_PROPOSITION"
+    type: "string"
+    description: "The primary normative or moral claim under analysis."
+  - name: "TARGET_FRAMEWORK"
+    type: "string"
+    description: "The specific metaethical framework to apply (e.g., Expressivism, Cornell Realism, Mackie's Error Theory)."
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: "system"
+    content: |
+      You are the Principal Metaethicist and Lead Ontologist. Your objective is to perform a rigorous, systematic formalization and analysis of the semantic structure and ontological commitments of a moral proposition based on a specified metaethical framework.
+      Your analysis must adhere to the following strict methodology:
+      1. **Semantic Formalization**: Precisely deconstruct the {{MORAL_PROPOSITION}} into its underlying semantic components. Determine if the proposition is truth-apt (cognitive) or expresses non-cognitive attitudes (e.g., imperatives, emotions).
+      2. **Ontological Commitment Analysis**: Evaluate the proposition to identify any presumed metaphysical entities or truth-makers (e.g., mind-independent moral facts, natural properties).
+      3. **Framework Application**: Rigorously apply the {{TARGET_FRAMEWORK}} to evaluate the proposition. Formalize the implications of this framework on both the semantic and ontological status of the claim.
+      4. **Dialectical Conclusion**: Conclude on the overall status of the moral claim within the given framework, identifying any structural vulnerabilities (e.g., the Frege-Geach problem for non-cognitivism, epistemic access for non-naturalism).
+      Strict Formatting Constraints:
+      - Do NOT include any introductory text, pleasantries, or explanations.
+      - Output the analysis using explicit headings for the four steps.
+      - Ensure all logical derivations are formally valid and use strict philosophical terminology.
+  - role: "user"
+    content: |
+      <moral_proposition>
+      {{MORAL_PROPOSITION}}
+      </moral_proposition>
+      <target_framework>
+      {{TARGET_FRAMEWORK}}
+      </target_framework>
+      Execute the systematic formalization and semantic analysis of this moral proposition.
+testData:
+  - variables:
+      MORAL_PROPOSITION: "Murder is wrong."
+      TARGET_FRAMEWORK: "Ayer's Emotivism (Non-Cognitivism)"
+    expected: "Semantic Formalization"
+  - variables:
+      MORAL_PROPOSITION: "It is an objective fact that torturing innocents for fun is bad."
+      TARGET_FRAMEWORK: "Mackie's Error Theory"
+    expected: "Ontological Commitment Analysis"
+evaluators:
+  - type: regex
+    pattern: "(?i)(Semantic Formalization|Ontological Commitment Analysis|Framework Application|Dialectical Conclusion)"

--- a/prompts/scientific/philosophy/ethics/metaethics/overview.md
+++ b/prompts/scientific/philosophy/ethics/metaethics/overview.md
@@ -1,0 +1,4 @@
+# Metaethics Overview
+
+## Prompts
+- **[metaethical_discourse_semantic_analyzer](metaethical_discourse_semantic_analyzer.prompt.yaml)**: A highly rigorous prompt designed to systematically analyze and evaluate the semantic and ontological commitments of moral discourse, categorizing normative claims across metaethical frameworks (e.g., Non-Cognitivism, Moral Realism, Error Theory).

--- a/prompts/scientific/philosophy/ethics/overview.md
+++ b/prompts/scientific/philosophy/ethics/overview.md
@@ -1,4 +1,5 @@
 # Ethics Overview
 
 ## Categories
+- [Metaethics/](metaethics/overview.md)
 - [Normative Ethics/](normative_ethics/overview.md)


### PR DESCRIPTION
Fills the gap in philosophical prompts by creating `prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.yaml`. Updates related overviews and docs.

---
*PR created automatically by Jules for task [11349093033381188174](https://jules.google.com/task/11349093033381188174) started by @fderuiter*