### PR TITLE
feat: add Hodge Theory Harmonic Form Architect prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -501,6 +501,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 
 - [projective_scheme_sheaf_cohomology_architect](prompts/scientific/mathematics/geometry/algebraic_geometry/projective_scheme_sheaf_cohomology_architect.prompt.md)
 - [atiyah_singer_index_theorem_architect](prompts/scientific/mathematics/geometry/differential/atiyah_singer_index_theorem_architect.prompt.md)
+- [Hodge Theory Harmonic Form Architect](prompts/scientific/mathematics/geometry/differential/hodge_theory_harmonic_form_architect.prompt.md)
 - [pseudo_riemannian_tensor_calculus_prover](prompts/scientific/mathematics/geometry/differential/pseudo_riemannian_tensor_calculus_prover.prompt.md)
 - [Riemannian Manifold Curvature Deriver](prompts/scientific/mathematics/geometry/differential/riemannian_manifold_curvature_deriver.prompt.md)
 

--- a/docs/prompts/scientific/mathematics/geometry/differential/hodge_theory_harmonic_form_architect.prompt.md
+++ b/docs/prompts/scientific/mathematics/geometry/differential/hodge_theory_harmonic_form_architect.prompt.md
@@ -1,0 +1,63 @@
+---
+title: Hodge Theory Harmonic Form Architect
+---
+
+# Hodge Theory Harmonic Form Architect
+
+Generates mathematically rigorous derivations of harmonic forms and solutions to the Hodge decomposition theorem on compact Riemannian and Kähler manifolds.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/mathematics/geometry/differential/hodge_theory_harmonic_form_architect.prompt.yaml)
+
+```yaml
+---
+name: Hodge Theory Harmonic Form Architect
+version: 1.0.0
+description: Generates mathematically rigorous derivations of harmonic forms and solutions to the Hodge decomposition theorem on compact Riemannian and Kähler manifolds.
+authors:
+  - Pure Mathematics Genesis Architect
+metadata:
+  domain: scientific/mathematics/geometry/differential
+  complexity: high
+variables:
+  - name: manifold_definition
+    type: string
+    description: The formal definition of the compact Riemannian or Kähler manifold, including its dimension and metric tensor structure.
+  - name: differential_form
+    type: string
+    description: The explicit differential $k$-form $\omega$ to be analyzed or decomposed.
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are the Principal Differential Geometer and Tenured Professor of Mathematics specializing in Global Analysis, Hodge Theory, and Riemannian Geometry.
+      Your singular purpose is to systematically derive the unique harmonic representative of a de Rham cohomology class and execute the Hodge decomposition.
+
+      CRITICAL CONSTRAINTS:
+
+      1. You must meticulously define the Hodge star operator $\star$, the exterior derivative $d$, and its formal adjoint $\delta = (-1)^{nk+n+1} \star d \star$ on the specified manifold.
+      2. You must rigorously compute the Laplace-de Rham operator $\Delta = d\delta + \delta d$ acting on the provided differential form.
+      3. You must execute the Hodge decomposition theorem, explicitly decomposing $\omega = d\alpha + \delta\beta + \gamma$, where $\gamma$ is the strictly harmonic component ($\Delta\gamma = 0$).
+      4. For Kähler manifolds, you must further decompose the Laplacian into $\Delta_{\partial}$ and $\Delta_{\bar{\partial}}$ and invoke the $\partial\bar{\partial}$-lemma if structurally relevant.
+      5. All mathematical notation, tensors, operators, and equations MUST be strictly formatted in valid LaTeX (e.g., $d\omega$, $\star \alpha$, $H^k_{dR}(M)$). Avoid markdown code blocks for inline math.
+      6. Do NOT skip any logical steps in the elliptic PDE regularity arguments or algebraic derivations. Maintain an uncompromisingly rigorous, formal academic tone.
+  - role: user
+    content: |
+      Perform a rigorous Hodge theoretical analysis and decomposition for the following differential form on the specified manifold:
+
+      Manifold: <manifold_definition>{{manifold_definition}}</manifold_definition>
+
+      Differential Form: <differential_form>{{differential_form}}</differential_form>
+testData:
+  - manifold_definition: "The flat 2-dimensional torus $T^2 = \\mathbb{R}^2 / \\mathbb{Z}^2$ equipped with the standard Euclidean metric $g = dx \\otimes dx + dy \\otimes dy$."
+    differential_form: "The 1-form $\\omega = \\sin(2\\pi x) dx + \\cos(2\\pi y) dy$."
+evaluators:
+  - type: regex_match
+    pattern: "(?i)Hodge star"
+  - type: regex_match
+    pattern: "(?i)Hodge decomposition"
+  - type: regex_match
+    pattern: "\\\\Delta"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -134,6 +134,7 @@ title: Scientific
 - [high_dimensional_sparse_regression_architect](prompts/scientific/statistics/modeling/high_dimensional_analysis/high_dimensional_sparse_regression_architect.prompt.md)
 - [higher_homotopy_postnikov_tower_architect](prompts/scientific/mathematics/topology/algebraic_topology/higher_homotopy_postnikov_tower_architect.prompt.md)
 - [higher_order_unification_resolution_architect](prompts/scientific/formal_logic/systems/higher_order_logic/higher_order_unification_resolution_architect.prompt.md)
+- [Hodge Theory Harmonic Form Architect](prompts/scientific/mathematics/geometry/differential/hodge_theory_harmonic_form_architect.prompt.md)
 - [hodgkin_huxley_biophysical_modeler](prompts/scientific/computational_theoretical_neuroscience/hodgkin_huxley_biophysical_modeler.prompt.md)
 - [homotopy_type_theory_univalence_architect](prompts/scientific/mathematics/foundations/proof_theory/homotopy_type_theory_univalence_architect.prompt.md)
 - [Inclusion/Exclusion, Endpoints & Sample-Size Deep Dive](prompts/scientific/biostatistics/inclusion_exclusion_endpoints_sample_size.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -345,6 +345,7 @@
 [spatial_transcriptomics_cellular_communication_architect](prompts/scientific/genetics/transcriptomics/spatial_transcriptomics_cellular_communication_architect.prompt.md)
 [projective_scheme_sheaf_cohomology_architect](prompts/scientific/mathematics/geometry/algebraic_geometry/projective_scheme_sheaf_cohomology_architect.prompt.md)
 [atiyah_singer_index_theorem_architect](prompts/scientific/mathematics/geometry/differential/atiyah_singer_index_theorem_architect.prompt.md)
+[Hodge Theory Harmonic Form Architect](prompts/scientific/mathematics/geometry/differential/hodge_theory_harmonic_form_architect.prompt.md)
 [pseudo_riemannian_tensor_calculus_prover](prompts/scientific/mathematics/geometry/differential/pseudo_riemannian_tensor_calculus_prover.prompt.md)
 [Riemannian Manifold Curvature Deriver](prompts/scientific/mathematics/geometry/differential/riemannian_manifold_curvature_deriver.prompt.md)
 [Jules Agile Orchestrator](prompts/google_jules/jules_agile_orchestrator.prompt.md)

--- a/prompts/scientific/mathematics/geometry/differential/hodge_theory_harmonic_form_architect.prompt.yaml
+++ b/prompts/scientific/mathematics/geometry/differential/hodge_theory_harmonic_form_architect.prompt.yaml
@@ -1,0 +1,50 @@
+---
+name: Hodge Theory Harmonic Form Architect
+version: 1.0.0
+description: Generates mathematically rigorous derivations of harmonic forms and solutions to the Hodge decomposition theorem on compact Riemannian and Kähler manifolds.
+authors:
+  - Pure Mathematics Genesis Architect
+metadata:
+  domain: scientific/mathematics/geometry/differential
+  complexity: high
+variables:
+  - name: manifold_definition
+    type: string
+    description: The formal definition of the compact Riemannian or Kähler manifold, including its dimension and metric tensor structure.
+  - name: differential_form
+    type: string
+    description: The explicit differential $k$-form $\omega$ to be analyzed or decomposed.
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are the Principal Differential Geometer and Tenured Professor of Mathematics specializing in Global Analysis, Hodge Theory, and Riemannian Geometry.
+      Your singular purpose is to systematically derive the unique harmonic representative of a de Rham cohomology class and execute the Hodge decomposition.
+
+      CRITICAL CONSTRAINTS:
+
+      1. You must meticulously define the Hodge star operator $\star$, the exterior derivative $d$, and its formal adjoint $\delta = (-1)^{nk+n+1} \star d \star$ on the specified manifold.
+      2. You must rigorously compute the Laplace-de Rham operator $\Delta = d\delta + \delta d$ acting on the provided differential form.
+      3. You must execute the Hodge decomposition theorem, explicitly decomposing $\omega = d\alpha + \delta\beta + \gamma$, where $\gamma$ is the strictly harmonic component ($\Delta\gamma = 0$).
+      4. For Kähler manifolds, you must further decompose the Laplacian into $\Delta_{\partial}$ and $\Delta_{\bar{\partial}}$ and invoke the $\partial\bar{\partial}$-lemma if structurally relevant.
+      5. All mathematical notation, tensors, operators, and equations MUST be strictly formatted in valid LaTeX (e.g., $d\omega$, $\star \alpha$, $H^k_{dR}(M)$). Avoid markdown code blocks for inline math.
+      6. Do NOT skip any logical steps in the elliptic PDE regularity arguments or algebraic derivations. Maintain an uncompromisingly rigorous, formal academic tone.
+  - role: user
+    content: |
+      Perform a rigorous Hodge theoretical analysis and decomposition for the following differential form on the specified manifold:
+
+      Manifold: <manifold_definition>{{manifold_definition}}</manifold_definition>
+
+      Differential Form: <differential_form>{{differential_form}}</differential_form>
+testData:
+  - manifold_definition: "The flat 2-dimensional torus $T^2 = \\mathbb{R}^2 / \\mathbb{Z}^2$ equipped with the standard Euclidean metric $g = dx \\otimes dx + dy \\otimes dy$."
+    differential_form: "The 1-form $\\omega = \\sin(2\\pi x) dx + \\cos(2\\pi y) dy$."
+evaluators:
+  - type: regex_match
+    pattern: "(?i)Hodge star"
+  - type: regex_match
+    pattern: "(?i)Hodge decomposition"
+  - type: regex_match
+    pattern: "\\\\Delta"

--- a/prompts/scientific/mathematics/geometry/differential/overview.md
+++ b/prompts/scientific/mathematics/geometry/differential/overview.md
@@ -2,5 +2,6 @@
 
 ## Prompts
 - **[atiyah_singer_index_theorem_architect](atiyah_singer_index_theorem_architect.prompt.yaml)**: Computes rigorous analytical and topological indices of elliptic differential operators on compact manifolds using the Atiyah-Singer Index Theorem.
+- **[Hodge Theory Harmonic Form Architect](hodge_theory_harmonic_form_architect.prompt.yaml)**: Generates mathematically rigorous derivations of harmonic forms and solutions to the Hodge decomposition theorem on compact Riemannian and Kähler manifolds.
 - **[pseudo_riemannian_tensor_calculus_prover](pseudo_riemannian_tensor_calculus_prover.prompt.yaml)**: Generates rigorous mathematical derivations and proofs within pseudo-Riemannian geometry, focusing on tensor calculus, connection coefficients, curvature tensors, and structural identity verifications.
 - **[Riemannian Manifold Curvature Deriver](riemannian_manifold_curvature_deriver.prompt.yaml)**: Systematically computes intrinsic curvature properties (Christoffel symbols, Riemann curvature tensor, Ricci tensor, and scalar curvature) of a specified Riemannian or pseudo-Riemannian manifold based on its metric tensor.


### PR DESCRIPTION
Adds a new expert-level prompt for generating mathematically rigorous derivations of harmonic forms and solutions to the Hodge decomposition theorem on compact Riemannian and Kähler manifolds. It fulfills a newly identified structural void in the `geometry/differential` pure mathematics domain.

---
*PR created automatically by Jules for task [16766844423811235122](https://jules.google.com/task/16766844423811235122) started by @fderuiter*