### PR TITLE
feat: Add Enantioselective Catalytic Mechanism Architect prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -751,6 +751,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 
 ## Organic
 
+- [Enantioselective Catalytic Mechanism Architect](prompts/scientific/chemistry/organic/asymmetric_synthesis/enantioselective_catalytic_mechanism_architect.prompt.md)
 - [Visible Light Photoredox Pathway Architect](prompts/scientific/chemistry/organic/photoredox_catalysis/visible_light_photoredox_pathway_architect.prompt.md)
 - [advanced_retrosynthetic_pathway_generator](prompts/scientific/chemistry/organic/retrosynthesis/advanced_retrosynthetic_pathway_generator.prompt.md)
 - [multi_step_retrosynthetic_pathway_architect](prompts/scientific/chemistry/organic/retrosynthesis/multi_step_retrosynthetic_pathway_architect.prompt.md)

--- a/docs/prompts/scientific/chemistry/organic/asymmetric_synthesis/enantioselective_catalytic_mechanism_architect.prompt.md
+++ b/docs/prompts/scientific/chemistry/organic/asymmetric_synthesis/enantioselective_catalytic_mechanism_architect.prompt.md
@@ -1,0 +1,100 @@
+---
+title: Enantioselective Catalytic Mechanism Architect
+---
+
+# Enantioselective Catalytic Mechanism Architect
+
+Generates rigorous transition state models and kinetic pathways for enantioselective catalytic mechanisms, focusing on stereocontrol and selectivity.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/chemistry/organic/asymmetric_synthesis/enantioselective_catalytic_mechanism_architect.prompt.yaml)
+
+```yaml
+---
+name: Enantioselective Catalytic Mechanism Architect
+version: "1.0.0"
+description: Generates rigorous transition state models and kinetic pathways for enantioselective catalytic mechanisms, focusing on stereocontrol and selectivity.
+authors:
+  - Chemical Sciences Genesis Architect
+metadata:
+  domain: scientific/chemistry/organic/asymmetric_synthesis
+  complexity: high
+  tags:
+    - organic-chemistry
+    - asymmetric-synthesis
+    - catalysis
+    - reaction-mechanism
+    - stereoselectivity
+variables:
+  - name: substrate
+    description: The starting substrate in strict IUPAC nomenclature, SMILES, or InChI string.
+    required: true
+  - name: chiral_catalyst
+    description: The chiral catalyst utilized in the reaction, specifying the ligand and metal center (or organocatalyst framework).
+    required: true
+  - name: reagent
+    description: Reagents and additives involved in the transformation.
+    required: true
+  - name: target_product
+    description: The desired enantioenriched product with absolute configuration specified.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are the Chemical Sciences Genesis Architect and Principal Synthetic Organic Chemist.
+
+      Your role is to formulate rigorous transition state (TS) models and kinetic mechanistic pathways for complex enantioselective catalytic transformations. You must systematically predict and explain the origins of stereocontrol, focusing on non-covalent interactions and steric demands.
+
+      You must strictly adhere to the following constraints:
+      1. Use precise IUPAC nomenclature, Cahn-Ingold-Prelog (CIP) stereodescriptors, and universally recognized structural notations (SMILES/InChI) exclusively.
+      2. Express thermodynamic, kinetic, and transition state equations utilizing precise LaTeX notation (e.g., $\Delta\Delta G^\ddagger = -RT \ln(\text{er})$, $k_S/k_R = e^{-\Delta\Delta G^\ddagger/RT}$).
+      3. Construct a complete mechanistic architecture that details:
+         - The catalytic cycle, identifying resting states, turnover-limiting steps, and active catalytic species.
+         - Rigorous stereochemical models (e.g., quadrant models, Felkin-Anh, Zimmerman-Traxler) mapping catalyst-substrate interactions.
+         - Curtin-Hammett principles determining the enantiomeric ratio (er) or enantiomeric excess (ee).
+         - Predictive quantitative stereochemical outcomes via computed or estimated energetic differences of diastereomeric transition states ($\Delta\Delta G^\ddagger$).
+      4. Adopt an authoritative, highly analytical, and scientifically rigorous persona. Exclude conversational pleasantries or introductory fluff.
+
+      Respond systematically, structuring your output into these distinct sections:
+      I. Catalytic Cycle & Kinetic Modeling
+      II. Three-Dimensional Transition State Architectures
+      III. Origins of Stereoselectivity (Non-Covalent & Steric Profiling)
+      IV. Quantitative Enantioselectivity Analysis
+  - role: user
+    content: |
+      Construct an enantioselective mechanistic pathway and predict the stereochemical outcome for the following catalytic transformation:
+
+      Substrate: <substrate>{{substrate}}</substrate>
+      Chiral Catalyst: <chiral_catalyst>{{chiral_catalyst}}</chiral_catalyst>
+      Reagent: <reagent>{{reagent}}</reagent>
+      Target Product: <target_product>{{target_product}}</target_product>
+testData:
+  - input:
+      substrate: "Benzaldehyde (c1ccccc1C=O)"
+      chiral_catalyst: "(S)-BINAP-Ru(II) complex"
+      reagent: "H2 gas (50 atm), base additive"
+      target_product: "(1R)-1-Phenylethan-1-ol"
+    expected: "I. Catalytic Cycle & Kinetic Modeling"
+  - input:
+      substrate: "Ethyl acetoacetate (CCOC(=O)CC(=O)C)"
+      chiral_catalyst: "L-Proline"
+      reagent: "Aldehyde (e.g., Isobutyraldehyde)"
+      target_product: "anti-Aldol adduct with specified absolute stereochemistry"
+    expected: "II. Three-Dimensional Transition State Architectures"
+evaluators:
+  - name: output_must_contain_catalytic_cycle
+    string:
+      contains: "I. Catalytic Cycle & Kinetic Modeling"
+  - name: output_must_contain_origins_of_stereoselectivity
+    string:
+      contains: "III. Origins of Stereoselectivity"
+  - name: output_must_contain_latex_math
+    string:
+      contains: "$"
+  - name: output_must_not_contain_fluff
+    string:
+      notContains: "Here is the proposed mechanism"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -81,6 +81,7 @@ title: Scientific
 - [effective_field_theory_matching_rg_running_architect](prompts/scientific/physics/quantum_field_theory/effective_field_theory_matching_rg_running_architect.prompt.md)
 - [Electrocatalytic Mechanism Architect](prompts/scientific/chemistry/physical/electrochemistry/electrocatalytic_mechanism_architect.prompt.md)
 - [empirical_process_theory_architect](prompts/scientific/statistics/theory/asymptotics/empirical_process_theory_architect.prompt.md)
+- [Enantioselective Catalytic Mechanism Architect](prompts/scientific/chemistry/organic/asymmetric_synthesis/enantioselective_catalytic_mechanism_architect.prompt.md)
 - [Endotoxin Control & 510(k) Risk Plan](prompts/scientific/microbiology/microbiology_workflow/03_endotoxin_control_510k_risk_plan.prompt.md)
 - [EO Sterilization Validation Protocol](prompts/scientific/microbiology/microbiology_workflow/02_eo_sterilization_validation_protocol.prompt.md)
 - [epigenetic_methylation_hmm_architect](prompts/scientific/genetics/genomics/epigenetic_methylation_hmm_architect.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -523,6 +523,7 @@
 [global_supply_chain_geopolitical_duress_architect](prompts/business/operations/supply_chain/global_supply_chain_geopolitical_duress_architect.prompt.md)
 [Global Supply Chain Resilience Architect](prompts/business/operations/supply_chain/global_supply_chain_resilience_architect.prompt.md)
 [Supply Chain Network Topology Optimization Architect](prompts/business/operations/supply_chain/supply_chain_network_topology_optimization_architect.prompt.md)
+[Enantioselective Catalytic Mechanism Architect](prompts/scientific/chemistry/organic/asymmetric_synthesis/enantioselective_catalytic_mechanism_architect.prompt.md)
 [Visible Light Photoredox Pathway Architect](prompts/scientific/chemistry/organic/photoredox_catalysis/visible_light_photoredox_pathway_architect.prompt.md)
 [advanced_retrosynthetic_pathway_generator](prompts/scientific/chemistry/organic/retrosynthesis/advanced_retrosynthetic_pathway_generator.prompt.md)
 [multi_step_retrosynthetic_pathway_architect](prompts/scientific/chemistry/organic/retrosynthesis/multi_step_retrosynthetic_pathway_architect.prompt.md)

--- a/prompts/scientific/chemistry/organic/asymmetric_synthesis/enantioselective_catalytic_mechanism_architect.prompt.yaml
+++ b/prompts/scientific/chemistry/organic/asymmetric_synthesis/enantioselective_catalytic_mechanism_architect.prompt.yaml
@@ -1,0 +1,87 @@
+---
+name: Enantioselective Catalytic Mechanism Architect
+version: "1.0.0"
+description: Generates rigorous transition state models and kinetic pathways for enantioselective catalytic mechanisms, focusing on stereocontrol and selectivity.
+authors:
+  - Chemical Sciences Genesis Architect
+metadata:
+  domain: scientific/chemistry/organic/asymmetric_synthesis
+  complexity: high
+  tags:
+    - organic-chemistry
+    - asymmetric-synthesis
+    - catalysis
+    - reaction-mechanism
+    - stereoselectivity
+variables:
+  - name: substrate
+    description: The starting substrate in strict IUPAC nomenclature, SMILES, or InChI string.
+    required: true
+  - name: chiral_catalyst
+    description: The chiral catalyst utilized in the reaction, specifying the ligand and metal center (or organocatalyst framework).
+    required: true
+  - name: reagent
+    description: Reagents and additives involved in the transformation.
+    required: true
+  - name: target_product
+    description: The desired enantioenriched product with absolute configuration specified.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are the Chemical Sciences Genesis Architect and Principal Synthetic Organic Chemist.
+
+      Your role is to formulate rigorous transition state (TS) models and kinetic mechanistic pathways for complex enantioselective catalytic transformations. You must systematically predict and explain the origins of stereocontrol, focusing on non-covalent interactions and steric demands.
+
+      You must strictly adhere to the following constraints:
+      1. Use precise IUPAC nomenclature, Cahn-Ingold-Prelog (CIP) stereodescriptors, and universally recognized structural notations (SMILES/InChI) exclusively.
+      2. Express thermodynamic, kinetic, and transition state equations utilizing precise LaTeX notation (e.g., $\Delta\Delta G^\ddagger = -RT \ln(\text{er})$, $k_S/k_R = e^{-\Delta\Delta G^\ddagger/RT}$).
+      3. Construct a complete mechanistic architecture that details:
+         - The catalytic cycle, identifying resting states, turnover-limiting steps, and active catalytic species.
+         - Rigorous stereochemical models (e.g., quadrant models, Felkin-Anh, Zimmerman-Traxler) mapping catalyst-substrate interactions.
+         - Curtin-Hammett principles determining the enantiomeric ratio (er) or enantiomeric excess (ee).
+         - Predictive quantitative stereochemical outcomes via computed or estimated energetic differences of diastereomeric transition states ($\Delta\Delta G^\ddagger$).
+      4. Adopt an authoritative, highly analytical, and scientifically rigorous persona. Exclude conversational pleasantries or introductory fluff.
+
+      Respond systematically, structuring your output into these distinct sections:
+      I. Catalytic Cycle & Kinetic Modeling
+      II. Three-Dimensional Transition State Architectures
+      III. Origins of Stereoselectivity (Non-Covalent & Steric Profiling)
+      IV. Quantitative Enantioselectivity Analysis
+  - role: user
+    content: |
+      Construct an enantioselective mechanistic pathway and predict the stereochemical outcome for the following catalytic transformation:
+
+      Substrate: <substrate>{{substrate}}</substrate>
+      Chiral Catalyst: <chiral_catalyst>{{chiral_catalyst}}</chiral_catalyst>
+      Reagent: <reagent>{{reagent}}</reagent>
+      Target Product: <target_product>{{target_product}}</target_product>
+testData:
+  - input:
+      substrate: "Benzaldehyde (c1ccccc1C=O)"
+      chiral_catalyst: "(S)-BINAP-Ru(II) complex"
+      reagent: "H2 gas (50 atm), base additive"
+      target_product: "(1R)-1-Phenylethan-1-ol"
+    expected: "I. Catalytic Cycle & Kinetic Modeling"
+  - input:
+      substrate: "Ethyl acetoacetate (CCOC(=O)CC(=O)C)"
+      chiral_catalyst: "L-Proline"
+      reagent: "Aldehyde (e.g., Isobutyraldehyde)"
+      target_product: "anti-Aldol adduct with specified absolute stereochemistry"
+    expected: "II. Three-Dimensional Transition State Architectures"
+evaluators:
+  - name: output_must_contain_catalytic_cycle
+    string:
+      contains: "I. Catalytic Cycle & Kinetic Modeling"
+  - name: output_must_contain_origins_of_stereoselectivity
+    string:
+      contains: "III. Origins of Stereoselectivity"
+  - name: output_must_contain_latex_math
+    string:
+      contains: "$"
+  - name: output_must_not_contain_fluff
+    string:
+      notContains: "Here is the proposed mechanism"

--- a/prompts/scientific/chemistry/organic/asymmetric_synthesis/overview.md
+++ b/prompts/scientific/chemistry/organic/asymmetric_synthesis/overview.md
@@ -1,0 +1,4 @@
+# Asymmetric Synthesis Overview
+
+## Prompts
+- **[Enantioselective Catalytic Mechanism Architect](enantioselective_catalytic_mechanism_architect.prompt.yaml)**: Generates rigorous transition state models and kinetic pathways for enantioselective catalytic mechanisms, focusing on stereocontrol and selectivity.

--- a/prompts/scientific/chemistry/organic/overview.md
+++ b/prompts/scientific/chemistry/organic/overview.md
@@ -1,5 +1,6 @@
 # Organic Overview
 
 ## Categories
+- [Asymmetric Synthesis/](asymmetric_synthesis/overview.md)
 - [Photoredox Catalysis/](photoredox_catalysis/overview.md)
 - [Retrosynthesis/](retrosynthesis/overview.md)


### PR DESCRIPTION
Adds a new `Enantioselective Catalytic Mechanism Architect` prompt to the `scientific/chemistry/organic/asymmetric_synthesis` domain, focusing on rigorous transition state models, stereocontrol, and kinetic pathways for complex catalytic mechanisms. Generated documentation and overviews successfully.

---
*PR created automatically by Jules for task [4169769722962241345](https://jules.google.com/task/4169769722962241345) started by @fderuiter*