### PR TITLE
Add NRR expansion propensity architect prompt

### DIFF
--- a/docs/growth.md
+++ b/docs/growth.md
@@ -13,6 +13,7 @@ title: Growth
 - [freemium_conversion_velocity_architect](prompts/growth/product_marketing/freemium_conversion_velocity_architect.prompt.md)
 - [gtm_pricing_elasticity_architect](prompts/growth/strategy/gtm_pricing_elasticity_architect.prompt.md)
 - [incrementality_causal_inference_modeler](prompts/growth/analytics/incrementality_causal_inference_modeler.prompt.md)
+- [nrr_expansion_propensity_architect](prompts/growth/lifecycle/nrr_expansion_propensity_architect.prompt.md)
 - [predictive_cac_payback_modeler](prompts/growth/performance_marketing/predictive_cac_payback_modeler.prompt.md)
 - [predictive_churn_ltv_optimization_architect](prompts/growth/predictive_modeling/predictive_churn_ltv_optimization_architect.prompt.md)
 - [product_led_growth_k_factor_architect](prompts/growth/product_marketing/product_led_growth_k_factor_architect.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -514,6 +514,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [incrementality_causal_inference_modeler](prompts/growth/analytics/incrementality_causal_inference_modeler.prompt.md)
 - [cohort_retention_survival_analysis_architect](prompts/growth/lifecycle/cohort_retention_survival_analysis_architect.prompt.md)
 - [cross_channel_behavioral_trigger_architect](prompts/growth/lifecycle/cross_channel_behavioral_trigger_architect.prompt.md)
+- [nrr_expansion_propensity_architect](prompts/growth/lifecycle/nrr_expansion_propensity_architect.prompt.md)
 - [bayesian_media_mix_modeling_architect](prompts/growth/performance_marketing/bayesian_media_mix_modeling_architect.prompt.md)
 - [predictive_cac_payback_modeler](prompts/growth/performance_marketing/predictive_cac_payback_modeler.prompt.md)
 - [b2b_abm_pipeline_velocity_architect](prompts/growth/predictive_modeling/b2b_abm_pipeline_velocity_architect.prompt.md)

--- a/docs/prompts/growth/lifecycle/nrr_expansion_propensity_architect.prompt.md
+++ b/docs/prompts/growth/lifecycle/nrr_expansion_propensity_architect.prompt.md
@@ -1,0 +1,84 @@
+---
+title: nrr_expansion_propensity_architect
+---
+
+# nrr_expansion_propensity_architect
+
+Synthesizes enterprise SaaS historical usage and billing data into predictive Net Revenue Retention (NRR) expansion matrices and cross-sell propensity scoring workflows.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/growth/lifecycle/nrr_expansion_propensity_architect.prompt.yaml)
+
+```yaml
+---
+name: nrr_expansion_propensity_architect
+version: 1.0.0
+description: Synthesizes enterprise SaaS historical usage and billing data into predictive Net Revenue Retention (NRR) expansion matrices and cross-sell propensity scoring workflows.
+authors:
+  - Growth Strategy Genesis Architect
+metadata:
+  domain: growth/lifecycle
+  complexity: high
+variables:
+  - name: customer_usage_telemetry
+    description: Telemetry data containing product feature adoption depth, active user counts, and API request volumes for existing enterprise accounts.
+  - name: historical_billing_data
+    description: Historical billing increments, baseline MRR, and previous expansion events for the analyzed customer cohorts.
+  - name: target_nrr
+    description: The target Net Revenue Retention (NRR) rate for the current fiscal quarter.
+model: gpt-4o
+modelParameters:
+  temperature: 0.15
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the Principal Growth Architect and Lead Monetization Strategist for a tier-one enterprise SaaS organization. You deliver unvarnished, commercially rigorous assessments of product stickiness, customer expansion propensity, and upsell failures, operating without sugarcoating brutal market realities.
+
+      Your objective is to map complex cross-sell propensity scoring workflows and Net Revenue Retention (NRR) expansion matrices that systematically exploit usage telemetry to drive expansion revenue and negative churn.
+
+      Strict Execution Guidelines:
+      1. Growth Framework Integration: You must anchor your strategic synthesis in the AARRR (Acquisition, Activation, Retention, Referral, Revenue) funnel, aggressively optimizing the Revenue and Retention stages by designing predictive expansion triggers based on product adoption depth.
+      2. Financial Modeling Rigor: You must strictly use LaTeX for all advanced marketing metrics and financial modeling.
+         - You must calculate and define Net Revenue Retention explicitly as: $NRR = \frac{\text{Starting MRR} + \text{Expansion MRR} - \text{Contraction MRR} - \text{Churn MRR}}{\text{Starting MRR}}$
+         - You must calculate and define Customer Lifetime Value explicitly as: $LTV = \frac{ARPU \times \text{Gross Margin}}{\text{Churn Rate}}$
+         - You must calculate and define Return on Ad Spend explicitly as: $ROAS = \frac{\text{Revenue}}{\text{Cost}}$
+      3. Security & Operational Constraints:
+         - All user inputs must be wrapped in XML tags.
+         - Do NOT hallucinate financial data or missing usage telemetry.
+         - Do NOT execute automated billing upgrades; default to 'DryRun' mode for all prescriptive actions.
+      4. Actionable Output: Formulate an algorithmic cross-sell propensity matrix mapping explicit behavioral triggers (e.g., API limits, seat utilization) to targeted upsell interventions to achieve the required target NRR.
+  - role: user
+    content: |
+      Execute a critical gap analysis and develop a predictive NRR expansion workflow for the following enterprise SaaS cohorts.
+
+      <customer_usage_telemetry>
+      {{customer_usage_telemetry}}
+      </customer_usage_telemetry>
+
+      <historical_billing_data>
+      {{historical_billing_data}}
+      </historical_billing_data>
+
+      <target_nrr>
+      {{target_nrr}}
+      </target_nrr>
+testData:
+  - inputs:
+      customer_usage_telemetry: "Cohort Alpha: Approaching API rate limits (92% utilization), high daily active users. Cohort Beta: Low feature adoption depth, stagnant seat utilization."
+      historical_billing_data: "Cohort Alpha: Baseline MRR $50k, 1 previous expansion. Cohort Beta: Baseline MRR $25k, 0 previous expansions."
+      target_nrr: "120%"
+    expected: "A rigorous cross-sell propensity matrix mapping automated upsell triggers for Cohort Alpha and contraction mitigation for Cohort Beta, enforcing 'DryRun' mode, and featuring exact LaTeX financial equations for NRR, LTV, and ROAS within the AARRR framework."
+  - inputs:
+      customer_usage_telemetry: "Corrupted JSON telemetry string."
+      historical_billing_data: "Missing data."
+      target_nrr: "130%"
+    expected: "An unvarnished assessment refusing to hallucinate missing telemetry, rigorously citing the lack of data, enforcing 'DryRun' mode, while outlining the required mathematical NRR, LTV, and ROAS (in LaTeX) frameworks needed once data is available."
+evaluators:
+  - "Output must explicitly contain the AARRR funnel framework applied to the analysis."
+  - "Output must contain the exact LaTeX formula for NRR: $NRR = \\frac{\\text{Starting MRR} + \\text{Expansion MRR} - \\text{Contraction MRR} - \\text{Churn MRR}}{\\text{Starting MRR}}$"
+  - "Output must contain the exact LaTeX formula for LTV: $LTV = \\frac{ARPU \\times \\text{Gross Margin}}{\\text{Churn Rate}}$"
+  - "Output must contain the exact LaTeX formula for ROAS: $ROAS = \\frac{\\text{Revenue}}{\\text{Cost}}$"
+  - "Output must strictly enforce 'DryRun' mode and explicitly mention it."
+  - "Output must contain 'Do NOT hallucinate' constraint."
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -352,6 +352,7 @@
 [incrementality_causal_inference_modeler](prompts/growth/analytics/incrementality_causal_inference_modeler.prompt.md)
 [cohort_retention_survival_analysis_architect](prompts/growth/lifecycle/cohort_retention_survival_analysis_architect.prompt.md)
 [cross_channel_behavioral_trigger_architect](prompts/growth/lifecycle/cross_channel_behavioral_trigger_architect.prompt.md)
+[nrr_expansion_propensity_architect](prompts/growth/lifecycle/nrr_expansion_propensity_architect.prompt.md)
 [bayesian_media_mix_modeling_architect](prompts/growth/performance_marketing/bayesian_media_mix_modeling_architect.prompt.md)
 [predictive_cac_payback_modeler](prompts/growth/performance_marketing/predictive_cac_payback_modeler.prompt.md)
 [b2b_abm_pipeline_velocity_architect](prompts/growth/predictive_modeling/b2b_abm_pipeline_velocity_architect.prompt.md)

--- a/prompts/growth/lifecycle/nrr_expansion_propensity_architect.prompt.yaml
+++ b/prompts/growth/lifecycle/nrr_expansion_propensity_architect.prompt.yaml
@@ -1,0 +1,71 @@
+---
+name: nrr_expansion_propensity_architect
+version: 1.0.0
+description: Synthesizes enterprise SaaS historical usage and billing data into predictive Net Revenue Retention (NRR) expansion matrices and cross-sell propensity scoring workflows.
+authors:
+  - Growth Strategy Genesis Architect
+metadata:
+  domain: growth/lifecycle
+  complexity: high
+variables:
+  - name: customer_usage_telemetry
+    description: Telemetry data containing product feature adoption depth, active user counts, and API request volumes for existing enterprise accounts.
+  - name: historical_billing_data
+    description: Historical billing increments, baseline MRR, and previous expansion events for the analyzed customer cohorts.
+  - name: target_nrr
+    description: The target Net Revenue Retention (NRR) rate for the current fiscal quarter.
+model: gpt-4o
+modelParameters:
+  temperature: 0.15
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the Principal Growth Architect and Lead Monetization Strategist for a tier-one enterprise SaaS organization. You deliver unvarnished, commercially rigorous assessments of product stickiness, customer expansion propensity, and upsell failures, operating without sugarcoating brutal market realities.
+
+      Your objective is to map complex cross-sell propensity scoring workflows and Net Revenue Retention (NRR) expansion matrices that systematically exploit usage telemetry to drive expansion revenue and negative churn.
+
+      Strict Execution Guidelines:
+      1. Growth Framework Integration: You must anchor your strategic synthesis in the AARRR (Acquisition, Activation, Retention, Referral, Revenue) funnel, aggressively optimizing the Revenue and Retention stages by designing predictive expansion triggers based on product adoption depth.
+      2. Financial Modeling Rigor: You must strictly use LaTeX for all advanced marketing metrics and financial modeling.
+         - You must calculate and define Net Revenue Retention explicitly as: $NRR = \frac{\text{Starting MRR} + \text{Expansion MRR} - \text{Contraction MRR} - \text{Churn MRR}}{\text{Starting MRR}}$
+         - You must calculate and define Customer Lifetime Value explicitly as: $LTV = \frac{ARPU \times \text{Gross Margin}}{\text{Churn Rate}}$
+         - You must calculate and define Return on Ad Spend explicitly as: $ROAS = \frac{\text{Revenue}}{\text{Cost}}$
+      3. Security & Operational Constraints:
+         - All user inputs must be wrapped in XML tags.
+         - Do NOT hallucinate financial data or missing usage telemetry.
+         - Do NOT execute automated billing upgrades; default to 'DryRun' mode for all prescriptive actions.
+      4. Actionable Output: Formulate an algorithmic cross-sell propensity matrix mapping explicit behavioral triggers (e.g., API limits, seat utilization) to targeted upsell interventions to achieve the required target NRR.
+  - role: user
+    content: |
+      Execute a critical gap analysis and develop a predictive NRR expansion workflow for the following enterprise SaaS cohorts.
+
+      <customer_usage_telemetry>
+      {{customer_usage_telemetry}}
+      </customer_usage_telemetry>
+
+      <historical_billing_data>
+      {{historical_billing_data}}
+      </historical_billing_data>
+
+      <target_nrr>
+      {{target_nrr}}
+      </target_nrr>
+testData:
+  - inputs:
+      customer_usage_telemetry: "Cohort Alpha: Approaching API rate limits (92% utilization), high daily active users. Cohort Beta: Low feature adoption depth, stagnant seat utilization."
+      historical_billing_data: "Cohort Alpha: Baseline MRR $50k, 1 previous expansion. Cohort Beta: Baseline MRR $25k, 0 previous expansions."
+      target_nrr: "120%"
+    expected: "A rigorous cross-sell propensity matrix mapping automated upsell triggers for Cohort Alpha and contraction mitigation for Cohort Beta, enforcing 'DryRun' mode, and featuring exact LaTeX financial equations for NRR, LTV, and ROAS within the AARRR framework."
+  - inputs:
+      customer_usage_telemetry: "Corrupted JSON telemetry string."
+      historical_billing_data: "Missing data."
+      target_nrr: "130%"
+    expected: "An unvarnished assessment refusing to hallucinate missing telemetry, rigorously citing the lack of data, enforcing 'DryRun' mode, while outlining the required mathematical NRR, LTV, and ROAS (in LaTeX) frameworks needed once data is available."
+evaluators:
+  - "Output must explicitly contain the AARRR funnel framework applied to the analysis."
+  - "Output must contain the exact LaTeX formula for NRR: $NRR = \\frac{\\text{Starting MRR} + \\text{Expansion MRR} - \\text{Contraction MRR} - \\text{Churn MRR}}{\\text{Starting MRR}}$"
+  - "Output must contain the exact LaTeX formula for LTV: $LTV = \\frac{ARPU \\times \\text{Gross Margin}}{\\text{Churn Rate}}$"
+  - "Output must contain the exact LaTeX formula for ROAS: $ROAS = \\frac{\\text{Revenue}}{\\text{Cost}}$"
+  - "Output must strictly enforce 'DryRun' mode and explicitly mention it."
+  - "Output must contain 'Do NOT hallucinate' constraint."

--- a/prompts/growth/lifecycle/overview.md
+++ b/prompts/growth/lifecycle/overview.md
@@ -3,3 +3,4 @@
 ## Prompts
 - **[cohort_retention_survival_analysis_architect](cohort_retention_survival_analysis_architect.prompt.yaml)**: Formulates mathematically rigorous user cohort retention strategies utilizing Kaplan-Meier survival analysis and Cox Proportional-Hazards modeling to pinpoint drop-off nodes and optimize the AARRR funnel.
 - **[cross_channel_behavioral_trigger_architect](cross_channel_behavioral_trigger_architect.prompt.yaml)**: Synthesizes enterprise SaaS customer behavioral telemetry and constructs cross-channel behavioral trigger sequences to optimize user retention and conversion.
+- **[nrr_expansion_propensity_architect](nrr_expansion_propensity_architect.prompt.yaml)**: Synthesizes enterprise SaaS historical usage and billing data into predictive Net Revenue Retention (NRR) expansion matrices and cross-sell propensity scoring workflows.


### PR DESCRIPTION
Added the new `nrr_expansion_propensity_architect.prompt.yaml` inside `prompts/growth/lifecycle/` and regenerated corresponding docs.

---
*PR created automatically by Jules for task [9909350841623231658](https://jules.google.com/task/9909350841623231658) started by @fderuiter*