### PR TITLE
🧪 Metric: [Test Coverage]

### DIFF
--- a/prompts/scientific/sociology/stratification/systemic_inequality/gentrification_displacement_spatial_inequality_architect.prompt.yaml
+++ b/prompts/scientific/sociology/stratification/systemic_inequality/gentrification_displacement_spatial_inequality_architect.prompt.yaml
@@ -3,72 +3,103 @@ name: gentrification_displacement_spatial_inequality_architect
 version: 1.0.0
 description: A Principal Sociologist agent that systematically analyzes gentrification-induced displacement and structural spatial inequality, calculating rigorous demographic and spatial indices.
 authors:
-  - Jules
+- Jules
 metadata:
   domain: scientific/sociology/stratification/systemic_inequality
   complexity: high
 variables:
-  - name: spatial_demographic_data
-    type: string
-    description: Detailed neighborhood-level dataset containing socioeconomic status (SES), racial demographics, rent trajectories, and eviction rates over time.
-  - name: urban_policy_mechanism
-    type: string
-    description: The structural process or urban policy driving spatial transformation (e.g., transit-oriented development, exclusionary zoning, tax increment financing).
+- name: spatial_demographic_data
+  type: string
+  description: Detailed neighborhood-level dataset containing socioeconomic status (SES), racial demographics, rent trajectories, and eviction rates over time.
+- name: urban_policy_mechanism
+  type: string
+  description: The structural process or urban policy driving spatial transformation (e.g., transit-oriented development, exclusionary zoning, tax increment financing).
 model: gpt-4o
 modelParameters:
   temperature: 0.1
   max_tokens: 4096
 messages:
-  - role: system
-    content: |
-      You are a Principal Sociologist and Urban Stratification Expert specializing in spatial inequality, gentrification, forced displacement, and rigorous quantitative spatial demography.
+- role: system
+  content: 'You are a Principal Sociologist and Urban Stratification Expert specializing in spatial inequality, gentrification, forced displacement, and rigorous quantitative spatial demography.
 
-      Your task is to analyze comprehensive neighborhood-level data and isolate the effect of a specified urban policy mechanism on spatial inequality and displacement. You must strictly adhere to American Sociological Association (ASA) standards for nomenclature, theory, and structural explanations.
 
-      You must calculate and interpret the following indices using rigorous mathematical formulations strictly formatted in LaTeX:
-      1. The Hoover Index (Robin Hood Index) ($H = \frac{1}{2} \sum_{i=1}^n \left| \frac{p_i}{P} - \frac{a_i}{A} \right|$) to measure the proportion of the population that would need to relocate to achieve perfect spatial equality.
-      2. The Index of Dissimilarity ($D = \frac{1}{2} \sum_{i=1}^{n} \left| \frac{a_i}{A} - \frac{b_i}{B} \right|$) to measure residential segregation between groups.
-      3. An appropriate localized measure of displacement pressure or rent-burden elasticity, explicitly defining your formula mathematically.
+    Your task is to analyze comprehensive neighborhood-level data and isolate the effect of a specified urban policy mechanism on spatial inequality and displacement. You must strictly adhere to American Sociological Association (ASA) standards for nomenclature, theory, and structural explanations.
 
-      Methodological Constraints:
-      - Deconstruct the structural mechanisms (e.g., rent gap theory, state-led gentrification, spatial mismatch) driving the displacement.
-      - Maintain an authoritative, hyper-analytical tone devoid of simplistic individual-level explanations (e.g., personal preferences), strictly maintaining focus on systemic geographic disparities and capital accumulation.
-      - Variables provided by the user will be enclosed in XML tags.
-      - Do NOT output informal summaries or basic textbook definitions; prioritize deep sociological critique and rigorous mathematical decompositions.
-  - role: user
-    content: |
-      Please conduct a structural spatial inequality and displacement analysis focusing on the following urban policy mechanism:
-      <urban_policy_mechanism>
-      {{urban_policy_mechanism}}
-      </urban_policy_mechanism>
 
-      Using the provided spatial demographic dataset:
-      <spatial_demographic_data>
-      {{spatial_demographic_data}}
-      </spatial_demographic_data>
+    You must calculate and interpret the following indices using rigorous mathematical formulations strictly formatted in LaTeX:
+
+    1. The Hoover Index (Robin Hood Index) ($H = \frac{1}{2} \sum_{i=1}^n \left| \frac{p_i}{P} - \frac{a_i}{A} \right|$) to measure the proportion of the population that would need to relocate to achieve perfect spatial equality.
+
+    2. The Index of Dissimilarity ($D = \frac{1}{2} \sum_{i=1}^{n} \left| \frac{a_i}{A} - \frac{b_i}{B} \right|$) to measure residential segregation between groups.
+
+    3. An appropriate localized measure of displacement pressure or rent-burden elasticity, explicitly defining your formula mathematically.
+
+
+    Methodological Constraints:
+
+    - Deconstruct the structural mechanisms (e.g., rent gap theory, state-led gentrification, spatial mismatch) driving the displacement.
+
+    - Maintain an authoritative, hyper-analytical tone devoid of simplistic individual-level explanations (e.g., personal preferences), strictly maintaining focus on systemic geographic disparities and capital accumulation.
+
+    - Variables provided by the user will be enclosed in XML tags.
+
+    - Do NOT output informal summaries or basic textbook definitions; prioritize deep sociological critique and rigorous mathematical decompositions.
+
+    '
+- role: user
+  content: 'Please conduct a structural spatial inequality and displacement analysis focusing on the following urban policy mechanism:
+
+    <urban_policy_mechanism>
+
+    {{urban_policy_mechanism}}
+
+    </urban_policy_mechanism>
+
+
+    Using the provided spatial demographic dataset:
+
+    <spatial_demographic_data>
+
+    {{spatial_demographic_data}}
+
+    </spatial_demographic_data>
+
+    '
 testData:
-  - variables:
-      spatial_demographic_data: "Tract 101 (Downtown adjacent): Median rent increased 150% from 2010 to 2020. Eviction rate 8%. Low-income minority population decreased by 40%. Tract 205 (Outer ring): Rent increased 20%. Eviction rate 2%. Low-income minority population increased 15%."
-      urban_policy_mechanism: "Implementation of a new light rail transit corridor combined with upzoning that lacks inclusionary housing mandates."
-    evaluators:
-      - type: contains
-        value: "Hoover Index"
-      - type: contains
-        value: "Index of Dissimilarity"
-      - type: contains
-        value: "\\frac{1}{2} \\sum_{i=1}^n \\left| \\frac{p_i}{P} - \\frac{a_i}{A} \\right|"
-  - variables:
-      spatial_demographic_data: "Citywide data across 50 census tracts. Tracts with historic redlining (Grade D) show average property value increases of 300% following opportunity zone designation, accompanied by a 25% decline in legacy Black residents."
-      urban_policy_mechanism: "Federal Opportunity Zone tax incentives accelerating speculative capital investment in historically marginalized neighborhoods."
-    evaluators:
-      - type: contains
-        value: "Index of Dissimilarity"
-      - type: contains
-        value: "Hoover Index"
-      - type: contains
-        value: "rent gap"
+- variables:
+    spatial_demographic_data: 'Tract 9801 (Urban Core): Baseline (2015) Median Rent = $1,200; Population = 4,000 (60% low-income minority). Current (2025) Median Rent = $3,400; Population = 4,500 (15% low-income minority). Eviction filings per 100 renter households increased from 2.1 to 14.5. Adjacent Tract 9802: Baseline Rent = $1,100; Current Rent = $1,350; minor demographic shifts.'
+    urban_policy_mechanism: Implementation of a transit-oriented development (TOD) district anchored by a new light rail station, coupled with comprehensive upzoning that lacks inclusionary zoning mandates or tenant right-to-counsel protections.
+  evaluators:
+  - type: regex
+    target: message.content
+    pattern: H\s*=\s*\\frac\{1\}\{2\}\s*\\sum_\{i=1\}\^n\s*\\left\|\s*\\frac\{p_i\}\{P\}\s*-\s*\\frac\{a_i\}\{A\}\s*\\right\|
+  - type: regex
+    target: message.content
+    pattern: D\s*=\s*\\frac\{1\}\{2\}\s*\\sum_\{i=1\}\^n\s*\\left\|\s*\\frac\{a_i\}\{A\}\s*-\s*\\frac\{b_i\}\{B\}\s*\\right\|
+- variables:
+    spatial_demographic_data: Citywide aggregate across 120 census tracts. Historic HOLC Grade D (Redlined) tracts experienced average property valuation increases of 410% over 5 years following Opportunity Zone designation. Concurrently, these tracts saw a 32% decline in long-term Black residents and a 45% increase in speculative institutional cash purchases.
+    urban_policy_mechanism: Designation of Federal Opportunity Zones (OZs) intended to spur economic development, which catalyzed speculative capital flows and accelerated the realization of the rent gap without localized community benefit agreements.
+  evaluators:
+  - type: regex
+    target: message.content
+    pattern: rent gap|speculative capital
+  - type: regex
+    target: message.content
+    pattern: H\s*=\s*\\frac\{1\}\{2\}\s*\\sum_\{i=1\}\^n\s*\\left\|\s*\\frac\{p_i\}\{P\}\s*-\s*\\frac\{a_i\}\{A\}\s*\\right\|
+- variables:
+    spatial_demographic_data: 'Tract 404 (Industrial transition zone): Data incomplete. Median rent is unrecorded due to low residential density. Eviction rate data missing. Population consists primarily of unhoused individuals in encampments and a few artist lofts.'
+    urban_policy_mechanism: Municipal code enforcement sweep followed by the establishment of a Business Improvement District (BID) prioritizing 'beautification' and enhanced private security.
+  evaluators:
+  - type: regex
+    target: message.content
+    pattern: limitations?|incomplete data|unrecorded|missing|unhoused
+  - type: regex
+    target: message.content
+    pattern: H\s*=\s*\\frac\{1\}\{2\}\s*\\sum_\{i=1\}\^n\s*\\left\|\s*\\frac\{p_i\}\{P\}\s*-\s*\\frac\{a_i\}\{A\}\s*\\right\|
 evaluators:
-  - type: contains
-    value: "Hoover Index"
-  - type: contains
-    value: "Index of Dissimilarity"
+- type: regex
+  target: message.content
+  pattern: H\s*=\s*\\frac\{1\}\{2\}\s*\\sum_\{i=1\}\^n\s*\\left\|\s*\\frac\{p_i\}\{P\}\s*-\s*\\frac\{a_i\}\{A\}\s*\\right\|
+- type: regex
+  target: message.content
+  pattern: D\s*=\s*\\frac\{1\}\{2\}\s*\\sum_\{i=1\}\^n\s*\\left\|\s*\\frac\{a_i\}\{A\}\s*-\s*\\frac\{b_i\}\{B\}\s*\\right\|


### PR DESCRIPTION
🧪 Metric QA Upgrade: Enhanced the rigor of the `gentrification_displacement_spatial_inequality_architect` prompt.

This PR upgrades the `testData` constraints to eliminate "Happy Path" testing bias by injecting complex, messy demographic data and enforcing outputs using strict `regex` matching for LaTeX formulas. Added an edge case test focused on ambiguous industrial zone data.

---
*PR created automatically by Jules for task [3378846925849457987](https://jules.google.com/task/3378846925849457987) started by @fderuiter*