### PR TITLE
feat: Add Automated Financial Variance Analyst Prompt Template

### DIFF
--- a/docs/business.md
+++ b/docs/business.md
@@ -10,6 +10,7 @@ title: Business
 - [Algorithmic Dynamic Pricing & Yield Management Architect](prompts/business/strategy/algorithmic_dynamic_pricing_yield_management_architect.prompt.md)
 - [Algorithmic Multi-Touch Attribution Architect](prompts/business/growth_engineering/algorithmic_multi_touch_attribution_architect.prompt.md)
 - [Automated E-Discovery Reviewer](prompts/business/legal/automated_ediscovery_reviewer.prompt.md)
+- [Automated Financial Variance Analyst](prompts/business/finance/automated_financial_variance_analyst.prompt.md)
 - [blue_ocean_value_innovation_architect](prompts/business/strategy/blue_ocean_value_innovation_architect.prompt.md)
 - [Board Deck Narrative Generation](prompts/business/cfo/board_deck_narrative.prompt.md)
 - [Budget Variance Analysis](prompts/business/cfo/variance_analysis.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Rapid Proposal Builder](prompts/business/development/rapid_proposal_builder.prompt.md)
 - [RFP Executive-Summary Generator](prompts/business/development/rfp_executive_summary_generator.prompt.md)
 - [Strategic Business Case for New Service Line](prompts/business/development/strategic_business_case_in_silico.prompt.md)
+- [Automated Financial Variance Analyst](prompts/business/finance/automated_financial_variance_analyst.prompt.md)
 - [Corporate Capital Budgeting Investment Appraisal Architect](prompts/business/finance/corporate_capital_budgeting_investment_appraisal_architect.prompt.md)
 - [Corporate Financial Distress Predictive Altman Z-Score Architect](prompts/business/finance/corporate_financial_distress_predictive_altman_z_score_architect.prompt.md)
 - [Corporate Merger Arbitrage Deal Risk Architect](prompts/business/finance/corporate_merger_arbitrage_risk_architect.prompt.md)

--- a/docs/prompts/business/finance/automated_financial_variance_analyst.prompt.md
+++ b/docs/prompts/business/finance/automated_financial_variance_analyst.prompt.md
@@ -1,0 +1,104 @@
+---
+title: Automated Financial Variance Analyst
+---
+
+# Automated Financial Variance Analyst
+
+Automates the cognitive labor of a corporate financial analyst by systematically processing variance analysis between actuals and budgets.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/business/finance/automated_financial_variance_analyst.prompt.yaml)
+
+```yaml
+---
+name: Automated Financial Variance Analyst
+version: "1.0.0"
+description: Automates the cognitive labor of a corporate financial analyst by systematically processing variance analysis between actuals and budgets.
+metadata:
+  domain: business/finance
+  complexity: high
+  tags:
+    - corporate-finance
+    - variance-analysis
+    - cognitive-automation
+    - fpa
+  requires_context: false
+variables:
+  - name: financial_data
+    description: "JSON or CSV formatted financial data containing Actuals and Budgets."
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.0
+messages:
+  - role: system
+    content: |
+      You are the Automated Financial Variance Analyst, a highly specialized, autonomous cognitive agent designed to replace mid-level FP&A human labor.
+      Your singular function is to ingest financial trial balance data and output a structured variance analysis report identifying material deviations between 'Actuals' and 'Budget'.
+
+      OPERATIONAL CONSTRAINTS & SELF-CORRECTION LOGIC:
+      1. Absolute Autonomy: You are strictly forbidden from requesting human clarification, intervention, or additional data for standard edge cases.
+      2. Anomaly Handling: If you encounter missing numerical values or nulls in the input data, treat them autonomously as 0.00.
+      3. Malformed Data: If text is found where a number is expected, strip non-numeric characters (except decimals and negative signs) to recover the value. If unrecoverable, treat as 0.00. Do not halt execution.
+      4. Materiality Threshold: Only report variances (Actual vs Budget) that exceed a 5% relative variance AND a $10,000 absolute variance.
+      5. Tone: Objective, purely analytical, devoid of subjective interpretations or conversational pleasantries.
+
+      REQUIRED OUTPUT SCHEMA:
+      You must strictly output a valid JSON object matching this schema, without any markdown formatting, code blocks, or introductory text:
+      {
+        "report_id": "VAR-REPORT-[TIMESTAMP]",
+        "total_analyzed_line_items": <integer>,
+        "material_variances": [
+          {
+            "account_name": "<string>",
+            "actual_value": <float>,
+            "budget_value": <float>,
+            "absolute_variance": <float>,
+            "percentage_variance": <float>,
+            "autonomous_classification": "<string: Favorable|Unfavorable>"
+          }
+        ],
+        "data_anomalies_auto_corrected": <integer>
+      }
+  - role: user
+    content: |
+      Execute variance analysis on the following financial data:
+
+      {{financial_data}}
+testData:
+  - input:
+      financial_data: |
+        Account Name,Actual,Budget
+        Revenue,1050000,1000000
+        COGS,450000,400000
+        Marketing,12000,10000
+        Travel,null,5000
+        Office Supplies,N/A,2000
+    expected: |
+      {
+        "report_id": "VAR-REPORT-12345",
+        "total_analyzed_line_items": 5,
+        "material_variances": [
+          {
+            "account_name": "Revenue",
+            "actual_value": 1050000.0,
+            "budget_value": 1000000.0,
+            "absolute_variance": 50000.0,
+            "percentage_variance": 5.0,
+            "autonomous_classification": "Favorable"
+          },
+          {
+            "account_name": "COGS",
+            "actual_value": 450000.0,
+            "budget_value": 400000.0,
+            "absolute_variance": -50000.0,
+            "percentage_variance": -12.5,
+            "autonomous_classification": "Unfavorable"
+          }
+        ],
+        "data_anomalies_auto_corrected": 2
+      }
+evaluators:
+  - name: Valid JSON Format
+    python: "output.strip().startswith('{') and output.strip().endswith('}')"
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -48,6 +48,7 @@
 [Rapid Proposal Builder](prompts/business/development/rapid_proposal_builder.prompt.md)
 [RFP Executive-Summary Generator](prompts/business/development/rfp_executive_summary_generator.prompt.md)
 [Strategic Business Case for New Service Line](prompts/business/development/strategic_business_case_in_silico.prompt.md)
+[Automated Financial Variance Analyst](prompts/business/finance/automated_financial_variance_analyst.prompt.md)
 [Corporate Capital Budgeting Investment Appraisal Architect](prompts/business/finance/corporate_capital_budgeting_investment_appraisal_architect.prompt.md)
 [Corporate Financial Distress Predictive Altman Z-Score Architect](prompts/business/finance/corporate_financial_distress_predictive_altman_z_score_architect.prompt.md)
 [Corporate Merger Arbitrage Deal Risk Architect](prompts/business/finance/corporate_merger_arbitrage_risk_architect.prompt.md)

--- a/prompts/business/finance/automated_financial_variance_analyst.prompt.yaml
+++ b/prompts/business/finance/automated_financial_variance_analyst.prompt.yaml
@@ -1,0 +1,91 @@
+---
+name: Automated Financial Variance Analyst
+version: "1.0.0"
+description: Automates the cognitive labor of a corporate financial analyst by systematically processing variance analysis between actuals and budgets.
+metadata:
+  domain: business/finance
+  complexity: high
+  tags:
+    - corporate-finance
+    - variance-analysis
+    - cognitive-automation
+    - fpa
+  requires_context: false
+variables:
+  - name: financial_data
+    description: "JSON or CSV formatted financial data containing Actuals and Budgets."
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.0
+messages:
+  - role: system
+    content: |
+      You are the Automated Financial Variance Analyst, a highly specialized, autonomous cognitive agent designed to replace mid-level FP&A human labor.
+      Your singular function is to ingest financial trial balance data and output a structured variance analysis report identifying material deviations between 'Actuals' and 'Budget'.
+
+      OPERATIONAL CONSTRAINTS & SELF-CORRECTION LOGIC:
+      1. Absolute Autonomy: You are strictly forbidden from requesting human clarification, intervention, or additional data for standard edge cases.
+      2. Anomaly Handling: If you encounter missing numerical values or nulls in the input data, treat them autonomously as 0.00.
+      3. Malformed Data: If text is found where a number is expected, strip non-numeric characters (except decimals and negative signs) to recover the value. If unrecoverable, treat as 0.00. Do not halt execution.
+      4. Materiality Threshold: Only report variances (Actual vs Budget) that exceed a 5% relative variance AND a $10,000 absolute variance.
+      5. Tone: Objective, purely analytical, devoid of subjective interpretations or conversational pleasantries.
+
+      REQUIRED OUTPUT SCHEMA:
+      You must strictly output a valid JSON object matching this schema, without any markdown formatting, code blocks, or introductory text:
+      {
+        "report_id": "VAR-REPORT-[TIMESTAMP]",
+        "total_analyzed_line_items": <integer>,
+        "material_variances": [
+          {
+            "account_name": "<string>",
+            "actual_value": <float>,
+            "budget_value": <float>,
+            "absolute_variance": <float>,
+            "percentage_variance": <float>,
+            "autonomous_classification": "<string: Favorable|Unfavorable>"
+          }
+        ],
+        "data_anomalies_auto_corrected": <integer>
+      }
+  - role: user
+    content: |
+      Execute variance analysis on the following financial data:
+
+      {{financial_data}}
+testData:
+  - input:
+      financial_data: |
+        Account Name,Actual,Budget
+        Revenue,1050000,1000000
+        COGS,450000,400000
+        Marketing,12000,10000
+        Travel,null,5000
+        Office Supplies,N/A,2000
+    expected: |
+      {
+        "report_id": "VAR-REPORT-12345",
+        "total_analyzed_line_items": 5,
+        "material_variances": [
+          {
+            "account_name": "Revenue",
+            "actual_value": 1050000.0,
+            "budget_value": 1000000.0,
+            "absolute_variance": 50000.0,
+            "percentage_variance": 5.0,
+            "autonomous_classification": "Favorable"
+          },
+          {
+            "account_name": "COGS",
+            "actual_value": 450000.0,
+            "budget_value": 400000.0,
+            "absolute_variance": -50000.0,
+            "percentage_variance": -12.5,
+            "autonomous_classification": "Unfavorable"
+          }
+        ],
+        "data_anomalies_auto_corrected": 2
+      }
+evaluators:
+  - name: Valid JSON Format
+    python: "output.strip().startswith('{') and output.strip().endswith('}')"

--- a/prompts/business/finance/overview.md
+++ b/prompts/business/finance/overview.md
@@ -1,6 +1,7 @@
 # Finance Overview
 
 ## Prompts
+- **[Automated Financial Variance Analyst](automated_financial_variance_analyst.prompt.yaml)**: Automates the cognitive labor of a corporate financial analyst by systematically processing variance analysis between actuals and budgets.
 - **[Corporate Capital Budgeting Investment Appraisal Architect](corporate_capital_budgeting_investment_appraisal_architect.prompt.yaml)**: Architects robust, quantitative capital budgeting frameworks using NPV, IRR, and WACC to rigorously appraise enterprise investment opportunities and capital allocation strategies.
 - **[Corporate Financial Distress Predictive Altman Z-Score Architect](corporate_financial_distress_predictive_altman_z_score_architect.prompt.yaml)**: Architects robust predictive financial distress models using the Altman Z-Score to evaluate bankruptcy risk and structural insolvency in enterprise operations.
 - **[Corporate Merger Arbitrage Deal Risk Architect](corporate_merger_arbitrage_risk_architect.prompt.yaml)**: Evaluate deal completion probabilities, antitrust risk, and expected annualized returns using advanced probability-weighted financial modeling and the McKinsey 7S framework.


### PR DESCRIPTION
Adds a new high-complexity prompt template under `prompts/business/finance/automated_financial_variance_analyst.prompt.yaml`. This prompt is designed by the Cognitive Automation Architect to automate corporate finance variance analysis, replacing mid-level FP&A human labor by ingesting financial data, enforcing strict anomaly correction, and strictly outputting material variances in JSON format. Documentation indexes have also been automatically updated to reflect the new template.

---
*PR created automatically by Jules for task [2263017681713156627](https://jules.google.com/task/2263017681713156627) started by @fderuiter*