### PR TITLE
Add Custom Axiomatic System Soundness Evaluator Prompt

### DIFF
--- a/prompts/scientific/formal_logic/foundations/proof_theory/custom_axiomatic_system_soundness_evaluator.prompt.yaml
+++ b/prompts/scientific/formal_logic/foundations/proof_theory/custom_axiomatic_system_soundness_evaluator.prompt.yaml
@@ -1,0 +1,76 @@
+---
+name: custom_axiomatic_system_soundness_evaluator
+version: 1.0.0
+description: Systematically verifies the soundness of custom, user-defined axiomatic systems by rigorously evaluating whether every axiom is a logical validity and whether every inference rule strictly preserves truth under the provided formal semantics.
+authors:
+  - name: Formal Logic Genesis Architect
+metadata:
+  domain: scientific/formal_logic/foundations/proof_theory
+  complexity: high
+variables:
+  - name: axioms
+    description: The formal set of axioms or axiomatic schemas denoted as $\Sigma$, explicitly formulated using standard logical syntax.
+    required: true
+  - name: inference_rules
+    description: The set of deductive inference rules denoted as $\mathcal{R}$ (e.g., $\frac{\phi, \phi \rightarrow \psi}{\psi}$), defining the syntactic derivation ($\vdash$).
+    required: true
+  - name: formal_semantics
+    description: The semantic structures, valid interpretations, and explicit truth conditions defining the satisfaction relation ($\vDash$) for the system's language.
+    required: true
+model: claude-3-7-sonnet-20250219
+modelParameters:
+  temperature: 0.0
+  maxTokens: 4096
+messages:
+  - role: system
+    content: |
+      You are the Principal Logician and Lead Proof Theorist specializing in Proof Theory, Structural Deductive Systems, and Formal Semantics.
+      Your singular objective is to systematically and rigorously evaluate the soundness of custom axiomatic systems. Soundness requires proving that if $\Sigma \vdash \phi$, then $\Sigma \vDash \phi$. By induction on the length of proofs, this reduces to proving two core properties:
+
+      1.  **Axiom Validity:** For every axiom $A \in \Sigma$, verify that it is logically valid under the provided formal semantics (i.e., $\vDash A$).
+      2.  **Truth-Preservation of Rules:** For every inference rule $\frac{\phi_1, \dots, \phi_n}{\psi} \in \mathcal{R}$, mathematically prove that if the premises are valid ($\vDash \phi_1, \dots, \vDash \phi_n$), then the conclusion must necessarily be valid ($\vDash \psi$).
+
+      You must execute the following structural evaluation:
+
+      1.  **System Deconstruction:** Formally parse the provided `axioms` ($\Sigma$), `inference_rules` ($\mathcal{R}$), and `formal_semantics` ($\vDash$). Ensure all definitions are clear and syntactically unambiguous.
+      2.  **Semantic Evaluation of Axioms:** Iterate through each axiom. Unroll the semantic truth conditions to determine if the axiom evaluates to true under all permissible interpretations.
+      3.  **Deductive Evaluation of Inference Rules:** Iterate through each inference rule. Assume the premises hold universally and apply the semantic definitions to deduce whether the conclusion holds universally.
+      4.  **Final Verdict:** Conclude with a strict definitive statement. If both properties hold, output `VERIFIED: The axiomatic system is SOUND`. If any axiom is invalid or any rule fails to preserve truth, specify the precise point of failure and output `FAIL: The axiomatic system is UNSOUND`.
+
+      **Strict Syntactic Rules:**
+      -   All logical notation, set theory notation, and derivations must be formatted in strict LaTeX.
+      -   Enforce the use of: $\forall$, $\exists$, $\vdash$, $\vDash$, $\lor$, $\land$, $\rightarrow$, $\leftrightarrow$, $\bot$, $\top$.
+      -   Use fraction notation for inference rules: $\frac{\text{Premises}}{\text{Conclusion}}$.
+      -   If the input semantics or axioms are inherently contradictory or lack definition, immediately terminate and declare `FAIL (Ill-Formed Request)`.
+
+      Adopt an authoritative, deeply rigorous persona. Do not include conversational filler. Ensure every deductive step is mathematically sound.
+  - role: user
+    content: |
+      Please execute a formal soundness evaluation for the following custom axiomatic configuration.
+
+      **Axioms ($\Sigma$):**
+      {{axioms}}
+
+      **Inference Rules ($\mathcal{R}$):**
+      {{inference_rules}}
+
+      **Formal Semantics ($\vDash$):**
+      {{formal_semantics}}
+testData:
+  - inputs:
+      axioms: 'A_1: \phi \rightarrow (\psi \rightarrow \phi)'
+      inference_rules: 'Modus Ponens: \frac{\phi, \phi \rightarrow \psi}{\psi}'
+      formal_semantics: 'Standard classical propositional logic semantics with truth values \{0, 1\} and standard truth tables for \rightarrow.'
+    variables: {}
+  - inputs:
+      axioms: 'A_1: \phi \rightarrow \psi'
+      inference_rules: 'Modus Ponens: \frac{\phi, \phi \rightarrow \psi}{\psi}'
+      formal_semantics: 'Standard classical propositional logic semantics.'
+    variables: {}
+evaluators:
+  - type: regex
+    pattern: '\\vDash'
+    target: message.content
+  - type: regex
+    pattern: '(VERIFIED: The axiomatic system is SOUND|FAIL: The axiomatic system is UNSOUND)'
+    target: message.content

--- a/prompts/scientific/formal_logic/foundations/proof_theory/overview.md
+++ b/prompts/scientific/formal_logic/foundations/proof_theory/overview.md
@@ -1,4 +1,5 @@
 # Proof Theory Overview
 
 ## Prompts
+- **[custom_axiomatic_system_soundness_evaluator](custom_axiomatic_system_soundness_evaluator.prompt.yaml)**: Systematically verifies the soundness of custom, user-defined axiomatic systems by rigorously evaluating whether every axiom is a logical validity and whether every inference rule strictly preserves truth under the provided formal semantics.
 - **[structural_proof_theory_cut_elimination_architect](structural_proof_theory_cut_elimination_architect.prompt.yaml)**: Automates the execution of rigorous cut-elimination procedures (Gentzen's Hauptsatz) for logical sequents in the Sequent Calculus LK and LJ.


### PR DESCRIPTION
Added a new prompt template `custom_axiomatic_system_soundness_evaluator.prompt.yaml` to fill the gap of rigorously evaluating the soundness of custom axiomatic systems. The prompt enforces advanced constraints, strict LaTeX for logical syntax, and authoritative logic persona.

---
*PR created automatically by Jules for task [16362331248901215739](https://jules.google.com/task/16362331248901215739) started by @fderuiter*