### PR TITLE
feat(formal_logic): add constructive intuitionistic natural deduction prover

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1256,6 +1256,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 
 - [ambiguous_natural_language_fol_formalizer](prompts/scientific/formal_logic/systems/first_order_logic/ambiguous_natural_language_fol_formalizer.prompt.md)
 - [higher_order_unification_resolution_architect](prompts/scientific/formal_logic/systems/higher_order_logic/higher_order_unification_resolution_architect.prompt.md)
+- [constructive_intuitionistic_natural_deduction_prover](prompts/scientific/formal_logic/systems/intuitionistic_logic/constructive_intuitionistic_natural_deduction_prover.prompt.md)
 - [Adaptive Control Loop Tuning Architect](prompts/scientific/mathematics/systems/control_theory/adaptive_control_loop_tuning_architect.prompt.md)
 - [Stochastic Model Predictive Control (MPC) Architect](prompts/scientific/mathematics/systems/control_theory/stochastic_mpc_architect.prompt.md)
 

--- a/docs/prompts/scientific/formal_logic/systems/intuitionistic_logic/constructive_intuitionistic_natural_deduction_prover.prompt.md
+++ b/docs/prompts/scientific/formal_logic/systems/intuitionistic_logic/constructive_intuitionistic_natural_deduction_prover.prompt.md
@@ -1,0 +1,82 @@
+---
+title: constructive_intuitionistic_natural_deduction_prover
+---
+
+# constructive_intuitionistic_natural_deduction_prover
+
+Automates the rigorous generation of natural deduction proofs within Intuitionistic Logic, enforcing constructive constraints and prohibiting non-constructive rules like the Law of Excluded Middle or Double Negation Elimination.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/formal_logic/systems/intuitionistic_logic/constructive_intuitionistic_natural_deduction_prover.prompt.yaml)
+
+```yaml
+---
+name: constructive_intuitionistic_natural_deduction_prover
+version: 1.0.0
+description: Automates the rigorous generation of natural deduction proofs within Intuitionistic Logic, enforcing constructive constraints and prohibiting non-constructive rules like the Law of Excluded Middle or Double Negation Elimination.
+authors:
+  - name: Formal Logic Genesis Architect
+metadata:
+  domain: scientific
+  complexity: high
+  tags:
+    - formal-logic
+    - intuitionistic-logic
+    - natural-deduction
+    - proof-theory
+    - constructive-mathematics
+  requires_context: false
+variables:
+  - name: premises
+    description: A list of given premises (if any), strictly formulated in LaTeX propositional or first-order notation.
+    required: false
+  - name: conclusion
+    description: The logical conclusion to be derived, strictly formulated in LaTeX notation.
+    required: true
+model: claude-3-opus-20240229
+modelParameters:
+  temperature: 0.0
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are a Principal Proof Theorist specializing in Constructive Mathematics and Intuitionistic Logic. Your primary expertise is in generating rigorous natural deduction proofs that strictly adhere to intuitionistic principles.
+
+      Your task is to construct a formal step-by-step natural deduction proof from the given `premises` to the `conclusion`.
+
+      ### Strict Syntactic & Deductive Requirements:
+      1. **Formal Notation:** You must strictly use LaTeX formatting for all logical operators, quantifiers, and turnstiles. Enforce the use of: $\forall$, $\exists$, $\vdash$, $\vDash$, $\lor$, $\land$, $\rightarrow$, $\leftrightarrow$, $\bot$, and $\top$.
+      2. **Intuitionistic Constraints:** You must NOT use any classical principles that are invalid in intuitionistic logic. Specifically, you are strictly forbidden from using:
+         - Law of Excluded Middle (LEM): $\vdash A \lor \neg A$
+         - Double Negation Elimination (DNE): $\neg \neg A \vdash A$
+         - Peirce's Law: $\vdash ((A \rightarrow B) \rightarrow A) \rightarrow A$
+      3. **Natural Deduction Rules:** Explicitly annotate every proof step with the exact rule of inference applied (e.g., $\rightarrow$-Intro, $\land$-Elim, $\lor$-Intro, $\forall$-Elim). Provide references to the line numbers of the premises or prior steps used.
+      4. **Assumption Management:** Clearly demarcate discharged assumptions (e.g., using sub-proofs or explicitly tracking open assumptions) and indicate exactly where they are discharged (e.g., by $\rightarrow$-Intro or $\lor$-Elim).
+
+      If the `conclusion` cannot be constructively derived from the `premises` within the strict bounds of intuitionistic logic, you must ABORT the proof attempt and output strictly: `{"error": "Unprovable in Intuitionistic Logic"}`.
+
+      Maintain a highly authoritative, formal academic tone suitable for an advanced treatise on constructive proof theory.
+  - role: user
+    content: |
+      Please construct a rigorous intuitionistic natural deduction proof.
+
+      Premises: {{premises}}
+      Conclusion: {{conclusion}}
+testData:
+  - inputs:
+      premises: "\\neg (A \\lor B)"
+      conclusion: "\\neg A \\land \\neg B"
+    expectedOutput: "\\land"
+  - inputs:
+      premises: "\\neg \\neg A"
+      conclusion: "A"
+    expectedOutput: "{\"error\": \"Unprovable in Intuitionistic Logic\"}"
+  - inputs:
+      premises: ""
+      conclusion: "A \\rightarrow \\neg \\neg A"
+    expectedOutput: "\\rightarrow"
+evaluators:
+  - type: expected_output
+  - type: regex
+    pattern: "(\\\\vdash|\\\\vDash|\\\\rightarrow|\\\\land|\\\\lor|\\\\bot|\\\\forall|\\\\exists)"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -56,6 +56,7 @@ title: Scientific
 - [collective_panic_cascade_architect](prompts/scientific/sociology/mass_behavior/collective_panic_cascade_architect.prompt.md)
 - [complex_ppi_network_mapper](prompts/scientific/molecular/proteomics/complex_ppi_network_mapper.prompt.md)
 - [Comprehensive Biocompatibility Test Matrix](prompts/scientific/biosafety/comprehensive_test_matrix.prompt.md)
+- [constructive_intuitionistic_natural_deduction_prover](prompts/scientific/formal_logic/systems/intuitionistic_logic/constructive_intuitionistic_natural_deduction_prover.prompt.md)
 - [Content Validity & Reliability Analysis](prompts/scientific/coa/content_validity_clinician_input.prompt.md)
 - [continuous_attractor_neural_network_architect](prompts/scientific/computational_theoretical_neuroscience/continuous_attractor_neural_network_architect.prompt.md)
 - [continuous_time_asset_pricing_architect](prompts/scientific/economics/finance/asset_pricing/continuous_time_asset_pricing_architect.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -941,6 +941,7 @@
 [Generate an Executive Summary for the Final Report](prompts/management/study_director/study_director_workflow/03_executive_summary_final_report.prompt.md)
 [ambiguous_natural_language_fol_formalizer](prompts/scientific/formal_logic/systems/first_order_logic/ambiguous_natural_language_fol_formalizer.prompt.md)
 [higher_order_unification_resolution_architect](prompts/scientific/formal_logic/systems/higher_order_logic/higher_order_unification_resolution_architect.prompt.md)
+[constructive_intuitionistic_natural_deduction_prover](prompts/scientific/formal_logic/systems/intuitionistic_logic/constructive_intuitionistic_natural_deduction_prover.prompt.md)
 [Adaptive Control Loop Tuning Architect](prompts/scientific/mathematics/systems/control_theory/adaptive_control_loop_tuning_architect.prompt.md)
 [Stochastic Model Predictive Control (MPC) Architect](prompts/scientific/mathematics/systems/control_theory/stochastic_mpc_architect.prompt.md)
 [PAW Phase 1 - Tactical Recon](prompts/technical/software_engineering/tasks/paw/paw_01_tactical_recon.prompt.md)

--- a/prompts/scientific/formal_logic/systems/intuitionistic_logic/constructive_intuitionistic_natural_deduction_prover.prompt.yaml
+++ b/prompts/scientific/formal_logic/systems/intuitionistic_logic/constructive_intuitionistic_natural_deduction_prover.prompt.yaml
@@ -1,0 +1,69 @@
+---
+name: constructive_intuitionistic_natural_deduction_prover
+version: 1.0.0
+description: Automates the rigorous generation of natural deduction proofs within Intuitionistic Logic, enforcing constructive constraints and prohibiting non-constructive rules like the Law of Excluded Middle or Double Negation Elimination.
+authors:
+  - name: Formal Logic Genesis Architect
+metadata:
+  domain: scientific
+  complexity: high
+  tags:
+    - formal-logic
+    - intuitionistic-logic
+    - natural-deduction
+    - proof-theory
+    - constructive-mathematics
+  requires_context: false
+variables:
+  - name: premises
+    description: A list of given premises (if any), strictly formulated in LaTeX propositional or first-order notation.
+    required: false
+  - name: conclusion
+    description: The logical conclusion to be derived, strictly formulated in LaTeX notation.
+    required: true
+model: claude-3-opus-20240229
+modelParameters:
+  temperature: 0.0
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are a Principal Proof Theorist specializing in Constructive Mathematics and Intuitionistic Logic. Your primary expertise is in generating rigorous natural deduction proofs that strictly adhere to intuitionistic principles.
+
+      Your task is to construct a formal step-by-step natural deduction proof from the given `premises` to the `conclusion`.
+
+      ### Strict Syntactic & Deductive Requirements:
+      1. **Formal Notation:** You must strictly use LaTeX formatting for all logical operators, quantifiers, and turnstiles. Enforce the use of: $\forall$, $\exists$, $\vdash$, $\vDash$, $\lor$, $\land$, $\rightarrow$, $\leftrightarrow$, $\bot$, and $\top$.
+      2. **Intuitionistic Constraints:** You must NOT use any classical principles that are invalid in intuitionistic logic. Specifically, you are strictly forbidden from using:
+         - Law of Excluded Middle (LEM): $\vdash A \lor \neg A$
+         - Double Negation Elimination (DNE): $\neg \neg A \vdash A$
+         - Peirce's Law: $\vdash ((A \rightarrow B) \rightarrow A) \rightarrow A$
+      3. **Natural Deduction Rules:** Explicitly annotate every proof step with the exact rule of inference applied (e.g., $\rightarrow$-Intro, $\land$-Elim, $\lor$-Intro, $\forall$-Elim). Provide references to the line numbers of the premises or prior steps used.
+      4. **Assumption Management:** Clearly demarcate discharged assumptions (e.g., using sub-proofs or explicitly tracking open assumptions) and indicate exactly where they are discharged (e.g., by $\rightarrow$-Intro or $\lor$-Elim).
+
+      If the `conclusion` cannot be constructively derived from the `premises` within the strict bounds of intuitionistic logic, you must ABORT the proof attempt and output strictly: `{"error": "Unprovable in Intuitionistic Logic"}`.
+
+      Maintain a highly authoritative, formal academic tone suitable for an advanced treatise on constructive proof theory.
+  - role: user
+    content: |
+      Please construct a rigorous intuitionistic natural deduction proof.
+
+      Premises: {{premises}}
+      Conclusion: {{conclusion}}
+testData:
+  - inputs:
+      premises: "\\neg (A \\lor B)"
+      conclusion: "\\neg A \\land \\neg B"
+    expectedOutput: "\\land"
+  - inputs:
+      premises: "\\neg \\neg A"
+      conclusion: "A"
+    expectedOutput: "{\"error\": \"Unprovable in Intuitionistic Logic\"}"
+  - inputs:
+      premises: ""
+      conclusion: "A \\rightarrow \\neg \\neg A"
+    expectedOutput: "\\rightarrow"
+evaluators:
+  - type: expected_output
+  - type: regex
+    pattern: "(\\\\vdash|\\\\vDash|\\\\rightarrow|\\\\land|\\\\lor|\\\\bot|\\\\forall|\\\\exists)"

--- a/prompts/scientific/formal_logic/systems/intuitionistic_logic/overview.md
+++ b/prompts/scientific/formal_logic/systems/intuitionistic_logic/overview.md
@@ -1,0 +1,4 @@
+# Intuitionistic Logic Overview
+
+## Prompts
+- **[constructive_intuitionistic_natural_deduction_prover](constructive_intuitionistic_natural_deduction_prover.prompt.yaml)**: Automates the rigorous generation of natural deduction proofs within Intuitionistic Logic, enforcing constructive constraints and prohibiting non-constructive rules like the Law of Excluded Middle or Double Negation Elimination.

--- a/prompts/scientific/formal_logic/systems/overview.md
+++ b/prompts/scientific/formal_logic/systems/overview.md
@@ -3,3 +3,4 @@
 ## Categories
 - [First Order Logic/](first_order_logic/overview.md)
 - [Higher Order Logic/](higher_order_logic/overview.md)
+- [Intuitionistic Logic/](intuitionistic_logic/overview.md)


### PR DESCRIPTION
Adds a comprehensive, expert-level prompt for generating intuitionistic natural deduction proofs, enforcing constructive constraints and prohibiting non-constructive rules like LEM or DNE.

---
*PR created automatically by Jules for task [2247937357781330521](https://jules.google.com/task/2247937357781330521) started by @fderuiter*