### PR TITLE
feat(cdisc): add ADaM ADRS RECIST criteria derivation prompt

### DIFF
--- a/docs/clinical.md
+++ b/docs/clinical.md
@@ -6,6 +6,7 @@ title: Clinical
 
 ## Prompts
 - [21 CFR Part 11 Compliance Verification](prompts/clinical/data_management/part_11_compliance_verification.prompt.md)
+- [ADaM ADRS RECIST Derivation Architect](prompts/clinical/data_management/cdisc_compliance_workflow/05_adam_adrs_recist_derivation_architect.prompt.md)
 - [ADaM Derivation Writer](prompts/clinical/data_management/cdisc_compliance_workflow/03_adam_derivation_writer.prompt.md)
 - [Adaptive Recruitment and Retention Strategy](prompts/clinical/trial_execution/adaptive_recruitment_retention_strategy.prompt.md)
 - [adverse_event_signal_detection_architect](prompts/clinical/pharmacovigilance/adverse_event_signal_detection_architect.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -372,6 +372,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Raw-to-SDTM Auto-Mapper](prompts/clinical/data_management/cdisc_compliance_workflow/02_raw_to_sdtm_auto_mapper.prompt.md)
 - [ADaM Derivation Writer](prompts/clinical/data_management/cdisc_compliance_workflow/03_adam_derivation_writer.prompt.md)
 - [Controlled Terminology Harmonizer](prompts/clinical/data_management/cdisc_compliance_workflow/04_controlled_terminology_harmonizer.prompt.md)
+- [ADaM ADRS RECIST Derivation Architect](prompts/clinical/data_management/cdisc_compliance_workflow/05_adam_adrs_recist_derivation_architect.prompt.md)
 - [Clinical ETL Mapping Spec](prompts/clinical/data_management/data_management_etl_workflow/01_clinical_etl_mapping_spec.prompt.md)
 - [Clinical ETL Transformation QC](prompts/clinical/data_management/data_management_etl_workflow/02_clinical_etl_transformation_qc.prompt.md)
 - [Clinical ETL Pipeline Review](prompts/clinical/data_management/data_management_etl_workflow/03_clinical_etl_pipeline_review.prompt.md)

--- a/docs/prompts/clinical/data_management/cdisc_compliance_workflow/05_adam_adrs_recist_derivation_architect.prompt.md
+++ b/docs/prompts/clinical/data_management/cdisc_compliance_workflow/05_adam_adrs_recist_derivation_architect.prompt.md
@@ -1,0 +1,114 @@
+---
+title: ADaM ADRS RECIST Derivation Architect
+---
+
+# ADaM ADRS RECIST Derivation Architect
+
+Automates the complex derivation of oncology RECIST 1.1 criteria for the ADaM ADRS (Tumor Response) domain based on raw EDC data and SDTM Tu/TR domains.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/clinical/data_management/cdisc_compliance_workflow/05_adam_adrs_recist_derivation_architect.prompt.yaml)
+
+```yaml
+---
+name: ADaM ADRS RECIST Derivation Architect
+version: 1.0.0
+description: Automates the complex derivation of oncology RECIST 1.1 criteria for the ADaM ADRS (Tumor Response) domain based on raw EDC data and SDTM Tu/TR domains.
+authors:
+  - CDISC Architect
+metadata:
+  domain: clinical
+  complexity: high
+  tags:
+    - cdisc
+    - adam
+    - adrs
+    - recist
+    - oncology
+    - derivation
+  requires_context: true
+variables:
+  - name: sdtm_tu_data
+    description: SDTM Tumor Identification (TU) domain data representing baseline and post-baseline lesions.
+    required: true
+  - name: sdtm_tr_data
+    description: SDTM Tumor Results (TR) domain data representing lesion measurements over time.
+    required: true
+  - name: recist_version
+    description: The specific version of RECIST criteria to apply (default is RECIST 1.1).
+    required: false
+model: claude-3-opus-20240229
+modelParameters:
+  temperature: 0.2
+messages:
+  - role: system
+    content: |
+      You are a Principal Statistical Programmer and Lead CDISC Standards SME with deep expertise in oncology clinical trials and ADaM implementation.
+
+      Your task is to algorithmically derive the ADaM Tumor Response (ADRS) dataset conforming strictly to RECIST 1.1 guidelines and the ADaM Implementation Guide (IG) v1.3.
+
+      Inputs:
+      1. SDTM TU (Tumor Identification): Identifies target, non-target, and new lesions.
+      2. SDTM TR (Tumor Results): Provides quantitative and qualitative assessments of these lesions.
+
+      Requirements for ADRS Derivation:
+      - Parameters (PARAMCD): Calculate derived parameters such as Sum of Diameters (SUMD), Percent Change from Baseline (PCHG), Overall Target Lesion Response (TRGRESP), Overall Non-Target Lesion Response (NTRGRESP), and Overall Response (OVRRESP).
+      - Target Lesion Evaluation:
+          - CR: Disappearance of all target lesions.
+          - PR: >= 30% decrease in the sum of diameters (SUMD) of target lesions, taking as reference the baseline sum.
+          - PD: >= 20% increase in SUMD, taking as reference the smallest sum on study (nadir), AND an absolute increase of >= 5 mm.
+          - SD: Neither sufficient shrinkage to qualify for PR nor sufficient increase to qualify for PD.
+      - Overall Response Calculation: Accurately combine target, non-target, and new lesion status per RECIST 1.1 matrix to determine OVRRESP for each visit/timepoint.
+      - CDISC Conformance: Ensure AVAL (Numeric) and AVALC (Character) are populated correctly according to controlled terminology (e.g., 'CR', 'PR', 'SD', 'PD', 'NE'). Include AVISIT and AVISITN derived from analysis dates.
+
+      Constraints:
+      - Output strictly a mapping specification or programmatic logic sequence detailing the derivation of each ADRS parameter.
+      - Do NOT hallucinate variables outside of the ADaM IG.
+      - If missing measurements (e.g., NE) preclude determination of a response, appropriately flag or evaluate to 'NE' per RECIST rules.
+  - role: user
+    content: |
+      Derive the ADRS RECIST 1.1 response logic based on the following SDTM clinical data snapshots.
+
+      SDTM TU Data:
+      {{sdtm_tu_data}}
+
+      RECIST Version:
+      {{recist_version}}
+
+      SDTM TR Data:
+      {{sdtm_tr_data}}
+
+      Output the derivation rules formatted as an ADaM mapping specification matrix (Parameter | Condition/Logic | AVALC | AVAL).
+testData:
+  - input:
+      sdtm_tu_data: |
+        USUBJID, TULNKID, TULOC, TUSTRESC, VISITNUM
+        SUBJ-01, TL01, LUNG, TARGET, 1
+        SUBJ-01, TL02, LIVER, TARGET, 1
+        SUBJ-01, NTL01, BONE, NON-TARGET, 1
+      sdtm_tr_data: |
+        USUBJID, TRLNKID, TRTESTCD, TRORRES, VISITNUM
+        SUBJ-01, TL01, LDIAM, 40, 1
+        SUBJ-01, TL02, LDIAM, 35, 1
+        SUBJ-01, NTL01, TRSTRESC, PRESENT, 1
+        SUBJ-01, TL01, LDIAM, 20, 2
+        SUBJ-01, TL02, LDIAM, 25, 2
+        SUBJ-01, NTL01, TRSTRESC, PRESENT, 2
+    expected: |
+      Parameter | Condition/Logic | AVALC | AVAL
+      SUMD | Sum of LDIAM for TARGET lesions | 75 | 75 (Visit 1)
+      SUMD | Sum of LDIAM for TARGET lesions | 45 | 45 (Visit 2)
+      TRGRESP | PCHG <= -30% from baseline | PR | 2
+      NTRGRESP | Non-target lesions present | NON-CR/NON-PD | 3
+      OVRRESP | Target=PR, Non-Target=NON-CR/NON-PD, New Lesion=No | PR | 2
+evaluators:
+  - name: Includes RECIST parameters
+    string:
+      contains: SUMD
+  - name: Includes AVALC mapping
+    string:
+      contains: AVALC
+  - name: Includes OVRRESP calculation
+    regex:
+      pattern: OVRRESP
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -261,6 +261,7 @@
 [Raw-to-SDTM Auto-Mapper](prompts/clinical/data_management/cdisc_compliance_workflow/02_raw_to_sdtm_auto_mapper.prompt.md)
 [ADaM Derivation Writer](prompts/clinical/data_management/cdisc_compliance_workflow/03_adam_derivation_writer.prompt.md)
 [Controlled Terminology Harmonizer](prompts/clinical/data_management/cdisc_compliance_workflow/04_controlled_terminology_harmonizer.prompt.md)
+[ADaM ADRS RECIST Derivation Architect](prompts/clinical/data_management/cdisc_compliance_workflow/05_adam_adrs_recist_derivation_architect.prompt.md)
 [Clinical ETL Mapping Spec](prompts/clinical/data_management/data_management_etl_workflow/01_clinical_etl_mapping_spec.prompt.md)
 [Clinical ETL Transformation QC](prompts/clinical/data_management/data_management_etl_workflow/02_clinical_etl_transformation_qc.prompt.md)
 [Clinical ETL Pipeline Review](prompts/clinical/data_management/data_management_etl_workflow/03_clinical_etl_pipeline_review.prompt.md)

--- a/prompts/clinical/data_management/cdisc_compliance_workflow/05_adam_adrs_recist_derivation_architect.prompt.yaml
+++ b/prompts/clinical/data_management/cdisc_compliance_workflow/05_adam_adrs_recist_derivation_architect.prompt.yaml
@@ -1,0 +1,101 @@
+---
+name: ADaM ADRS RECIST Derivation Architect
+version: 1.0.0
+description: Automates the complex derivation of oncology RECIST 1.1 criteria for the ADaM ADRS (Tumor Response) domain based on raw EDC data and SDTM Tu/TR domains.
+authors:
+  - CDISC Architect
+metadata:
+  domain: clinical
+  complexity: high
+  tags:
+    - cdisc
+    - adam
+    - adrs
+    - recist
+    - oncology
+    - derivation
+  requires_context: true
+variables:
+  - name: sdtm_tu_data
+    description: SDTM Tumor Identification (TU) domain data representing baseline and post-baseline lesions.
+    required: true
+  - name: sdtm_tr_data
+    description: SDTM Tumor Results (TR) domain data representing lesion measurements over time.
+    required: true
+  - name: recist_version
+    description: The specific version of RECIST criteria to apply (default is RECIST 1.1).
+    required: false
+model: claude-3-opus-20240229
+modelParameters:
+  temperature: 0.2
+messages:
+  - role: system
+    content: |
+      You are a Principal Statistical Programmer and Lead CDISC Standards SME with deep expertise in oncology clinical trials and ADaM implementation.
+
+      Your task is to algorithmically derive the ADaM Tumor Response (ADRS) dataset conforming strictly to RECIST 1.1 guidelines and the ADaM Implementation Guide (IG) v1.3.
+
+      Inputs:
+      1. SDTM TU (Tumor Identification): Identifies target, non-target, and new lesions.
+      2. SDTM TR (Tumor Results): Provides quantitative and qualitative assessments of these lesions.
+
+      Requirements for ADRS Derivation:
+      - Parameters (PARAMCD): Calculate derived parameters such as Sum of Diameters (SUMD), Percent Change from Baseline (PCHG), Overall Target Lesion Response (TRGRESP), Overall Non-Target Lesion Response (NTRGRESP), and Overall Response (OVRRESP).
+      - Target Lesion Evaluation:
+          - CR: Disappearance of all target lesions.
+          - PR: >= 30% decrease in the sum of diameters (SUMD) of target lesions, taking as reference the baseline sum.
+          - PD: >= 20% increase in SUMD, taking as reference the smallest sum on study (nadir), AND an absolute increase of >= 5 mm.
+          - SD: Neither sufficient shrinkage to qualify for PR nor sufficient increase to qualify for PD.
+      - Overall Response Calculation: Accurately combine target, non-target, and new lesion status per RECIST 1.1 matrix to determine OVRRESP for each visit/timepoint.
+      - CDISC Conformance: Ensure AVAL (Numeric) and AVALC (Character) are populated correctly according to controlled terminology (e.g., 'CR', 'PR', 'SD', 'PD', 'NE'). Include AVISIT and AVISITN derived from analysis dates.
+
+      Constraints:
+      - Output strictly a mapping specification or programmatic logic sequence detailing the derivation of each ADRS parameter.
+      - Do NOT hallucinate variables outside of the ADaM IG.
+      - If missing measurements (e.g., NE) preclude determination of a response, appropriately flag or evaluate to 'NE' per RECIST rules.
+  - role: user
+    content: |
+      Derive the ADRS RECIST 1.1 response logic based on the following SDTM clinical data snapshots.
+
+      SDTM TU Data:
+      {{sdtm_tu_data}}
+
+      RECIST Version:
+      {{recist_version}}
+
+      SDTM TR Data:
+      {{sdtm_tr_data}}
+
+      Output the derivation rules formatted as an ADaM mapping specification matrix (Parameter | Condition/Logic | AVALC | AVAL).
+testData:
+  - input:
+      sdtm_tu_data: |
+        USUBJID, TULNKID, TULOC, TUSTRESC, VISITNUM
+        SUBJ-01, TL01, LUNG, TARGET, 1
+        SUBJ-01, TL02, LIVER, TARGET, 1
+        SUBJ-01, NTL01, BONE, NON-TARGET, 1
+      sdtm_tr_data: |
+        USUBJID, TRLNKID, TRTESTCD, TRORRES, VISITNUM
+        SUBJ-01, TL01, LDIAM, 40, 1
+        SUBJ-01, TL02, LDIAM, 35, 1
+        SUBJ-01, NTL01, TRSTRESC, PRESENT, 1
+        SUBJ-01, TL01, LDIAM, 20, 2
+        SUBJ-01, TL02, LDIAM, 25, 2
+        SUBJ-01, NTL01, TRSTRESC, PRESENT, 2
+    expected: |
+      Parameter | Condition/Logic | AVALC | AVAL
+      SUMD | Sum of LDIAM for TARGET lesions | 75 | 75 (Visit 1)
+      SUMD | Sum of LDIAM for TARGET lesions | 45 | 45 (Visit 2)
+      TRGRESP | PCHG <= -30% from baseline | PR | 2
+      NTRGRESP | Non-target lesions present | NON-CR/NON-PD | 3
+      OVRRESP | Target=PR, Non-Target=NON-CR/NON-PD, New Lesion=No | PR | 2
+evaluators:
+  - name: Includes RECIST parameters
+    string:
+      contains: SUMD
+  - name: Includes AVALC mapping
+    string:
+      contains: AVALC
+  - name: Includes OVRRESP calculation
+    regex:
+      pattern: OVRRESP

--- a/prompts/clinical/data_management/cdisc_compliance_workflow/overview.md
+++ b/prompts/clinical/data_management/cdisc_compliance_workflow/overview.md
@@ -5,3 +5,4 @@
 - **[Raw-to-SDTM Auto-Mapper](02_raw_to_sdtm_auto_mapper.prompt.yaml)**: Intelligently maps raw EDC variables to standard SDTM variables based on fuzzy logic and context.
 - **[ADaM Derivation Writer](03_adam_derivation_writer.prompt.yaml)**: Translates SAS/R programming logic into plain-English derivation descriptions for CDISC define.xml documentation.
 - **[Controlled Terminology Harmonizer](04_controlled_terminology_harmonizer.prompt.yaml)**: Standardizes a list of values (e.g., Units) to CDISC Controlled Terminology (NCI Preferred Terms).
+- **[ADaM ADRS RECIST Derivation Architect](05_adam_adrs_recist_derivation_architect.prompt.yaml)**: Automates the complex derivation of oncology RECIST 1.1 criteria for the ADaM ADRS (Tumor Response) domain based on raw EDC data and SDTM Tu/TR domains.


### PR DESCRIPTION
Added a new high-complexity prompt template for ADaM ADRS (Tumor Response) derivation using RECIST 1.1 guidelines. Solves a specialized edge case involving SDTM TU/TR domain mapping in oncology.

---
*PR created automatically by Jules for task [2414802750599384262](https://jules.google.com/task/2414802750599384262) started by @fderuiter*