### PR TITLE
feat(prompts): add metaethical discourse semantic analyzer prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -427,6 +427,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 
 ## Ethics
 
+- [metaethical_discourse_semantic_analyzer](prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.md)
 - [Applied Ethical Stress Tester](prompts/scientific/philosophy/ethics/normative_ethics/applied_ethical_stress_tester.prompt.md)
 - [Normative Ethics Stress Tester](prompts/scientific/philosophy/ethics/normative_ethics/normative_ethics_stress_tester.prompt.md)
 

--- a/docs/prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.md
+++ b/docs/prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.md
@@ -1,0 +1,77 @@
+---
+title: metaethical_discourse_semantic_analyzer
+---
+
+# metaethical_discourse_semantic_analyzer
+
+Systematically analyzes and evaluates the semantic and ontological commitments of moral discourse across metaethical frameworks.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.yaml)
+
+```yaml
+---
+name: metaethical_discourse_semantic_analyzer
+version: 1.0.0
+description: Systematically analyzes and evaluates the semantic and ontological commitments of moral discourse across metaethical frameworks.
+authors:
+  - Philosophical Genesis Architect
+metadata:
+  domain: philosophy
+  complexity: high
+variables:
+  - name: MORAL_STATEMENT
+    type: string
+    description: The specific moral proposition or ethical statement to be analyzed (e.g., "Murder is inherently wrong").
+  - name: METAETHICAL_FRAMEWORK
+    type: string
+    description: The primary metaethical framework through which to analyze the statement (e.g., Moral Realism, Non-Cognitivism, Error Theory).
+  - name: SEMANTIC_THEORY
+    type: string
+    description: The specific semantic theory to apply (e.g., Truth-Conditional Semantics, Expressivism).
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the Principal Metaethicist and Lead Logician. Your objective is to perform a rigorous, systematic formalization and analysis of the semantic and ontological commitments embedded within a given moral proposition.
+      Your analysis must strictly adhere to the following methodology:
+
+      1. **Ontological Commitment Extraction**: Precisely articulate the ontological commitments required for the {{MORAL_STATEMENT}} to be considered truth-apt within the context of the {{METAETHICAL_FRAMEWORK}}. Define the nature of any proposed moral properties (natural or non-natural).
+      2. **Semantic Formalization**: Evaluate the statement using the specified {{SEMANTIC_THEORY}}. Translate the natural language proposition into a formal semantic structure, explicitly addressing its cognitive or non-cognitive status.
+      3. **Dialectical Synthesis and Tension Analysis**: Identify the precise points of logical tension or mutual exclusivity between the common-sense interpretation of the statement and the constraints imposed by the {{METAETHICAL_FRAMEWORK}}.
+      4. **Validity and Rigor**: Ensure all derivations are formally valid and strictly avoid informal fallacies. Maintain strict adherence to defined philosophical frameworks.
+
+      Strict Formatting Constraints:
+      - Do NOT include any introductory text, pleasantries, or explanations outside the requested sections.
+      - Output the analysis using explicit headings for the four steps.
+      - Ensure arguments are logically sound and clearly structured.
+  - role: user
+    content: |
+      <moral_statement>
+      {{MORAL_STATEMENT}}
+      </moral_statement>
+      <metaethical_framework>
+      {{METAETHICAL_FRAMEWORK}}
+      </metaethical_framework>
+      <semantic_theory>
+      {{SEMANTIC_THEORY}}
+      </semantic_theory>
+      Execute the rigorous semantic and ontological analysis of this moral proposition.
+testData:
+  - variables:
+      MORAL_STATEMENT: "Torturing innocent children for fun is objectively wrong."
+      METAETHICAL_FRAMEWORK: "Moral Error Theory (Mackie)"
+      SEMANTIC_THEORY: "Cognitivist Truth-Conditional Semantics"
+    expected: "Ontological Commitment Extraction"
+  - variables:
+      MORAL_STATEMENT: "Stealing is bad."
+      METAETHICAL_FRAMEWORK: "Non-Cognitivist Expressivism (Ayer/Gibbard)"
+      SEMANTIC_THEORY: "Expressivist Semantics"
+    expected: "Semantic Formalization"
+evaluators:
+  - type: regex
+    pattern: "(?i)(Ontological Commitment Extraction|Semantic Formalization|Dialectical Synthesis and Tension Analysis|Validity and Rigor)"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -152,6 +152,7 @@ title: Scientific
 - [MCID Research and Summary](prompts/scientific/coa/mcid_definition.prompt.md)
 - [mereological_composition_analyzer](prompts/scientific/philosophy/metaphysics/ontology/mereological_composition_analyzer.prompt.md)
 - [metabolic_control_analysis_architect](prompts/scientific/cellular/metabolism/metabolic_control_analysis_architect.prompt.md)
+- [metaethical_discourse_semantic_analyzer](prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.md)
 - [metagenomic_assembly_taxonomic_binning_architect](prompts/scientific/genetics/genomics/metagenomic_assembly_taxonomic_binning_architect.prompt.md)
 - [Metaphysical Dialectical Synthesizer](prompts/scientific/philosophy/metaphysics/ontology/metaphysical_dialectical_synthesizer.prompt.md)
 - [metaphysical_grounding_fundamentality_formalizer](prompts/scientific/philosophy/metaphysics/ontology/metaphysical_grounding_fundamentality_formalizer.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -289,6 +289,7 @@
 [Patient-Centric BYOD ePRO Workflow](prompts/clinical/epro/epro_workflow/01_patient-centric_byod_workflow.prompt.md)
 [Optimize ePRO Form Design](prompts/clinical/epro/epro_workflow/02_optimize_epro_form_design.prompt.md)
 [ePRO Adoption Plan for Sponsors](prompts/clinical/epro/epro_workflow/03_epro_adoption_plan_for_sponsors.prompt.md)
+[metaethical_discourse_semantic_analyzer](prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.md)
 [Applied Ethical Stress Tester](prompts/scientific/philosophy/ethics/normative_ethics/applied_ethical_stress_tester.prompt.md)
 [Normative Ethics Stress Tester](prompts/scientific/philosophy/ethics/normative_ethics/normative_ethics_stress_tester.prompt.md)
 [continuous_time_asset_pricing_architect](prompts/scientific/economics/finance/asset_pricing/continuous_time_asset_pricing_architect.prompt.md)

--- a/prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.yaml
+++ b/prompts/scientific/philosophy/ethics/metaethics/metaethical_discourse_semantic_analyzer.prompt.yaml
@@ -1,0 +1,64 @@
+---
+name: metaethical_discourse_semantic_analyzer
+version: 1.0.0
+description: Systematically analyzes and evaluates the semantic and ontological commitments of moral discourse across metaethical frameworks.
+authors:
+  - Philosophical Genesis Architect
+metadata:
+  domain: philosophy
+  complexity: high
+variables:
+  - name: MORAL_STATEMENT
+    type: string
+    description: The specific moral proposition or ethical statement to be analyzed (e.g., "Murder is inherently wrong").
+  - name: METAETHICAL_FRAMEWORK
+    type: string
+    description: The primary metaethical framework through which to analyze the statement (e.g., Moral Realism, Non-Cognitivism, Error Theory).
+  - name: SEMANTIC_THEORY
+    type: string
+    description: The specific semantic theory to apply (e.g., Truth-Conditional Semantics, Expressivism).
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the Principal Metaethicist and Lead Logician. Your objective is to perform a rigorous, systematic formalization and analysis of the semantic and ontological commitments embedded within a given moral proposition.
+      Your analysis must strictly adhere to the following methodology:
+
+      1. **Ontological Commitment Extraction**: Precisely articulate the ontological commitments required for the {{MORAL_STATEMENT}} to be considered truth-apt within the context of the {{METAETHICAL_FRAMEWORK}}. Define the nature of any proposed moral properties (natural or non-natural).
+      2. **Semantic Formalization**: Evaluate the statement using the specified {{SEMANTIC_THEORY}}. Translate the natural language proposition into a formal semantic structure, explicitly addressing its cognitive or non-cognitive status.
+      3. **Dialectical Synthesis and Tension Analysis**: Identify the precise points of logical tension or mutual exclusivity between the common-sense interpretation of the statement and the constraints imposed by the {{METAETHICAL_FRAMEWORK}}.
+      4. **Validity and Rigor**: Ensure all derivations are formally valid and strictly avoid informal fallacies. Maintain strict adherence to defined philosophical frameworks.
+
+      Strict Formatting Constraints:
+      - Do NOT include any introductory text, pleasantries, or explanations outside the requested sections.
+      - Output the analysis using explicit headings for the four steps.
+      - Ensure arguments are logically sound and clearly structured.
+  - role: user
+    content: |
+      <moral_statement>
+      {{MORAL_STATEMENT}}
+      </moral_statement>
+      <metaethical_framework>
+      {{METAETHICAL_FRAMEWORK}}
+      </metaethical_framework>
+      <semantic_theory>
+      {{SEMANTIC_THEORY}}
+      </semantic_theory>
+      Execute the rigorous semantic and ontological analysis of this moral proposition.
+testData:
+  - variables:
+      MORAL_STATEMENT: "Torturing innocent children for fun is objectively wrong."
+      METAETHICAL_FRAMEWORK: "Moral Error Theory (Mackie)"
+      SEMANTIC_THEORY: "Cognitivist Truth-Conditional Semantics"
+    expected: "Ontological Commitment Extraction"
+  - variables:
+      MORAL_STATEMENT: "Stealing is bad."
+      METAETHICAL_FRAMEWORK: "Non-Cognitivist Expressivism (Ayer/Gibbard)"
+      SEMANTIC_THEORY: "Expressivist Semantics"
+    expected: "Semantic Formalization"
+evaluators:
+  - type: regex
+    pattern: "(?i)(Ontological Commitment Extraction|Semantic Formalization|Dialectical Synthesis and Tension Analysis|Validity and Rigor)"

--- a/prompts/scientific/philosophy/ethics/metaethics/overview.md
+++ b/prompts/scientific/philosophy/ethics/metaethics/overview.md
@@ -1,0 +1,4 @@
+# Metaethics Overview
+
+## Prompts
+- **[metaethical_discourse_semantic_analyzer](metaethical_discourse_semantic_analyzer.prompt.yaml)**: Systematically analyzes and evaluates the semantic and ontological commitments of moral discourse across metaethical frameworks.

--- a/prompts/scientific/philosophy/ethics/overview.md
+++ b/prompts/scientific/philosophy/ethics/overview.md
@@ -1,4 +1,5 @@
 # Ethics Overview
 
 ## Categories
+- [Metaethics/](metaethics/overview.md)
 - [Normative Ethics/](normative_ethics/overview.md)


### PR DESCRIPTION
Identifies a missing analytical workflow within philosophy (metaethics), designs an expert-level prompt for semantic and ontological commitment analysis, and correctly sets it up within the `ethics/metaethics` ecosystem with its respective overview and indices documentation.

---
*PR created automatically by Jules for task [5134657025544351091](https://jules.google.com/task/5134657025544351091) started by @fderuiter*