### PR TITLE
Add Pinnacle 21 issue resolution architect prompt

### DIFF
--- a/docs/clinical.md
+++ b/docs/clinical.md
@@ -93,6 +93,7 @@ title: Clinical
 - [Personalized Investigator-Outreach Email Generator](prompts/clinical/site_acquisition/site_acquisition_workflow/03_investigator_outreach_email_generator.prompt.md)
 - [Pharmacovigilance Risk Management Plan Architect](prompts/clinical/pharmacovigilance/pharmacovigilance_risk_management_plan_architect.prompt.md)
 - [Phase II Oncology DMP](prompts/clinical/data_management/phase_ii_oncology_dmp.prompt.md)
+- [Pinnacle 21 Conformance Issue Resolution Architect](prompts/clinical/data_management/cdisc_compliance_workflow/06_pinnacle21_issue_resolution_architect.prompt.md)
 - [Portfolio-Level Clinical Operations Roadmap](prompts/clinical/trial_execution/portfolio_clin_ops_roadmap.prompt.md)
 - [Post-Market Safety Signal Trending](prompts/clinical/safety/clinical_safety_workflow/03_post_market_safety_signal_trending.prompt.md)
 - [Protocol Amendment Rationale Drafter](prompts/clinical/medical_writing/protocol_amendment_rationale_drafter.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -373,6 +373,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [ADaM Derivation Writer](prompts/clinical/data_management/cdisc_compliance_workflow/03_adam_derivation_writer.prompt.md)
 - [Controlled Terminology Harmonizer](prompts/clinical/data_management/cdisc_compliance_workflow/04_controlled_terminology_harmonizer.prompt.md)
 - [ADaM ADRS RECIST Derivation Architect](prompts/clinical/data_management/cdisc_compliance_workflow/05_adam_adrs_recist_derivation_architect.prompt.md)
+- [Pinnacle 21 Conformance Issue Resolution Architect](prompts/clinical/data_management/cdisc_compliance_workflow/06_pinnacle21_issue_resolution_architect.prompt.md)
 - [Clinical ETL Mapping Spec](prompts/clinical/data_management/data_management_etl_workflow/01_clinical_etl_mapping_spec.prompt.md)
 - [Clinical ETL Transformation QC](prompts/clinical/data_management/data_management_etl_workflow/02_clinical_etl_transformation_qc.prompt.md)
 - [Clinical ETL Pipeline Review](prompts/clinical/data_management/data_management_etl_workflow/03_clinical_etl_pipeline_review.prompt.md)

--- a/docs/prompts/clinical/data_management/cdisc_compliance_workflow/06_pinnacle21_issue_resolution_architect.prompt.md
+++ b/docs/prompts/clinical/data_management/cdisc_compliance_workflow/06_pinnacle21_issue_resolution_architect.prompt.md
@@ -1,0 +1,111 @@
+---
+title: Pinnacle 21 Conformance Issue Resolution Architect
+---
+
+# Pinnacle 21 Conformance Issue Resolution Architect
+
+Automates the programmatic diagnosis, resolution strategy generation, and code remediation for complex Pinnacle 21 (P21) Enterprise conformance rule rejections in CDISC SDTM and ADaM submissions.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/clinical/data_management/cdisc_compliance_workflow/06_pinnacle21_issue_resolution_architect.prompt.yaml)
+
+```yaml
+---
+name: Pinnacle 21 Conformance Issue Resolution Architect
+version: 1.0.0
+description: Automates the programmatic diagnosis, resolution strategy generation, and code remediation for complex Pinnacle 21 (P21) Enterprise conformance rule rejections in CDISC SDTM and ADaM submissions.
+authors:
+  - CDISC Architect
+metadata:
+  domain: clinical
+  complexity: high
+  tags:
+    - cdisc
+    - pinnacle21
+    - conformance
+    - sdtm
+    - adam
+    - resolution
+  requires_context: true
+variables:
+  - name: p21_report_extract
+    description: Raw extract or JSON representation of the Pinnacle 21 validation report detailing the rule violations.
+    required: true
+  - name: dataset_context
+    description: Metadata or sample data from the offending dataset (e.g., domain, variables, types).
+    required: true
+  - name: cdisc_standard
+    description: The targeted CDISC standard and version (e.g., SDTMIG 3.3, ADaMIG 1.3).
+    required: true
+model: claude-3-opus-20240229
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are a Principal Statistical Programmer and Lead CDISC Standards SME, recognized as a global authority on Pinnacle 21 Enterprise validation, clinical data standards, and regulatory submission readiness.
+
+      Your objective is to systematically diagnose Pinnacle 21 conformance rule rejections and formulate rigorous, implementation-ready programmatic resolution strategies that strictly adhere to CDISC Implementation Guides (IGs).
+
+      Inputs:
+      1. Pinnacle 21 Report Extract: The specific rule IDs (e.g., SD1080, AD0018), error messages, and descriptions of the violations.
+      2. Dataset Context: The structure and relevant sample data of the offending domains.
+      3. CDISC Standard: The target IG version for compliance.
+
+      Operational Guidelines:
+      - Diagnostic Accuracy: Pinpoint the root cause of the conformance issue by cross-referencing the P21 rule logic against the specified CDISC IG.
+      - Remediation Strategy: Provide a precise, step-by-step resolution strategy to address the underlying data, mapping, or metadata issue. Focus on actual programmatic fixes, not temporary workarounds or false positive explanations (unless unequivocally proven to be an agency-accepted false positive).
+      - Code Remediation: Provide standard SAS or R pseudocode demonstrating the required derivation or transformation to correct the issue.
+      - CDISC Conformance: Ensure all recommendations strictly obey controlled terminology, variable core assignments (Required, Expected, Permissible), and structural requirements.
+
+      Constraints:
+      - Do NOT suggest suppressing errors without a comprehensive justification aligned with regulatory guidelines (e.g., FDA Study Data Technical Conformance Guide).
+      - Output your analysis as a structured YAML resolution payload containing: rule_id, root_cause, resolution_strategy, and remediation_pseudocode.
+  - role: user
+    content: |
+      Diagnose and resolve the following Pinnacle 21 conformance issues based on the provided report extract and dataset context.
+
+      Pinnacle 21 Report Extract:
+      {{p21_report_extract}}
+
+      Dataset Context:
+      {{dataset_context}}
+
+      CDISC Standard:
+      {{cdisc_standard}}
+testData:
+  - input:
+      p21_report_extract: |
+        Rule ID: SD1080
+        Message: Missing value for --SEQ variable
+        Domain: AE
+      dataset_context: |
+        Domain: AE
+        Variables: STUDYID, DOMAIN, USUBJID, AETERM, AESTDTC
+        Sample: ['PROJ-01', 'AE', 'SUBJ-01', 'HEADACHE', '2023-01-15']
+      cdisc_standard: SDTMIG 3.3
+    expected: |
+      rule_id: SD1080
+      root_cause: The AESEQ variable is structurally required for the AE domain to uniquely identify records per subject but is absent from the dataset.
+      resolution_strategy: Derive AESEQ by grouping the dataset by USUBJID and assigning a sequential integer starting from 1 for each record within the subject.
+      remediation_pseudocode: |
+        proc sort data=ae;
+          by usubjid aestdtc;
+        run;
+        data ae;
+          set ae;
+          by usubjid;
+          if first.usubjid then aeseq = 1;
+          else aeseq + 1;
+        run;
+evaluators:
+  - name: Includes rule_id
+    string:
+      contains: rule_id
+  - name: Includes root_cause
+    string:
+      contains: root_cause
+  - name: Includes resolution_strategy
+    string:
+      contains: resolution_strategy
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -262,6 +262,7 @@
 [ADaM Derivation Writer](prompts/clinical/data_management/cdisc_compliance_workflow/03_adam_derivation_writer.prompt.md)
 [Controlled Terminology Harmonizer](prompts/clinical/data_management/cdisc_compliance_workflow/04_controlled_terminology_harmonizer.prompt.md)
 [ADaM ADRS RECIST Derivation Architect](prompts/clinical/data_management/cdisc_compliance_workflow/05_adam_adrs_recist_derivation_architect.prompt.md)
+[Pinnacle 21 Conformance Issue Resolution Architect](prompts/clinical/data_management/cdisc_compliance_workflow/06_pinnacle21_issue_resolution_architect.prompt.md)
 [Clinical ETL Mapping Spec](prompts/clinical/data_management/data_management_etl_workflow/01_clinical_etl_mapping_spec.prompt.md)
 [Clinical ETL Transformation QC](prompts/clinical/data_management/data_management_etl_workflow/02_clinical_etl_transformation_qc.prompt.md)
 [Clinical ETL Pipeline Review](prompts/clinical/data_management/data_management_etl_workflow/03_clinical_etl_pipeline_review.prompt.md)

--- a/prompts/clinical/data_management/cdisc_compliance_workflow/06_pinnacle21_issue_resolution_architect.prompt.yaml
+++ b/prompts/clinical/data_management/cdisc_compliance_workflow/06_pinnacle21_issue_resolution_architect.prompt.yaml
@@ -1,0 +1,98 @@
+---
+name: Pinnacle 21 Conformance Issue Resolution Architect
+version: 1.0.0
+description: Automates the programmatic diagnosis, resolution strategy generation, and code remediation for complex Pinnacle 21 (P21) Enterprise conformance rule rejections in CDISC SDTM and ADaM submissions.
+authors:
+  - CDISC Architect
+metadata:
+  domain: clinical
+  complexity: high
+  tags:
+    - cdisc
+    - pinnacle21
+    - conformance
+    - sdtm
+    - adam
+    - resolution
+  requires_context: true
+variables:
+  - name: p21_report_extract
+    description: Raw extract or JSON representation of the Pinnacle 21 validation report detailing the rule violations.
+    required: true
+  - name: dataset_context
+    description: Metadata or sample data from the offending dataset (e.g., domain, variables, types).
+    required: true
+  - name: cdisc_standard
+    description: The targeted CDISC standard and version (e.g., SDTMIG 3.3, ADaMIG 1.3).
+    required: true
+model: claude-3-opus-20240229
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: |
+      You are a Principal Statistical Programmer and Lead CDISC Standards SME, recognized as a global authority on Pinnacle 21 Enterprise validation, clinical data standards, and regulatory submission readiness.
+
+      Your objective is to systematically diagnose Pinnacle 21 conformance rule rejections and formulate rigorous, implementation-ready programmatic resolution strategies that strictly adhere to CDISC Implementation Guides (IGs).
+
+      Inputs:
+      1. Pinnacle 21 Report Extract: The specific rule IDs (e.g., SD1080, AD0018), error messages, and descriptions of the violations.
+      2. Dataset Context: The structure and relevant sample data of the offending domains.
+      3. CDISC Standard: The target IG version for compliance.
+
+      Operational Guidelines:
+      - Diagnostic Accuracy: Pinpoint the root cause of the conformance issue by cross-referencing the P21 rule logic against the specified CDISC IG.
+      - Remediation Strategy: Provide a precise, step-by-step resolution strategy to address the underlying data, mapping, or metadata issue. Focus on actual programmatic fixes, not temporary workarounds or false positive explanations (unless unequivocally proven to be an agency-accepted false positive).
+      - Code Remediation: Provide standard SAS or R pseudocode demonstrating the required derivation or transformation to correct the issue.
+      - CDISC Conformance: Ensure all recommendations strictly obey controlled terminology, variable core assignments (Required, Expected, Permissible), and structural requirements.
+
+      Constraints:
+      - Do NOT suggest suppressing errors without a comprehensive justification aligned with regulatory guidelines (e.g., FDA Study Data Technical Conformance Guide).
+      - Output your analysis as a structured YAML resolution payload containing: rule_id, root_cause, resolution_strategy, and remediation_pseudocode.
+  - role: user
+    content: |
+      Diagnose and resolve the following Pinnacle 21 conformance issues based on the provided report extract and dataset context.
+
+      Pinnacle 21 Report Extract:
+      {{p21_report_extract}}
+
+      Dataset Context:
+      {{dataset_context}}
+
+      CDISC Standard:
+      {{cdisc_standard}}
+testData:
+  - input:
+      p21_report_extract: |
+        Rule ID: SD1080
+        Message: Missing value for --SEQ variable
+        Domain: AE
+      dataset_context: |
+        Domain: AE
+        Variables: STUDYID, DOMAIN, USUBJID, AETERM, AESTDTC
+        Sample: ['PROJ-01', 'AE', 'SUBJ-01', 'HEADACHE', '2023-01-15']
+      cdisc_standard: SDTMIG 3.3
+    expected: |
+      rule_id: SD1080
+      root_cause: The AESEQ variable is structurally required for the AE domain to uniquely identify records per subject but is absent from the dataset.
+      resolution_strategy: Derive AESEQ by grouping the dataset by USUBJID and assigning a sequential integer starting from 1 for each record within the subject.
+      remediation_pseudocode: |
+        proc sort data=ae;
+          by usubjid aestdtc;
+        run;
+        data ae;
+          set ae;
+          by usubjid;
+          if first.usubjid then aeseq = 1;
+          else aeseq + 1;
+        run;
+evaluators:
+  - name: Includes rule_id
+    string:
+      contains: rule_id
+  - name: Includes root_cause
+    string:
+      contains: root_cause
+  - name: Includes resolution_strategy
+    string:
+      contains: resolution_strategy

--- a/prompts/clinical/data_management/cdisc_compliance_workflow/overview.md
+++ b/prompts/clinical/data_management/cdisc_compliance_workflow/overview.md
@@ -6,3 +6,4 @@
 - **[ADaM Derivation Writer](03_adam_derivation_writer.prompt.yaml)**: Translates SAS/R programming logic into plain-English derivation descriptions for CDISC define.xml documentation.
 - **[Controlled Terminology Harmonizer](04_controlled_terminology_harmonizer.prompt.yaml)**: Standardizes a list of values (e.g., Units) to CDISC Controlled Terminology (NCI Preferred Terms).
 - **[ADaM ADRS RECIST Derivation Architect](05_adam_adrs_recist_derivation_architect.prompt.yaml)**: Automates the complex derivation of oncology RECIST 1.1 criteria for the ADaM ADRS (Tumor Response) domain based on raw EDC data and SDTM Tu/TR domains.
+- **[Pinnacle 21 Conformance Issue Resolution Architect](06_pinnacle21_issue_resolution_architect.prompt.yaml)**: Automates the programmatic diagnosis, resolution strategy generation, and code remediation for complex Pinnacle 21 (P21) Enterprise conformance rule rejections in CDISC SDTM and ADaM submissions.


### PR DESCRIPTION
Adds a new prompt to automate the programmatic diagnosis, resolution strategy generation, and code remediation for complex Pinnacle 21 (P21) Enterprise conformance rule rejections in CDISC SDTM and ADaM submissions.

---
*PR created automatically by Jules for task [13577328232149817140](https://jules.google.com/task/13577328232149817140) started by @fderuiter*