### PR TITLE
feat: Add AWS Lambda serverless persistence forensics prompt

### DIFF
--- a/prompts/technical/security/secops/incident_response/aws_lambda_serverless_persistence_forensics_analyst.prompt.yaml
+++ b/prompts/technical/security/secops/incident_response/aws_lambda_serverless_persistence_forensics_analyst.prompt.yaml
@@ -1,0 +1,95 @@
+---
+name: AWS Lambda Serverless Persistence Forensics Analyst
+version: 1.0.0
+description: Generates expert-level forensic analysis and response strategies for detecting, reconstructing, and eradicating serverless persistence mechanisms, malicious layer injection, and IAM role abuse in AWS Lambda environments.
+authors:
+  - name: Cybersecurity Genesis Architect
+metadata:
+  domain: technical
+  complexity: high
+  tags:
+    - security
+    - secops
+    - incident-response
+    - aws
+    - lambda
+    - forensics
+    - serverless
+  requires_context: true
+variables:
+  - name: cloudtrail_logs
+    type: string
+    description: "Extracted AWS CloudTrail logs detailing anomalous UpdateFunctionCode, AddPermission, or UpdateFunctionConfiguration API calls."
+    required: true
+  - name: lambda_telemetry
+    type: string
+    description: "Amazon CloudWatch logs and AWS X-Ray traces capturing anomalous outbound network connections, unexpected child process execution, or prolonged execution durations."
+    required: true
+  - name: function_configuration
+    type: string
+    description: "JSON definitions of the suspect Lambda functions, including injected layers, modified environment variables, and attached execution roles."
+    required: true
+model: gpt-4o
+modelParameters:
+  temperature: 0.1
+messages:
+  - role: system
+    content: >
+      You are the "Principal Cloud Incident Responder", an elite expert in AWS forensics, serverless exploitation, and IAM security boundaries.
+      Your objective is to systematically analyze provided forensic artifacts to detect, reconstruct, and mitigate AWS Lambda serverless persistence and exfiltration.
+
+      You must synthesize the user's `cloudtrail_logs`, `lambda_telemetry`, and `function_configuration` to formulate a highly technical, definitive forensic report.
+
+      Your output MUST strictly adhere to the following constraints and structure:
+      1. **Persistence Vector Reconstruction**: Detail the specific serverless persistence technique. Identify if the attacker injected a malicious Lambda layer, modified handler environment variables to execute wrapper scripts, or exploited excessive execution role permissions (e.g., s3:GetObject or iam:PassRole). Use precise AWS terminology.
+      2. **Configuration Analysis**: Scrutinize the function configurations to identify unauthorized cross-account resource-based policies (via AddPermission) or malicious extensions/layers loaded via /opt.
+      3. **Post-Exploitation Actions**: Explicitly map CloudWatch logs and X-Ray traces to adversarial actions. Detail indicators of data exfiltration (e.g., DNS exfiltration, outbound connections to untrusted IPs) or lateral movement across the AWS environment using the function's attached IAM role credentials.
+      4. **Eradication and Mitigation**: Provide actionable, low-level eradication steps. This MUST include specific AWS CLI commands required to instantly revoke the Lambda execution role's temporary credentials, remove malicious layers, delete unauthorized resource-based policies, and restore the function to a known good state. Ensure instructions strictly specify ReadOnly or DryRun mode where applicable.
+
+      Maintain an uncompromisingly technical, authoritative persona. Do not provide generic advice. Be definitive in your assessments based on the provided data.
+      Explicit Negative Constraints: Do NOT suggest manual log review without automated parsing. Do NOT recommend disabling CloudTrail during the incident.
+      In cases where the data indicates the attacker has successfully pivoted from the Lambda environment to assume highly privileged administrative roles (e.g., AdministratorAccess) via IAM PassRole or privilege escalation, you MUST output a JSON block `{"status": "CRITICAL", "recommendation": "ACCOUNT_WIDE_COMPROMISE_ISOLATION_REQUIRED"}` within your report. If requested to perform unsafe or destructive actions outside the scope of eradication, you MUST output `{"error": "unsafe"}`.
+  - role: user
+    content: >
+      Perform a comprehensive AWS Lambda serverless persistence forensic analysis based on the following parameters:
+
+      <cloudtrail_logs>
+      {{cloudtrail_logs}}
+      </cloudtrail_logs>
+
+      <lambda_telemetry>
+      {{lambda_telemetry}}
+      </lambda_telemetry>
+
+      <function_configuration>
+      {{function_configuration}}
+      </function_configuration>
+testData:
+  - variables:
+      cloudtrail_logs: |-
+        {"eventName": "UpdateFunctionConfiguration", "sourceIPAddress": "198.51.100.23", "userAgent": "aws-cli/2.0.0", "requestParameters": {"functionName": "arn:aws:lambda:us-east-1:123456789012:function:DataProcessor", "layers": ["arn:aws:lambda:us-east-1:999999999999:layer:MaliciousLayer:1"]}}
+      lambda_telemetry: |-
+        [INFO] START RequestId: abc-123 Version: $LATEST
+        [ERROR] Runtime.ExitError: Exited with error
+        [INFO] Outbound connection to 203.0.113.5:443 established
+      function_configuration: |-
+        {"FunctionName": "DataProcessor", "Role": "arn:aws:iam::123456789012:role/LambdaBasicExecution", "Layers": [{"Arn": "arn:aws:lambda:us-east-1:999999999999:layer:MaliciousLayer:1"}], "Environment": {"Variables": {"LD_PRELOAD": "/opt/malicious.so"}}}
+    expected: "LD_PRELOAD"
+  - variables:
+      cloudtrail_logs: |-
+        {"eventName": "AssumeRole", "requestParameters": {"roleArn": "arn:aws:iam::123456789012:role/OrganizationAccountAccessRole", "roleSessionName": "LambdaPivotedSession"}}
+      lambda_telemetry: |-
+        [INFO] Executing sts:AssumeRole for highly privileged role
+      function_configuration: |-
+        {"FunctionName": "AdminTaskLambda", "Role": "arn:aws:iam::123456789012:role/CompromisedLambdaRole"}
+    expected: "ACCOUNT_WIDE_COMPROMISE_ISOLATION_REQUIRED"
+evaluators:
+  - name: Persistence Mechanism Identification
+    type: regex
+    pattern: "(?i)(LD_PRELOAD|malicious layer|/opt)"
+  - name: Eradication Command Presence
+    type: regex
+    pattern: "(?i)(aws lambda update-function-configuration|aws iam put-role-policy|aws lambda remove-permission|aws iam revoke-role-session)"
+  - name: Critical Lockdown Recommendation
+    type: regex
+    pattern: "(?i)(\\{\\s*\"status\"\\s*:\\s*\"CRITICAL\"\\s*,\\s*\"recommendation\"\\s*:\\s*\"ACCOUNT_WIDE_COMPROMISE_ISOLATION_REQUIRED\"\\s*\\})"

--- a/prompts/technical/security/secops/incident_response/overview.md
+++ b/prompts/technical/security/secops/incident_response/overview.md
@@ -1,5 +1,6 @@
 # Incident Response Overview
 
 ## Prompts
+- **[AWS Lambda Serverless Persistence Forensics Analyst](aws_lambda_serverless_persistence_forensics_analyst.prompt.yaml)**: Generates expert-level forensic analysis and response strategies for detecting, reconstructing, and eradicating serverless persistence mechanisms, malicious layer injection, and IAM role abuse in AWS Lambda environments.
 - **[Kubernetes Container Escape Forensics Analyst](kubernetes_container_escape_forensics_analyst.prompt.yaml)**: Generates expert-level forensic analysis and response strategies for detecting, reconstructing, and eradicating Kubernetes container escape techniques and cluster-level privilege escalation.
 - **[OAuth Illicit Consent Grant Forensics Analyst](oauth_illicit_consent_grant_forensics_analyst.prompt.yaml)**: Generates expert-level forensic analysis and response strategies for identifying and eradicating OAuth 2.0 illicit consent grant attacks and malicious application registrations within cloud environments.


### PR DESCRIPTION
This PR introduces the `aws_lambda_serverless_persistence_forensics_analyst.prompt.yaml` file into the `prompts/technical/security/secops/incident_response/` directory.

The prompt is designed to systematically analyze AWS CloudTrail logs, CloudWatch/X-Ray telemetry, and Lambda function configurations to detect, reconstruct, and mitigate serverless persistence mechanisms, malicious layer injection, and IAM role abuse. It strictly adheres to the requested expert persona and formatting constraints, including negative constraints and critical condition block generation for broad account compromises.

All repository checks and YAML schemas have been validated and pass successfully.

---
*PR created automatically by Jules for task [16321430062209486344](https://jules.google.com/task/16321430062209486344) started by @fderuiter*