### PR TITLE
🧱 Mason: Fix evaluator schema for Jules Developer Agent

### DIFF
--- a/docs/prompts/google_jules/jules_developer_agent.prompt.md
+++ b/docs/prompts/google_jules/jules_developer_agent.prompt.md
@@ -118,6 +118,9 @@ testData:
   - name: Refusal JSON
     regex:
       pattern: '{"error": "unsafe"}'
-evaluators: []
+evaluators:
+  - name: Global No Markdown Enclosure
+    type: regex
+    pattern: "^(?!```).*$"
 
 ```

--- a/prompts/google_jules/jules_developer_agent.prompt.yaml
+++ b/prompts/google_jules/jules_developer_agent.prompt.yaml
@@ -107,4 +107,7 @@ testData:
   - name: Refusal JSON
     regex:
       pattern: '{"error": "unsafe"}'
-evaluators: []
+evaluators:
+  - name: Global No Markdown Enclosure
+    type: regex
+    pattern: "^(?!```).*$"


### PR DESCRIPTION
- Removed invalid `evaluators: []` from `prompts/google_jules/jules_developer_agent.prompt.yaml` and replaced it with a valid global regex evaluator to check for plain text output outside Markdown backticks.
- Removed the tracking content incorrectly inserted into `.jules/mason.md` which is reserved strictly for tracking "critical learnings" according to the prompt constraints.
- Generated and synchronized docs.

---
*PR created automatically by Jules for task [17840791969960030107](https://jules.google.com/task/17840791969960030107) started by @fderuiter*