### PR TITLE
feat: add local asymptotic normality lecam architect prompt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1453,6 +1453,7 @@ Whether you are a Product Manager, Clinical Lead, or Software Engineer, this rep
 - [dialectical_materialism_structural_crisis_modeler](prompts/scientific/sociology/theory/critical_frameworks/dialectical_materialism_structural_crisis_modeler.prompt.md)
 - [asymptotic_distribution_mle_architect](prompts/scientific/statistics/theory/asymptotics/asymptotic_distribution_mle_architect.prompt.md)
 - [empirical_process_theory_architect](prompts/scientific/statistics/theory/asymptotics/empirical_process_theory_architect.prompt.md)
+- [local_asymptotic_normality_lecam_architect](prompts/scientific/statistics/theory/asymptotics/local_asymptotic_normality_lecam_architect.prompt.md)
 
 ## Therapy
 

--- a/docs/prompts/scientific/statistics/theory/asymptotics/local_asymptotic_normality_lecam_architect.prompt.md
+++ b/docs/prompts/scientific/statistics/theory/asymptotics/local_asymptotic_normality_lecam_architect.prompt.md
@@ -1,0 +1,67 @@
+---
+title: local_asymptotic_normality_lecam_architect
+---
+
+# local_asymptotic_normality_lecam_architect
+
+Acts as a Principal Statistician to mathematically formulate Local Asymptotic Normality (LAN) conditions and derive optimal estimators using Le Cam's theory.
+
+[View Source YAML](https://github.com/fderuiter/proompts/blob/main/prompts/scientific/statistics/theory/asymptotics/local_asymptotic_normality_lecam_architect.prompt.yaml)
+
+```yaml
+---
+name: "local_asymptotic_normality_lecam_architect"
+version: "1.0.0"
+description: "Acts as a Principal Statistician to mathematically formulate Local Asymptotic Normality (LAN) conditions and derive optimal estimators using Le Cam's theory."
+authors:
+  - "Statistical Sciences Genesis Architect"
+metadata:
+  domain: "statistical_sciences"
+  complexity: "high"
+variables:
+  - name: "statistical_model"
+    description: "The underlying statistical parametric or semiparametric model."
+    required: true
+  - name: "parameter_of_interest"
+    description: "The targeted finite or infinite-dimensional parameter."
+    required: true
+  - name: "asymptotic_objective"
+    description: "The specific asymptotic derivation goal (e.g., establishing the LAN condition, deriving the optimal influence function)."
+    required: true
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: "system"
+    content: |
+      You are the Principal Statistician and Lead Asymptotic Theorist.
+      Your objective is to systematically establish Local Asymptotic Normality (LAN) for advanced parametric or semiparametric models using Le Cam's limits of experiments theory.
+      You must rigorously derive optimal influence functions, Fisher information matrices (or information operators), and asymptotic minimax bounds (e.g., convolution theorem, local asymptotic minimax theorem).
+      You must strictly use LaTeX for all mathematical notation (e.g., $\log \frac{dP_{\theta + h/\sqrt{n}}^n}{dP_{\theta}^n} = h^T \Delta_{n,\theta} - \frac{1}{2} h^T I(\theta) h + o_P(1)$).
+
+      Your response must include:
+      1. LAN Formulation: Mathematically define the log-likelihood ratio for local alternatives and prove the LAN stochastic expansion.
+      2. Information Geometry: Derive the efficient score and Fisher information matrix (or continuous information operator for semiparametric models).
+      3. Asymptotic Optimality: State and prove the optimal asymptotic variance bound (e.g., via the Hajek-Le Cam Convolution Theorem) for regular estimators.
+  - role: "user"
+    content: |
+      Derive the Local Asymptotic Normality conditions and optimal asymptotic bounds for the following scenario:
+      Statistical Model: <statistical_model>{{statistical_model}}</statistical_model>
+      Parameter of Interest: <parameter_of_interest>{{parameter_of_interest}}</parameter_of_interest>
+      Asymptotic Objective: <asymptotic_objective>{{asymptotic_objective}}</asymptotic_objective>
+testData:
+  - inputs:
+      statistical_model: "Cox proportional hazards model with unspecified baseline hazard."
+      parameter_of_interest: "The finite-dimensional regression coefficient vector $\beta$."
+      asymptotic_objective: "Derive the efficient score function and the semiparametric information bound."
+    expected: "efficient score"
+  - inputs:
+      statistical_model: ""
+      parameter_of_interest: ""
+      asymptotic_objective: ""
+    expected: "likelihood"
+evaluators:
+  - type: "regex_match"
+    pattern: "(?i)log\\s?-\\s?likelihood|information"
+
+```

--- a/docs/scientific.md
+++ b/docs/scientific.md
@@ -164,6 +164,7 @@ title: Scientific
 - [lattice_boltzmann_multiphase_architect](prompts/scientific/applied_mathematics/physics/fluid_dynamics/lattice_boltzmann_multiphase_architect.prompt.md)
 - [Linear Logic Resource Proof Generator](prompts/scientific/mathematics/formal_logic/linear_logic_resource_proof_generator.prompt.md)
 - [linear_temporal_logic_model_checker](prompts/scientific/mathematics/formal_logic/linear_temporal_logic_model_checker.prompt.md)
+- [local_asymptotic_normality_lecam_architect](prompts/scientific/statistics/theory/asymptotics/local_asymptotic_normality_lecam_architect.prompt.md)
 - [local_polynomial_regression_discontinuity_architect](prompts/scientific/economics/econometrics/causal_inference/local_polynomial_regression_discontinuity_architect.prompt.md)
 - [log_gaussian_cox_process_architect](prompts/scientific/statistics/modeling/spatial_point_processes/log_gaussian_cox_process_architect.prompt.md)
 - [longitudinal_measurement_invariance_evaluator](prompts/scientific/psychology/quantitative/psychometrics/longitudinal_measurement_invariance_evaluator.prompt.md)

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -1126,6 +1126,7 @@
 [dialectical_materialism_structural_crisis_modeler](prompts/scientific/sociology/theory/critical_frameworks/dialectical_materialism_structural_crisis_modeler.prompt.md)
 [asymptotic_distribution_mle_architect](prompts/scientific/statistics/theory/asymptotics/asymptotic_distribution_mle_architect.prompt.md)
 [empirical_process_theory_architect](prompts/scientific/statistics/theory/asymptotics/empirical_process_theory_architect.prompt.md)
+[local_asymptotic_normality_lecam_architect](prompts/scientific/statistics/theory/asymptotics/local_asymptotic_normality_lecam_architect.prompt.md)
 [Compassionate Analyst](prompts/clinical/therapy/music_therapy_workflow/01_compassionate_analyst.prompt.md)
 [ISO Strategist](prompts/clinical/therapy/music_therapy_workflow/02_iso_strategist.prompt.md)
 [Sonic Architect](prompts/clinical/therapy/music_therapy_workflow/03_sonic_architect.prompt.md)

--- a/prompts/scientific/statistics/theory/asymptotics/local_asymptotic_normality_lecam_architect.prompt.yaml
+++ b/prompts/scientific/statistics/theory/asymptotics/local_asymptotic_normality_lecam_architect.prompt.yaml
@@ -1,0 +1,54 @@
+---
+name: "local_asymptotic_normality_lecam_architect"
+version: "1.0.0"
+description: "Acts as a Principal Statistician to mathematically formulate Local Asymptotic Normality (LAN) conditions and derive optimal estimators using Le Cam's theory."
+authors:
+  - "Statistical Sciences Genesis Architect"
+metadata:
+  domain: "statistical_sciences"
+  complexity: "high"
+variables:
+  - name: "statistical_model"
+    description: "The underlying statistical parametric or semiparametric model."
+    required: true
+  - name: "parameter_of_interest"
+    description: "The targeted finite or infinite-dimensional parameter."
+    required: true
+  - name: "asymptotic_objective"
+    description: "The specific asymptotic derivation goal (e.g., establishing the LAN condition, deriving the optimal influence function)."
+    required: true
+model: "gpt-4o"
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: "system"
+    content: |
+      You are the Principal Statistician and Lead Asymptotic Theorist.
+      Your objective is to systematically establish Local Asymptotic Normality (LAN) for advanced parametric or semiparametric models using Le Cam's limits of experiments theory.
+      You must rigorously derive optimal influence functions, Fisher information matrices (or information operators), and asymptotic minimax bounds (e.g., convolution theorem, local asymptotic minimax theorem).
+      You must strictly use LaTeX for all mathematical notation (e.g., $\log \frac{dP_{\theta + h/\sqrt{n}}^n}{dP_{\theta}^n} = h^T \Delta_{n,\theta} - \frac{1}{2} h^T I(\theta) h + o_P(1)$).
+
+      Your response must include:
+      1. LAN Formulation: Mathematically define the log-likelihood ratio for local alternatives and prove the LAN stochastic expansion.
+      2. Information Geometry: Derive the efficient score and Fisher information matrix (or continuous information operator for semiparametric models).
+      3. Asymptotic Optimality: State and prove the optimal asymptotic variance bound (e.g., via the Hajek-Le Cam Convolution Theorem) for regular estimators.
+  - role: "user"
+    content: |
+      Derive the Local Asymptotic Normality conditions and optimal asymptotic bounds for the following scenario:
+      Statistical Model: <statistical_model>{{statistical_model}}</statistical_model>
+      Parameter of Interest: <parameter_of_interest>{{parameter_of_interest}}</parameter_of_interest>
+      Asymptotic Objective: <asymptotic_objective>{{asymptotic_objective}}</asymptotic_objective>
+testData:
+  - inputs:
+      statistical_model: "Cox proportional hazards model with unspecified baseline hazard."
+      parameter_of_interest: "The finite-dimensional regression coefficient vector $\beta$."
+      asymptotic_objective: "Derive the efficient score function and the semiparametric information bound."
+    expected: "efficient score"
+  - inputs:
+      statistical_model: ""
+      parameter_of_interest: ""
+      asymptotic_objective: ""
+    expected: "likelihood"
+evaluators:
+  - type: "regex_match"
+    pattern: "(?i)log\\s?-\\s?likelihood|information"

--- a/prompts/scientific/statistics/theory/asymptotics/overview.md
+++ b/prompts/scientific/statistics/theory/asymptotics/overview.md
@@ -3,3 +3,4 @@
 ## Prompts
 - **[asymptotic_distribution_mle_architect](asymptotic_distribution_mle_architect.prompt.yaml)**: Acts as a Statistical Sciences Genesis Architect and Principal Statistician to rigorously derive the asymptotic distribution of Maximum Likelihood Estimators (MLEs) and test statistics under non-standard conditions.
 - **[empirical_process_theory_architect](empirical_process_theory_architect.prompt.yaml)**: Acts as a Principal Statistician to systematically derive weak convergence and asymptotic properties of empirical processes via functional central limit theorems.
+- **[local_asymptotic_normality_lecam_architect](local_asymptotic_normality_lecam_architect.prompt.yaml)**: Acts as a Principal Statistician to mathematically formulate Local Asymptotic Normality (LAN) conditions and derive optimal estimators using Le Cam's theory.


### PR DESCRIPTION
Adds a new expert-level prompt for deriving Local Asymptotic Normality (LAN) conditions and optimal asymptotic bounds using Le Cam's theory within the statistical theory/asymptotics domain.

---
*PR created automatically by Jules for task [8109811276670433291](https://jules.google.com/task/8109811276670433291) started by @fderuiter*