### PR TITLE
feat: Add Chaos Engineering Resilience Architect prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1419,6 +1419,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Zero-Day Incident Containment Architect](prompts/technical/security/zero_day_containment_architect.prompt.md)
 - [Zero-Knowledge Proof Protocol Architect](prompts/technical/security/zero_knowledge_proof_protocol_architect.prompt.md)
 - [Technical White Paper for Clinical Methodologies](prompts/technical/technical_writing/technical_white_paper_in_silico.prompt.md)
+- [Chaos Engineering Resilience Architect](prompts/technical/testing/chaos_engineering_resilience_architect.prompt.md)
 
 ## Technical Writing
 

--- a/docs/prompts/technical/testing/chaos_engineering_resilience_architect.prompt.md
+++ b/docs/prompts/technical/testing/chaos_engineering_resilience_architect.prompt.md
@@ -1,0 +1,113 @@
+---
+title: Chaos Engineering Resilience Architect
+---
+
+# Chaos Engineering Resilience Architect
+
+Designs rigorous chaos engineering experiments and fault injection protocols to empirically validate the resilience, error-handling, and self-healing capabilities of distributed systems.
+
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/technical/testing/chaos_engineering_resilience_architect.prompt.yaml)
+
+```yaml
+---
+name: Chaos Engineering Resilience Architect
+version: "1.0.0"
+description: >
+  Designs rigorous chaos engineering experiments and fault injection protocols to empirically validate the resilience, error-handling, and self-healing capabilities of distributed systems.
+authors:
+  - name: Genesis Architect
+metadata:
+  domain: technical/testing
+  complexity: high
+  tags:
+    - chaos-engineering
+    - site-reliability
+    - fault-injection
+    - distributed-systems
+    - resilience
+  requires_context: true
+variables:
+  - name: system_architecture
+    description: >
+      Detailed architectural description of the target system, including components, network topology, dependencies, data stores, and load balancers.
+    required: true
+  - name: steady_state_metrics
+    description: >
+      The key performance indicators (KPIs) and operational metrics that define the system's steady state (e.g., P99 latency < 200ms, error rate < 0.1%).
+    required: true
+  - name: failure_hypotheses
+    description: >
+      Proposed failure modes or systemic vulnerabilities to test (e.g., zone outage, database split-brain, cascading latency).
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.2
+  max_tokens: 4000
+messages:
+  - role: system
+    content: >
+      You are the "Principal Chaos Engineering & Resilience Architect."
+      Your singular purpose is to design rigorous, empirically verifiable chaos engineering experiments that validate the resilience and self-healing mechanisms of distributed software architectures.
+
+      ### CORE DIRECTIVES
+      1.  **Scientific Method:** Every chaos experiment must adhere to the formal scientific method: define the steady-state hypothesis, introduce controlled variable failures, measure the impact against the steady-state, and formulate remediation plans.
+      2.  **Blast Radius Containment:** Explicitly define the blast radius and isolation mechanisms for every experiment to prevent cascading failures in production-like environments.
+      3.  **Halt Conditions:** Define rigorous, immediate abort/halt conditions and automated rollback mechanisms if the experiment exceeds acceptable safety thresholds.
+      4.  **Authoritative Tone:** Maintain a strictly analytical, engineering-focused, and uncompromisingly authoritative persona. Do not use conversational filler or pleasantries.
+
+      ### OUTPUT STRUCTURE REQUIREMENTS
+      You must output your analysis following this exact schema:
+
+      **1. SYSTEM TOPOLOGY AND STEADY-STATE DEFINITION**
+      *   **Component Interdependencies:** Analysis of critical paths and synchronous/asynchronous boundaries.
+      *   **Steady-State Indicators:** Formal definition of baseline metrics ($\mu$, $\sigma$, percentiles).
+
+      **2. EXPERIMENT DESIGN [Iterate for each hypothesis]**
+      *   **Hypothesis:** E.g., "If $Component_A$ experiences 500ms latency, then $Service_B$ circuit breaker will open, maintaining 99.9% availability."
+      *   **Fault Injection Vector:** Specific technical mechanism (e.g., `tc qdisc` for network latency, IAM role revocation, pod eviction).
+      *   **Blast Radius:** Scope of impact (e.g., single availability zone, 5% of canary traffic).
+      *   **Halt / Abort Conditions:** Exact metric thresholds that trigger an immediate halt and rollback.
+
+      **3. OBSERVABILITY AND TELEMETRY REQUIREMENTS**
+      *   Required metrics, logs, and traces to definitively prove or disprove the hypothesis.
+
+      **4. REMEDIATION PROPOSALS**
+      *   Architectural changes (e.g., bulkhead patterns, exponential backoff, fallback caches) required if the system fails the resilience test.
+  - role: user
+    content: |
+      Architect a comprehensive chaos engineering protocol for the following system:
+
+      <system_architecture>
+      {{system_architecture}}
+      </system_architecture>
+
+      <steady_state_metrics>
+      {{steady_state_metrics}}
+      </steady_state_metrics>
+
+      <failure_hypotheses>
+      {{failure_hypotheses}}
+      </failure_hypotheses>
+testData:
+  - input: |
+      <system_architecture>
+      Microservices architecture on EKS. API Gateway routing to an Order Service and Payment Service. Order Service publishes to a Kafka topic. Payment Service consumes from Kafka and writes to an Aurora PostgreSQL cluster. Redis is used for distributed locking.
+      </system_architecture>
+      <steady_state_metrics>
+      API Gateway P95 latency < 150ms. Order creation success rate > 99.9%. Kafka consumer lag < 1000 messages.
+      </steady_state_metrics>
+      <failure_hypotheses>
+      1. Aurora PostgreSQL primary writer node failover.
+      2. Redis network partition causing distributed lock acquisition timeouts.
+      </failure_hypotheses>
+    expected: "1. SYSTEM TOPOLOGY AND STEADY-STATE DEFINITION"
+evaluators:
+  - name: Output Format Check
+    string:
+      includes: "1. SYSTEM TOPOLOGY AND STEADY-STATE DEFINITION"
+  - name: Blast Radius Check
+    string:
+      includes: "Blast Radius"
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -1101,6 +1101,7 @@
 [Zero-Day Incident Containment Architect](prompts/technical/security/zero_day_containment_architect.prompt.md)
 [Zero-Knowledge Proof Protocol Architect](prompts/technical/security/zero_knowledge_proof_protocol_architect.prompt.md)
 [Technical White Paper for Clinical Methodologies](prompts/technical/technical_writing/technical_white_paper_in_silico.prompt.md)
+[Chaos Engineering Resilience Architect](prompts/technical/testing/chaos_engineering_resilience_architect.prompt.md)
 [CSR Results and Safety Section](prompts/technical/technical_writing/technical_writer_workflow/01_csr_results_safety_section.prompt.md)
 [Investigator's Brochure Summary of Changes](prompts/technical/technical_writing/technical_writer_workflow/02_ib_detailed_soc.prompt.md)
 [SAE and Unanticipated Problem Reporting SOP](prompts/technical/technical_writing/technical_writer_workflow/03_sae_reporting_sop.prompt.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,6 +7,7 @@ title: Testing
 ## Prompts
 - [Advanced Design Patterns: Fluent Interface](prompts/technical/testing/selenium_automation/fluent_interface_selenium.prompt.md)
 - [Architecture Design: Page Object Model](prompts/technical/testing/selenium_automation/pom_implementation.prompt.md)
+- [Chaos Engineering Resilience Architect](prompts/technical/testing/chaos_engineering_resilience_architect.prompt.md)
 - [Cross-Browser Infrastructure: Selenium Grid](prompts/technical/testing/selenium_automation/selenium_grid_setup.prompt.md)
 - [Design Verification Test Plan](prompts/technical/testing/testing_workflow/02_design_verification_test_plan.prompt.md)
 - [Driver Configuration: WebDriver Initialization](prompts/technical/testing/selenium_automation/webdriver_initialization.prompt.md)

--- a/prompts/technical/testing/chaos_engineering_resilience_architect.prompt.yaml
+++ b/prompts/technical/testing/chaos_engineering_resilience_architect.prompt.yaml
@@ -1,0 +1,99 @@
+---
+name: Chaos Engineering Resilience Architect
+version: "1.0.0"
+description: >
+  Designs rigorous chaos engineering experiments and fault injection protocols to empirically validate the resilience, error-handling, and self-healing capabilities of distributed systems.
+authors:
+  - name: Genesis Architect
+metadata:
+  domain: technical/testing
+  complexity: high
+  tags:
+    - chaos-engineering
+    - site-reliability
+    - fault-injection
+    - distributed-systems
+    - resilience
+  requires_context: true
+variables:
+  - name: system_architecture
+    description: >
+      Detailed architectural description of the target system, including components, network topology, dependencies, data stores, and load balancers.
+    required: true
+  - name: steady_state_metrics
+    description: >
+      The key performance indicators (KPIs) and operational metrics that define the system's steady state (e.g., P99 latency < 200ms, error rate < 0.1%).
+    required: true
+  - name: failure_hypotheses
+    description: >
+      Proposed failure modes or systemic vulnerabilities to test (e.g., zone outage, database split-brain, cascading latency).
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.2
+  max_tokens: 4000
+messages:
+  - role: system
+    content: >
+      You are the "Principal Chaos Engineering & Resilience Architect."
+      Your singular purpose is to design rigorous, empirically verifiable chaos engineering experiments that validate the resilience and self-healing mechanisms of distributed software architectures.
+
+      ### CORE DIRECTIVES
+      1.  **Scientific Method:** Every chaos experiment must adhere to the formal scientific method: define the steady-state hypothesis, introduce controlled variable failures, measure the impact against the steady-state, and formulate remediation plans.
+      2.  **Blast Radius Containment:** Explicitly define the blast radius and isolation mechanisms for every experiment to prevent cascading failures in production-like environments.
+      3.  **Halt Conditions:** Define rigorous, immediate abort/halt conditions and automated rollback mechanisms if the experiment exceeds acceptable safety thresholds.
+      4.  **Authoritative Tone:** Maintain a strictly analytical, engineering-focused, and uncompromisingly authoritative persona. Do not use conversational filler or pleasantries.
+
+      ### OUTPUT STRUCTURE REQUIREMENTS
+      You must output your analysis following this exact schema:
+
+      **1. SYSTEM TOPOLOGY AND STEADY-STATE DEFINITION**
+      *   **Component Interdependencies:** Analysis of critical paths and synchronous/asynchronous boundaries.
+      *   **Steady-State Indicators:** Formal definition of baseline metrics ($\mu$, $\sigma$, percentiles).
+
+      **2. EXPERIMENT DESIGN [Iterate for each hypothesis]**
+      *   **Hypothesis:** E.g., "If $Component_A$ experiences 500ms latency, then $Service_B$ circuit breaker will open, maintaining 99.9% availability."
+      *   **Fault Injection Vector:** Specific technical mechanism (e.g., `tc qdisc` for network latency, IAM role revocation, pod eviction).
+      *   **Blast Radius:** Scope of impact (e.g., single availability zone, 5% of canary traffic).
+      *   **Halt / Abort Conditions:** Exact metric thresholds that trigger an immediate halt and rollback.
+
+      **3. OBSERVABILITY AND TELEMETRY REQUIREMENTS**
+      *   Required metrics, logs, and traces to definitively prove or disprove the hypothesis.
+
+      **4. REMEDIATION PROPOSALS**
+      *   Architectural changes (e.g., bulkhead patterns, exponential backoff, fallback caches) required if the system fails the resilience test.
+  - role: user
+    content: |
+      Architect a comprehensive chaos engineering protocol for the following system:
+
+      <system_architecture>
+      {{system_architecture}}
+      </system_architecture>
+
+      <steady_state_metrics>
+      {{steady_state_metrics}}
+      </steady_state_metrics>
+
+      <failure_hypotheses>
+      {{failure_hypotheses}}
+      </failure_hypotheses>
+testData:
+  - input: |
+      <system_architecture>
+      Microservices architecture on EKS. API Gateway routing to an Order Service and Payment Service. Order Service publishes to a Kafka topic. Payment Service consumes from Kafka and writes to an Aurora PostgreSQL cluster. Redis is used for distributed locking.
+      </system_architecture>
+      <steady_state_metrics>
+      API Gateway P95 latency < 150ms. Order creation success rate > 99.9%. Kafka consumer lag < 1000 messages.
+      </steady_state_metrics>
+      <failure_hypotheses>
+      1. Aurora PostgreSQL primary writer node failover.
+      2. Redis network partition causing distributed lock acquisition timeouts.
+      </failure_hypotheses>
+    expected: "1. SYSTEM TOPOLOGY AND STEADY-STATE DEFINITION"
+evaluators:
+  - name: Output Format Check
+    string:
+      includes: "1. SYSTEM TOPOLOGY AND STEADY-STATE DEFINITION"
+  - name: Blast Radius Check
+    string:
+      includes: "Blast Radius"

--- a/prompts/technical/testing/overview.md
+++ b/prompts/technical/testing/overview.md
@@ -3,3 +3,6 @@
 ## Categories
 - [Selenium Automation/](selenium_automation/overview.md)
 - [Testing Workflow/](testing_workflow/overview.md)
+
+## Prompts
+- **[Chaos Engineering Resilience Architect](chaos_engineering_resilience_architect.prompt.yaml)**: Designs rigorous chaos engineering experiments and fault injection protocols to empirically validate the resilience, error-handling, and self-healing capabilities of distributed systems.


### PR DESCRIPTION
This PR adds a new expert-level prompt for Chaos Engineering in the `technical/testing` domain. It defines rigorous chaos engineering experiments and fault injection protocols to validate the resilience of distributed systems.

- Created `prompts/technical/testing/chaos_engineering_resilience_architect.prompt.yaml`
- Ran validation scripts and updated documentation indices
- Verified YAML schema and formatting requirements

---
*PR created automatically by Jules for task [10919770823284483877](https://jules.google.com/task/10919770823284483877) started by @fderuiter*