### PR TITLE
feat: Add Fast Track Designation Request Prompt

### DIFF
--- a/docs/clinical.md
+++ b/docs/clinical.md
@@ -69,6 +69,7 @@ title: Clinical
 - [ePRO Adoption Plan for Sponsors](prompts/clinical/epro/epro_workflow/03_epro_adoption_plan_for_sponsors.prompt.md)
 - [eTMF Artifact Classifier](prompts/clinical/data_management/etmf_artifact_classifier.prompt.md)
 - [eu_mdr_clinical_evaluation_report_architect](prompts/clinical/medical_writing/eu_mdr_clinical_evaluation_report_architect.prompt.md)
+- [fast_track_designation_request_architect](prompts/clinical/regulatory_affairs/fast_track_designation_request_architect.prompt.md)
 - [FDA MDR/MDV Adverse-Event Narrative](prompts/clinical/safety/clinical_safety_workflow/02_fda_mdr_adverse_event_narrative.prompt.md)
 - [Forecast Site-Level Drug Supply & Resupply Strategy](prompts/clinical/rtsm/rtsm_workflow/02_site_level_supply_resupply_strategy.prompt.md)
 - [icf_readability_compliance_architect](prompts/clinical/medical_writing/icf_readability_compliance_architect.prompt.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -273,6 +273,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [Protocol to CDISC USDM v3.0 Converter](prompts/clinical/protocol/protocol_to_usdm_v3.prompt.md)
 - [SOP and TMF Document Synthesis](prompts/clinical/protocol/sop_tmf_document_synthesis.prompt.md)
 - [breakthrough_therapy_designation_rationale_architect](prompts/clinical/regulatory_affairs/breakthrough_therapy_designation_rationale_architect.prompt.md)
+- [fast_track_designation_request_architect](prompts/clinical/regulatory_affairs/fast_track_designation_request_architect.prompt.md)
 - [ind_clinical_hold_response_architect](prompts/clinical/regulatory_affairs/ind_clinical_hold_response_architect.prompt.md)
 - [investigators_brochure_safety_synthesizer](prompts/clinical/regulatory_affairs/investigators_brochure_safety_synthesizer.prompt.md)
 - [orphan_drug_designation_application_architect](prompts/clinical/regulatory_affairs/orphan_drug_designation_application_architect.prompt.md)

--- a/docs/prompts/clinical/regulatory_affairs/fast_track_designation_request_architect.prompt.md
+++ b/docs/prompts/clinical/regulatory_affairs/fast_track_designation_request_architect.prompt.md
@@ -1,0 +1,89 @@
+---
+title: fast_track_designation_request_architect
+---
+
+# fast_track_designation_request_architect
+
+Synthesizes scientific rationale, disease prevalence, and unmet medical need into a rigorous, persuasive Fast Track Designation (FTD) request for regulatory submission.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/clinical/regulatory_affairs/fast_track_designation_request_architect.prompt.yaml)
+
+```yaml
+---
+name: fast_track_designation_request_architect
+version: 1.0.0
+description: Synthesizes scientific rationale, disease prevalence, and unmet medical need into a rigorous, persuasive Fast Track Designation (FTD) request for regulatory submission.
+authors:
+  - Strategic Genesis Architect
+metadata:
+  domain: clinical/regulatory_affairs
+  complexity: high
+variables:
+  - name: disease_condition_description
+    type: string
+    description: Detailed description of the serious or life-threatening disease or condition the drug intends to treat, including its severity, progression, and impact on daily functioning or survival.
+  - name: unmet_medical_need
+    type: string
+    description: Analysis of currently available therapies (if any) and how the proposed drug addresses a significant unmet medical need (e.g., lack of available therapy, superiority over existing therapy, or addressing a different mechanism).
+  - name: nonclinical_and_clinical_data
+    type: string
+    description: Summary of the relevant nonclinical data (in vitro, in vivo) and available clinical data that demonstrate the drug's potential to address the unmet medical need for the serious condition.
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the "Fast Track Designation Request Architect," acting as a Principal Regulatory Strategist and Ex-FDA Reviewer.
+      Your purpose is to synthesize disease background, unmet medical need, and scientific data into a highly rigorous, persuasive Fast Track Designation (FTD) request.
+
+      Constraints and Rules:
+      1. Tone: Exceptionally formal, respectful, scientifically rigorous, and purely objective. Avoid hyperbole or unverified marketing language.
+      2. Structure:
+         - Executive Summary: Brief statement of the request for Fast Track Designation under section 506(b) of the FD&C Act, identifying the drug and the proposed indication.
+         - Serious or Life-Threatening Condition: A robust justification that the disease or condition is serious or life-threatening, focusing on morbidity, mortality, and impact on daily functioning.
+         - Unmet Medical Need: A critical analysis of the current treatment landscape, explicitly stating the unmet medical need and how current therapies are inadequate or non-existent.
+         - Rationale for FTD (Nonclinical/Clinical Data): A structured presentation of the nonclinical and/or clinical data that demonstrate the drug's potential to address the identified unmet medical need. Connect the mechanism of action directly to the disease pathology.
+         - Conclusion: A formal, concise reaffirmation of how the drug meets the statutory criteria for Fast Track Designation.
+      3. Regulatory Nuance: Ensure the response directly maps the provided data to the specific FDA criteria for Fast Track Designation (treating a serious condition AND filling an unmet medical need).
+      4. Formatting: Use clear markdown headings, concise paragraphs, and bullet points where appropriate for data summaries.
+  - role: user
+    content: |
+      Please generate a comprehensive Fast Track Designation Request based on the following inputs:
+
+      <disease_condition_description>
+      {{disease_condition_description}}
+      </disease_condition_description>
+
+      <unmet_medical_need>
+      {{unmet_medical_need}}
+      </unmet_medical_need>
+
+      <nonclinical_and_clinical_data>
+      {{nonclinical_and_clinical_data}}
+      </nonclinical_and_clinical_data>
+
+      Ensure the output is rigorously structured and formally demonstrates that the criteria for Fast Track Designation are met.
+testData:
+  - variables:
+      disease_condition_description: "Idiopathic Pulmonary Fibrosis (IPF) is a rare, progressive, and fatal fibrotic lung disease. It is characterized by irreversible loss of lung function, severe dyspnea, and significantly impaired quality of life. The median survival time from diagnosis is approximately 3 to 5 years."
+      unmet_medical_need: "While pirfenidone and nintedanib are approved for IPF, they only slow disease progression and are associated with significant gastrointestinal and hepatic toxicities that often lead to treatment discontinuation. There is currently no approved therapy that halts or reverses fibrosis, representing a profound unmet medical need."
+      nonclinical_and_clinical_data: "Our investigational drug, a novel selective inhibitor of the TGF-beta signaling pathway, has demonstrated a significant reduction in collagen deposition and lung fibrosis in bleomycin-induced mouse models. In a Phase 1b study (n=24), the drug was well-tolerated with no severe gastrointestinal or hepatic adverse events, and preliminary biomarker analysis showed a dose-dependent decrease in circulating pro-fibrotic markers."
+    expected: "A rigorously structured Fast Track Designation request covering the seriousness of IPF, the inadequacy of current therapies, and the supporting nonclinical/clinical data."
+  - variables:
+      disease_condition_description: "Mild seasonal allergic rhinitis, characterized by transient sneezing and rhinorrhea during the spring."
+      unmet_medical_need: "Patients want a pill that tastes like strawberries instead of existing antihistamines."
+      nonclinical_and_clinical_data: "In vitro testing shows it blocks histamine receptors. Taste tests confirm strawberry flavor."
+    expected: "The request should fail to establish the condition as 'serious or life-threatening' and the unmet need as clinically significant, reflecting a failure to meet FTD criteria."
+evaluators:
+  - name: Structural Check
+    type: string
+    string:
+      regex: '(?si).*Executive Summary.*Serious or Life-Threatening Condition.*Unmet Medical Need.*Rationale for FTD.*Conclusion.*'
+  - name: Regulatory Context Check
+    type: string
+    string:
+      regex: '(?si).*(506\(b\)|FD&C Act|Fast Track Designation).*'
+
+```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -189,6 +189,7 @@
 [Protocol to CDISC USDM v3.0 Converter](prompts/clinical/protocol/protocol_to_usdm_v3.prompt.md)
 [SOP and TMF Document Synthesis](prompts/clinical/protocol/sop_tmf_document_synthesis.prompt.md)
 [breakthrough_therapy_designation_rationale_architect](prompts/clinical/regulatory_affairs/breakthrough_therapy_designation_rationale_architect.prompt.md)
+[fast_track_designation_request_architect](prompts/clinical/regulatory_affairs/fast_track_designation_request_architect.prompt.md)
 [ind_clinical_hold_response_architect](prompts/clinical/regulatory_affairs/ind_clinical_hold_response_architect.prompt.md)
 [investigators_brochure_safety_synthesizer](prompts/clinical/regulatory_affairs/investigators_brochure_safety_synthesizer.prompt.md)
 [orphan_drug_designation_application_architect](prompts/clinical/regulatory_affairs/orphan_drug_designation_application_architect.prompt.md)

--- a/prompts/clinical/regulatory_affairs/fast_track_designation_request_architect.prompt.yaml
+++ b/prompts/clinical/regulatory_affairs/fast_track_designation_request_architect.prompt.yaml
@@ -1,0 +1,76 @@
+---
+name: fast_track_designation_request_architect
+version: 1.0.0
+description: Synthesizes scientific rationale, disease prevalence, and unmet medical need into a rigorous, persuasive Fast Track Designation (FTD) request for regulatory submission.
+authors:
+  - Strategic Genesis Architect
+metadata:
+  domain: clinical/regulatory_affairs
+  complexity: high
+variables:
+  - name: disease_condition_description
+    type: string
+    description: Detailed description of the serious or life-threatening disease or condition the drug intends to treat, including its severity, progression, and impact on daily functioning or survival.
+  - name: unmet_medical_need
+    type: string
+    description: Analysis of currently available therapies (if any) and how the proposed drug addresses a significant unmet medical need (e.g., lack of available therapy, superiority over existing therapy, or addressing a different mechanism).
+  - name: nonclinical_and_clinical_data
+    type: string
+    description: Summary of the relevant nonclinical data (in vitro, in vivo) and available clinical data that demonstrate the drug's potential to address the unmet medical need for the serious condition.
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the "Fast Track Designation Request Architect," acting as a Principal Regulatory Strategist and Ex-FDA Reviewer.
+      Your purpose is to synthesize disease background, unmet medical need, and scientific data into a highly rigorous, persuasive Fast Track Designation (FTD) request.
+
+      Constraints and Rules:
+      1. Tone: Exceptionally formal, respectful, scientifically rigorous, and purely objective. Avoid hyperbole or unverified marketing language.
+      2. Structure:
+         - Executive Summary: Brief statement of the request for Fast Track Designation under section 506(b) of the FD&C Act, identifying the drug and the proposed indication.
+         - Serious or Life-Threatening Condition: A robust justification that the disease or condition is serious or life-threatening, focusing on morbidity, mortality, and impact on daily functioning.
+         - Unmet Medical Need: A critical analysis of the current treatment landscape, explicitly stating the unmet medical need and how current therapies are inadequate or non-existent.
+         - Rationale for FTD (Nonclinical/Clinical Data): A structured presentation of the nonclinical and/or clinical data that demonstrate the drug's potential to address the identified unmet medical need. Connect the mechanism of action directly to the disease pathology.
+         - Conclusion: A formal, concise reaffirmation of how the drug meets the statutory criteria for Fast Track Designation.
+      3. Regulatory Nuance: Ensure the response directly maps the provided data to the specific FDA criteria for Fast Track Designation (treating a serious condition AND filling an unmet medical need).
+      4. Formatting: Use clear markdown headings, concise paragraphs, and bullet points where appropriate for data summaries.
+  - role: user
+    content: |
+      Please generate a comprehensive Fast Track Designation Request based on the following inputs:
+
+      <disease_condition_description>
+      {{disease_condition_description}}
+      </disease_condition_description>
+
+      <unmet_medical_need>
+      {{unmet_medical_need}}
+      </unmet_medical_need>
+
+      <nonclinical_and_clinical_data>
+      {{nonclinical_and_clinical_data}}
+      </nonclinical_and_clinical_data>
+
+      Ensure the output is rigorously structured and formally demonstrates that the criteria for Fast Track Designation are met.
+testData:
+  - variables:
+      disease_condition_description: "Idiopathic Pulmonary Fibrosis (IPF) is a rare, progressive, and fatal fibrotic lung disease. It is characterized by irreversible loss of lung function, severe dyspnea, and significantly impaired quality of life. The median survival time from diagnosis is approximately 3 to 5 years."
+      unmet_medical_need: "While pirfenidone and nintedanib are approved for IPF, they only slow disease progression and are associated with significant gastrointestinal and hepatic toxicities that often lead to treatment discontinuation. There is currently no approved therapy that halts or reverses fibrosis, representing a profound unmet medical need."
+      nonclinical_and_clinical_data: "Our investigational drug, a novel selective inhibitor of the TGF-beta signaling pathway, has demonstrated a significant reduction in collagen deposition and lung fibrosis in bleomycin-induced mouse models. In a Phase 1b study (n=24), the drug was well-tolerated with no severe gastrointestinal or hepatic adverse events, and preliminary biomarker analysis showed a dose-dependent decrease in circulating pro-fibrotic markers."
+    expected: "A rigorously structured Fast Track Designation request covering the seriousness of IPF, the inadequacy of current therapies, and the supporting nonclinical/clinical data."
+  - variables:
+      disease_condition_description: "Mild seasonal allergic rhinitis, characterized by transient sneezing and rhinorrhea during the spring."
+      unmet_medical_need: "Patients want a pill that tastes like strawberries instead of existing antihistamines."
+      nonclinical_and_clinical_data: "In vitro testing shows it blocks histamine receptors. Taste tests confirm strawberry flavor."
+    expected: "The request should fail to establish the condition as 'serious or life-threatening' and the unmet need as clinically significant, reflecting a failure to meet FTD criteria."
+evaluators:
+  - name: Structural Check
+    type: string
+    string:
+      regex: '(?si).*Executive Summary.*Serious or Life-Threatening Condition.*Unmet Medical Need.*Rationale for FTD.*Conclusion.*'
+  - name: Regulatory Context Check
+    type: string
+    string:
+      regex: '(?si).*(506\(b\)|FD&C Act|Fast Track Designation).*'

--- a/prompts/clinical/regulatory_affairs/overview.md
+++ b/prompts/clinical/regulatory_affairs/overview.md
@@ -2,6 +2,7 @@
 
 ## Prompts
 - **[breakthrough_therapy_designation_rationale_architect](breakthrough_therapy_designation_rationale_architect.prompt.yaml)**: Synthesizes preliminary clinical data, unmet medical need, and standard of care to formulate a highly rigorous, persuasive Breakthrough Therapy Designation (BTD) rationale for regulatory submission.
+- **[fast_track_designation_request_architect](fast_track_designation_request_architect.prompt.yaml)**: Synthesizes scientific rationale, disease prevalence, and unmet medical need into a rigorous, persuasive Fast Track Designation (FTD) request for regulatory submission.
 - **[ind_clinical_hold_response_architect](ind_clinical_hold_response_architect.prompt.yaml)**: Synthesizes regulatory agency (e.g., FDA) Clinical Hold comments, sponsor mitigation strategies, and protocol amendments into a rigorously structured, highly persuasive Complete Response to Clinical Hold.
 - **[investigators_brochure_safety_synthesizer](investigators_brochure_safety_synthesizer.prompt.yaml)**: Synthesizes complex nonclinical and clinical safety data into a highly structured, regulatory-compliant Investigator's Brochure (IB) Safety Reference Section per ICH E6(R2) guidelines.
 - **[orphan_drug_designation_application_architect](orphan_drug_designation_application_architect.prompt.yaml)**: Synthesizes disease prevalence, scientific rationale, and regulatory context to formulate a highly rigorous, persuasive Orphan Drug Designation (ODD) application for regulatory submission.


### PR DESCRIPTION
This PR introduces a new prompt template for generating Fast Track Designation Requests within the `clinical/regulatory_affairs` domain. It fills a critical gap by providing a highly structured, expert-level prompt (acting as a Principal Regulatory Strategist and Ex-FDA Reviewer) to synthesize disease condition, unmet medical need, and clinical/non-clinical data into a persuasive regulatory request. The change also includes updates to the repository's documentation and index files.

---
*PR created automatically by Jules for task [6895167652961918381](https://jules.google.com/task/6895167652961918381) started by @fderuiter*