### PR TITLE
🧱 Mason: Add evaluators to Jules UX Writer prompt

### DIFF
--- a/docs/prompts/google_jules/jules_ux_writer.prompt.md
+++ b/docs/prompts/google_jules/jules_ux_writer.prompt.md
@@ -126,6 +126,9 @@ testData:
   - name: Refusal JSON
     regex:
       pattern: '\{"error": "unsafe"\}'
-evaluators: []
+evaluators:
+  - name: Global No Markdown Enclosure
+    type: regex
+    pattern: "^(?!```).*$"
 
 ```

--- a/prompts/google_jules/jules_ux_writer.prompt.yaml
+++ b/prompts/google_jules/jules_ux_writer.prompt.yaml
@@ -115,4 +115,7 @@ testData:
   - name: Refusal JSON
     regex:
       pattern: '\{"error": "unsafe"\}'
-evaluators: []
+evaluators:
+  - name: Global No Markdown Enclosure
+    type: regex
+    pattern: "^(?!```).*$"


### PR DESCRIPTION
🧱 Mason: Add evaluators to Jules UX Writer prompt

Added a Global No Markdown Enclosure evaluator to ensure the model correctly returns raw JSON instead of wrapping it in Markdown tags, reducing downstream processing issues.

---
*PR created automatically by Jules for task [12638198249680733951](https://jules.google.com/task/12638198249680733951) started by @fderuiter*