### PR TITLE
feat: add ANDA Architect prompt for generic drug submissions

### DIFF
--- a/prompts/regulatory/submissions/abbreviated_new_drug_application_anda_architect.prompt.yaml
+++ b/prompts/regulatory/submissions/abbreviated_new_drug_application_anda_architect.prompt.yaml
@@ -1,0 +1,79 @@
+---
+name: Abbreviated New Drug Application (ANDA) Architect
+version: 1.0.0
+description: Formulates rigorous, compliant FDA Abbreviated New Drug Application (ANDA) eCTD submissions for generic drugs, ensuring strict adherence to 21 CFR 314 and demonstrating bioequivalence to a Reference Listed Drug (RLD).
+authors:
+  - Strategic Genesis Architect
+metadata:
+  domain: regulatory
+  complexity: high
+  tags:
+    - anda
+    - fda
+    - generic-drug
+    - ectd
+    - bioequivalence
+    - submission
+    - rld
+    - regulatory-affairs
+  requires_context: true
+variables:
+  - name: generic_drug_name
+    description: The proposed generic drug name and active pharmaceutical ingredient.
+    required: true
+  - name: reference_listed_drug
+    description: The Reference Listed Drug (RLD) including its NDA number to which bioequivalence is being demonstrated.
+    required: true
+  - name: bioequivalence_summary
+    description: A high-level synthesis of in vivo or in vitro bioequivalence study outcomes.
+    required: true
+  - name: q1_q2_formulation_details
+    description: Details regarding Qualitative (Q1) and Quantitative (Q2) formulation sameness to the RLD.
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.2
+messages:
+  - role: system
+    content: |
+      You are the Principal FDA Abbreviated New Drug Application (ANDA) Architect, an elite regulatory strategist and commanding authority on US generic pharmaceutical regulation (21 CFR Part 314 Subpart C) and ICH M4 (eCTD) requirements. Your singular mandate is to construct impregnable, meticulously organized ANDA submission frameworks for generic drugs.
+
+      Your output must demonstrate unparalleled regulatory precision, pre-empting FDA Office of Generic Drugs (OGD) Refuse-to-Receive (RTR) letters. You must flawlessly integrate Quality (Module 3) and Bioequivalence (Module 5) data into the standardized eCTD architecture, establishing a compelling evidentiary narrative of therapeutic equivalence.
+
+      # Constraints & Directives
+
+      1.  **eCTD Hierarchical Mastery**: Strictly enforce the ICH M4 5-module eCTD taxonomy, emphasizing Module 1 (Administrative, including Patent Certifications and Exclusivity statements), Module 3 (Quality/CMC), and Module 5 (Bioequivalence).
+      2.  **Sameness Demonstration**: Explicitly detail the strategy for demonstrating Qualitative (Q1) and Quantitative (Q2) sameness to the Reference Listed Drug (RLD), addressing any permissible differences and their justification.
+      3.  **Bioequivalence Precision (Module 5)**: Define the precise structure for the Bioequivalence summary, study reports, and raw data sets (e.g., CDISC SDTM), ensuring robust statistical proof of equivalence (e.g., 90% confidence intervals for Cmax and AUC falling within the 80-125% range).
+      4.  **Tone & Persona**: Your tone is highly authoritative, purely analytical, and uncompromisingly rigorous. You address a sophisticated audience of Regulatory Affairs executives and FDA OGD reviewers. Do not use colloquialisms or speculative language.
+  - role: user
+    content: |
+      Architect the comprehensive ANDA eCTD framework for the following generic drug profile:
+
+      Generic Drug Name: {{generic_drug_name}}
+      Reference Listed Drug: {{reference_listed_drug}}
+      Bioequivalence Summary: {{bioequivalence_summary}}
+      Q1/Q2 Formulation Details: {{q1_q2_formulation_details}}
+
+      Construct a rigorous, section-by-section blueprint detailing the exact content requirements, evidentiary thresholds, patent certifications, and module cross-references required to secure FDA OGD approval.
+testData:
+  - generic_drug_name: Imatinib Mesylate Tablets, 100 mg and 400 mg
+    reference_listed_drug: Gleevec (imatinib mesylate) Tablets, NDA 021588
+    bioequivalence_summary: Single-dose, randomized, two-period, two-sequence crossover fasting and fed studies demonstrating 90% CIs for Cmax and AUC within 80-125%.
+    q1_q2_formulation_details: The generic formulation is exactly Q1 and Q2 the same as the RLD, utilizing identical inactive ingredients in the same proportions.
+    expected: A structured ANDA blueprint highlighting bioequivalence (Module 5), CMC controls (Module 3), and Q1/Q2 sameness without clinical safety/efficacy trials.
+  - generic_drug_name: Albuterol Sulfate Inhalation Aerosol, 90 mcg/actuation
+    reference_listed_drug: ProAir HFA (albuterol sulfate) Inhalation Aerosol, NDA 021457
+    bioequivalence_summary: In vitro aerodynamic particle size distribution (APSD) studies and in vivo pharmacodynamic (bronchodilation) studies demonstrating equivalence per product-specific guidance.
+    q1_q2_formulation_details: Propellant and excipients match the RLD Q1/Q2 requirements; device actuation mechanisms mathematically correlated to the reference.
+    expected: A structured ANDA blueprint covering in vitro/in vivo BE strategies for complex drug-device combinations, emphasizing Module 3 device controls.
+evaluators:
+  - name: Mentions Module 3
+    string:
+      contains: Module 3
+  - name: Mentions Module 5
+    string:
+      contains: Module 5
+  - name: Mentions FDA OGD
+    string:
+      contains: OGD

--- a/prompts/regulatory/submissions/overview.md
+++ b/prompts/regulatory/submissions/overview.md
@@ -2,6 +2,7 @@
 
 ## Prompts
 - **[510(k) Substantial Equivalence Preparation](510_k_substantial_equivalence_preparation.prompt.yaml)**: Draft a substantial equivalence comparison and summary between a subject device and predicate(s) to demonstrate safety and effectiveness.
+- **[Abbreviated New Drug Application (ANDA) Architect](abbreviated_new_drug_application_anda_architect.prompt.yaml)**: Formulates rigorous, compliant FDA Abbreviated New Drug Application (ANDA) eCTD submissions for generic drugs, ensuring strict adherence to 21 CFR 314 and demonstrating bioequivalence to a Reference Listed Drug (RLD).
 - **[Biologics License Application (BLA) Architect](biologics_license_application_bla_architect.prompt.yaml)**: Formulates rigorous, compliant FDA Biologics License Application (BLA) eCTD submissions for biological products, ensuring alignment with 21 CFR 600-680 and ICH M4 guidelines.
 - **[Combination Product Jurisdiction](combination_product_jurisdiction.prompt.yaml)**: Prepare a Request for Designation (RFD) to identify primary FDA jurisdiction.
 - **[De Novo Request Preparation](de_novo_request_preparation.prompt.yaml)**: Generate a summary of risks and mitigations for a De Novo classification request.


### PR DESCRIPTION
This PR introduces the `Abbreviated New Drug Application (ANDA) Architect` prompt to the `regulatory/submissions` domain.

### Gap Analysis
Currently, the `regulatory/submissions` domain contains prompts for `new_drug_application_nda_architect` (small molecules) and `biologics_license_application_bla_architect` (biologics). However, there is a distinct gap for an **Abbreviated New Drug Application (ANDA)** for generic drugs. ANDA submissions have a distinct workflow that focuses on demonstrating *bioequivalence* to a Reference Listed Drug (RLD) under 21 CFR Part 314 Subpart C, rather than establishing new clinical safety and efficacy data.

### Prompt Details
- **Role:** Principal FDA Abbreviated New Drug Application (ANDA) Architect
- **Focus:** Demonstrating Q1/Q2 sameness, structuring Bioequivalence summaries (Module 5), and ensuring rigorous CMC controls (Module 3) to prevent Refuse-to-Receive (RTR) letters.
- **Constraints:** Strict adherence to ICH M4 eCTD hierarchy and 21 CFR Part 314 Subpart C.
- **Complexity:** High

All tests (`test_all.py`) pass successfully.

---
*PR created automatically by Jules for task [18370535073887356238](https://jules.google.com/task/18370535073887356238) started by @fderuiter*